### PR TITLE
fix(web): address review feedback on PR #33

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -10,7 +10,6 @@
     "clean": "rm -rf dist node_modules/.vite"
   },
   "dependencies": {
-    "@tailwindcss/vite": "^4.2.2",
     "@xterm/addon-fit": "^0.10",
     "@xterm/addon-web-links": "^0.11",
     "@xterm/xterm": "^5",
@@ -18,13 +17,14 @@
     "mermaid": "^11.14.0",
     "react": "^19",
     "react-dom": "^19",
-    "react-icons": "^5.6.0",
-    "tailwindcss": "^4.2.2"
+    "react-icons": "^5.6.0"
   },
   "devDependencies": {
+    "@tailwindcss/vite": "^4.2.2",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "@vitejs/plugin-react": "^4",
+    "tailwindcss": "^4.2.2",
     "typescript": "^5",
     "vite": "^6"
   }

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -3,7 +3,8 @@
 @theme {
   /* Tokyo Night palette — keep these in sync with the inline-style usage
      across the existing components. After the Codex migration sweep,
-     inline styles will use these tokens via tw classes like bg-bg, text-fg, etc. */
+     components will move from inline styles to Tailwind utility classes
+     (e.g. bg-bg, text-fg, border-border) that reference these tokens. */
 
   --color-bg: #1a1b26;
   --color-bg-alt: #16161e;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,9 +48,6 @@ importers:
 
   apps/web:
     dependencies:
-      '@tailwindcss/vite':
-        specifier: ^4.2.2
-        version: 4.2.2(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))
       '@xterm/addon-fit':
         specifier: ^0.10
         version: 0.10.0(@xterm/xterm@5.5.0)
@@ -75,10 +72,10 @@ importers:
       react-icons:
         specifier: ^5.6.0
         version: 5.6.0(react@19.2.4)
-      tailwindcss:
-        specifier: ^4.2.2
-        version: 4.2.2
     devDependencies:
+      '@tailwindcss/vite':
+        specifier: ^4.2.2
+        version: 4.2.2(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))
       '@types/react':
         specifier: ^19
         version: 19.2.14
@@ -88,6 +85,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^4
         version: 4.7.0(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))
+      tailwindcss:
+        specifier: ^4.2.2
+        version: 4.2.2
       typescript:
         specifier: ^5
         version: 5.9.3


### PR DESCRIPTION
Fixes 2 review comments on PR #33.

## Changes
- Move `tailwindcss` + `@tailwindcss/vite` from `dependencies` to `devDependencies` (build-time tools, not runtime) [Gemini + Copilot]
- Reword contradictory comment in `apps/web/src/index.css` (the original wording said inline styles would use tw classes, which they can't) [Copilot]

## Test plan
- [x] `pnpm install` refreshes lockfile cleanly
- [x] `pnpm --filter @cpc/web run build` passes
- [ ] After merge, PR #33 will be closed and reopened to retrigger fresh review on combined code

This PR targets `prep/tailwind-v4-setup` (the feature branch), not `dev`.