### PR TITLE
prep(web): Vitest snapshot fixtures for marked baseline (round 2)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -7,6 +7,8 @@
     "dev": "vite --port 58830",
     "build": "tsc -b && vite build",
     "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "clean": "rm -rf dist node_modules/.vite"
   },
   "dependencies": {
@@ -23,7 +25,10 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "@vitejs/plugin-react": "^4",
+    "@vitest/ui": "^4.1.3",
+    "jsdom": "^29.0.2",
     "typescript": "^5",
-    "vite": "^6"
+    "vite": "^6",
+    "vitest": "^4.1.3"
   }
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -22,6 +22,7 @@
     "react-icons": "^5.6.0"
   },
   "devDependencies": {
+    "@types/node": "^22.19.17",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "@vitejs/plugin-react": "^4",

--- a/apps/web/src/__fixtures__/markdown/01-headings.md
+++ b/apps/web/src/__fixtures__/markdown/01-headings.md
@@ -1,0 +1,32 @@
+# Heading Level 1
+
+Some content under an h1 with **bold** text.
+
+## Heading Level 2
+
+A paragraph under h2 with `inline code` and a [link](https://example.com).
+
+### Heading Level 3
+
+- A bullet under h3
+- Another bullet
+
+#### Heading Level 4
+
+Paragraph under h4.
+
+##### Heading Level 5
+
+> A blockquote under h5.
+
+###### Heading Level 6
+
+Final paragraph under the smallest heading.
+
+## Another H2 After H6
+
+Content to test heading-reset behavior.
+
+### Nested h3
+
+And some trailing content.

--- a/apps/web/src/__fixtures__/markdown/02-lists.md
+++ b/apps/web/src/__fixtures__/markdown/02-lists.md
@@ -1,0 +1,45 @@
+# Lists
+
+## Unordered
+
+- Apple
+- Banana
+- Cherry
+
+## Ordered
+
+1. First
+2. Second
+3. Third
+
+## Nested (3+ deep)
+
+- Level 1 item A
+  - Level 2 item A.1
+    - Level 3 item A.1.a
+      - Level 4 item A.1.a.i
+    - Level 3 item A.1.b
+  - Level 2 item A.2
+- Level 1 item B
+
+## Task list
+
+- [ ] Open task
+- [x] Completed task
+- [ ] Another open task
+  - [x] Nested completed subtask
+  - [ ] Nested open subtask
+
+## Mixed ordered + unordered
+
+1. First ordered
+   - Unordered sub A
+   - Unordered sub B
+     1. Re-ordered sub-sub
+     2. Another re-ordered sub-sub
+2. Second ordered
+3. Third ordered with a paragraph.
+
+   Continuation paragraph inside list item.
+
+4. Fourth ordered

--- a/apps/web/src/__fixtures__/markdown/03-code-block-short.md
+++ b/apps/web/src/__fixtures__/markdown/03-code-block-short.md
@@ -1,0 +1,18 @@
+# Short code block
+
+Here is a small TypeScript snippet:
+
+```ts
+function greet(name: string): string {
+  return `Hello, ${name}!`;
+}
+
+greet("world");
+```
+
+And a short bash example:
+
+```bash
+pnpm install
+pnpm test
+```

--- a/apps/web/src/__fixtures__/markdown/04-code-block-wide.md
+++ b/apps/web/src/__fixtures__/markdown/04-code-block-wide.md
@@ -1,0 +1,19 @@
+# Wide code block (horizontal scroll target)
+
+This fixture exists to pin down the PR #20 regression around wide code blocks and horizontal scrolling.
+
+```ts
+// This single line is intentionally very long to force horizontal scrolling inside the rendered <pre><code> container so we can diff how marked and react-markdown lay out the overflow behavior under the same CSS.
+const veryLongIdentifier = { alpha: 1, beta: 2, gamma: 3, delta: 4, epsilon: 5, zeta: 6, eta: 7, theta: 8, iota: 9, kappa: 10, lambda: 11, mu: 12, nu: 13, xi: 14, omicron: 15, pi: 16, rho: 17, sigma: 18, tau: 19, upsilon: 20, phi: 21, chi: 22, psi: 23, omega: 24 };
+function doSomethingThatTakesAbsurdlyManyArgumentsAndReturnsAnAbsurdlyLongInlineTypeAnnotation(arg1: string, arg2: number, arg3: boolean, arg4: Record<string, unknown>, arg5: Array<{ id: string; value: number; metadata: Record<string, string> }>): Promise<{ ok: true; data: Array<{ id: string; value: number; metadata: Record<string, string> }> } | { ok: false; error: string }> {
+  return Promise.resolve({ ok: true, data: arg5 });
+}
+```
+
+And a short line afterwards to verify the following paragraph wraps normally after a wide code block:
+
+```
+$ curl -sSL https://example.com/some/very/long/path/that/should/not/wrap/inside/the/pre/block/because/pre/preserves/whitespace/and/horizontal/scroll/should/kick/in?query=param1&query=param2&query=param3
+```
+
+End of wide fixture.

--- a/apps/web/src/__fixtures__/markdown/05-table-narrow.md
+++ b/apps/web/src/__fixtures__/markdown/05-table-narrow.md
@@ -1,0 +1,9 @@
+# Narrow table
+
+| Name | Count |
+| ---- | ----: |
+| Apples | 3 |
+| Bananas | 12 |
+| Cherries | 47 |
+
+A short paragraph after the table.

--- a/apps/web/src/__fixtures__/markdown/06-table-wide.md
+++ b/apps/web/src/__fixtures__/markdown/06-table-wide.md
@@ -1,0 +1,11 @@
+# Wide table
+
+| Column A | Column B | Column C (with a long header) | Column D | Column E | Column F |
+| :------- | :------: | :---------------------------- | -------: | -------- | -------- |
+| alpha    | beta     | this is a fairly long cell value that should push the column width out | 1 | true | `code` |
+| gamma    | delta    | another long cell with **bold** and *italic* inline styles interleaved | 22 | false | [link](https://example.com) |
+| epsilon  | zeta     | short                                                                   | 333 | true | plain |
+| eta      | theta    | cell with a pipe escape \| inside it                                    | 4444 | false | `x` |
+| iota     | kappa    | final row with a [link](https://example.com/path?a=1&b=2) embedded     | 55555 | true | done |
+
+Trailing paragraph to verify flow after a wide table.

--- a/apps/web/src/__fixtures__/markdown/07-blockquote.md
+++ b/apps/web/src/__fixtures__/markdown/07-blockquote.md
@@ -1,0 +1,35 @@
+# Blockquotes
+
+Single-level blockquote:
+
+> This is a simple single-level blockquote.
+> It spans two lines of markdown source.
+
+With inline formatting:
+
+> A blockquote with **bold**, *italic*, `inline code`, and a [link](https://example.com).
+
+Nested blockquote:
+
+> Outer quote level 1.
+>
+> > Inner quote level 2 with some longer content to make sure wrapping works as expected.
+> >
+> > > Deepest quote level 3.
+> >
+> > Back to level 2.
+>
+> Back to level 1.
+
+Blockquote containing a list:
+
+> - Item one inside quote
+> - Item two inside quote
+>   - Nested item
+> - Item three inside quote
+
+Blockquote containing a code block:
+
+> ```ts
+> const quoted = "code inside blockquote";
+> ```

--- a/apps/web/src/__fixtures__/markdown/08-mixed-inline.md
+++ b/apps/web/src/__fixtures__/markdown/08-mixed-inline.md
@@ -1,0 +1,17 @@
+# Mixed inline formatting
+
+A single dense paragraph with **bold**, *italic*, ***bold-italic***, `inline code`, ~~strikethrough~~, and a [link](https://example.com) all interleaved into one flowing sentence so the renderer has to deal with many inline transitions in a row without any breaks between them at all.
+
+Another paragraph that **combines `code inside bold`** and *[links inside italics](https://example.com)* and `**not bold inside code**` to verify escape semantics.
+
+A line with emphasis edges: **bold at start** of a sentence, and another sentence ending with **bold at end**. Also *italic at start* and *italic at end*.
+
+Adjacent inline tokens: **bold**`code` and *italic***bold** and `code`[link](https://example.com).
+
+Strikethrough combos: ~~plain strike~~, ~~**bold strike**~~, ~~*italic strike*~~, ~~`code strike`~~.
+
+Line 1 with trailing spaces to force a soft break  
+Line 2 after the soft break.
+
+Line A
+Line B (single newline between — with `breaks: true`, marked renders this as `<br>`).

--- a/apps/web/src/__fixtures__/markdown/09-link-edge-cases.md
+++ b/apps/web/src/__fixtures__/markdown/09-link-edge-cases.md
@@ -1,0 +1,32 @@
+# Link edge cases
+
+Inline link with parens in URL: [wiki article](https://en.wikipedia.org/wiki/Markdown_(software)).
+
+Inline link with query + fragment: [search](https://example.com/path?query=foo&bar=baz#section-2).
+
+Inline link with title: [hover me](https://example.com "Example title").
+
+Autolink: <https://example.com/autolink>.
+
+Autolink email: <someone@example.com>.
+
+Reference-style link: see [the spec][ref-spec] for details.
+
+Another reference: [inline ref][] works too.
+
+Collapsed reference: [collapsed][].
+
+Shortcut reference: [shortcut].
+
+[ref-spec]: https://spec.commonmark.org/0.30/ "CommonMark 0.30"
+[inline ref]: https://example.com/inline-ref
+[collapsed]: https://example.com/collapsed
+[shortcut]: https://example.com/shortcut
+
+Link with special chars in text: [`code` in **bold** link text](https://example.com).
+
+Image: ![alt text](https://shared.claude.do/public/placeholder.png "image title").
+
+Link followed immediately by punctuation: see [example](https://example.com), then continue.
+
+Bare URL (not autolinked without angle brackets): https://example.com/bare

--- a/apps/web/src/__fixtures__/markdown/10-real-doc-adr.md
+++ b/apps/web/src/__fixtures__/markdown/10-real-doc-adr.md
@@ -1,0 +1,151 @@
+# ADR 0001: Package CPC as the Shareable Hub with Toolbox as a Git Submodule
+
+**Status:** Proposed
+**Date:** 2026-04-06
+**Deciders:** Liam (Chaintail), Claude
+**Context:** Hackathon friends asked for GitHub links to "what we built." This forced the question of what artifact best represents Claude's World as a sharable, runnable system.
+
+---
+
+## Context
+
+Claude's World is currently spread across multiple repositories and directories with no single artifact a new user could clone to "get the system":
+
+- **CPC** (`~/code/claude-pocket-console`) — the Telegram mini app, the most polished and visually impressive piece
+- **Toolbox** (`~/code/toolbox`) — reusable scripts (md-speak, share-doc, transcribe, hooks). About 20 of the 40 entries in `~/bin` are now symlinks into this repo. Migration is in progress.
+- **Skills** (`~/.claude/skills/` and `~/claudes-world/.claude/skills/`) — Claude Code skills, scattered across two locations
+- **Host config** (`~/do-box`) — VPS-specific systemd, Caddy, cloudflared (brittle whitelist-driven snapshot)
+- **Live state** (`~/claudes-world/`) — working directory, knowledge base, memory, ephemeral files
+
+When the user's hackathon friends asked for GitHub links, there was no clean answer. Pointing them to CPC alone misses the supporting infrastructure. Pointing them to multiple repos requires explaining the relationships. A monolithic "everything in one repo" approach was considered but rejected (see Alternatives).
+
+The user proposed: **what if CPC stays as the primary shareable artifact and toolbox is included as a dependency inside it?** This ADR captures that decision.
+
+---
+
+## Decision
+
+**CPC will be the primary shareable artifact for Claude's World. Toolbox will be embedded as a git submodule.**
+
+The structure will be:
+
+```
+claude-pocket-console/             ← what new users clone
+├── README.md                      ← "This is Claude's World"
+├── apps/web/                      ← React/Vite mini app
+├── apps/server/                   ← Hono API
+├── tools/                         ← git submodule → toolbox repo
+│   ├── md-speak/
+│   ├── share-doc/
+│   ├── transcribe/
+│   └── hooks/
+├── skills/                        ← Claude Code skills (migrated from ~/.claude/skills)
+└── docs/                          ← progressive disclosure (per OmniPass pattern)
+    ├── reference/
+    ├── guides/
+    └── conventions/
+```
+
+A new user would:
+1. `git clone --recursive github.com/{user}/claude-pocket-console`
+2. Read `README.md` and `AGENTS.md` (the index)
+3. Browse `docs/` for progressive disclosure on whatever interests them
+4. Run `pnpm install && pnpm run dev` to bring up CPC
+5. Optionally install the toolbox scripts to their own `~/bin` for full Claude Code integration
+
+Toolbox keeps its own repository, its own commit history, and its own lifecycle. CPC pins to a specific toolbox commit via the submodule reference, and bumps that pin intentionally when toolbox ships changes.
+
+---
+
+## Consequences
+
+### Positive
+
+- **One link to share.** "Check out github.com/{user}/claude-pocket-console" gives someone the whole system. The first impression is the polished mini app, not a wall of bash scripts.
+- **Toolbox stays portable.** Someone who wants only the scripts can clone toolbox alone without pulling CPC. The two repos serve different audiences (CPC for "show me the system," toolbox for "give me the tools").
+- **Independent lifecycles.** Toolbox can ship breaking changes, ship rapid iterations, or be totally rewritten without forcing a CPC release. CPC pins to a known-good commit and bumps deliberately.
+- **Smaller blast radius.** A bug in toolbox doesn't break CPC unless CPC explicitly bumps the submodule. Reverting is one commit away.
+- **Existing structure preserved.** The toolbox repo doesn't need restructuring. It just becomes a sub-tree inside CPC at `tools/`.
+- **Matches how people discover the project.** "Claude Pocket Console" is the recognizable name. Toolbox is invisible infrastructure. The submodule pattern reflects this asymmetry honestly.
+
+### Negative
+
+- **Submodule UX is clunky.** New contributors will forget `--recursive` on clone. They'll see an empty `tools/` directory and be confused. Mitigation: README has a "first steps" section that explicitly addresses this, and `pnpm install` could check for the submodule and warn if missing.
+- **Submodule pin updates require explicit commits.** When toolbox ships a fix, CPC needs a commit to pull it in. Not bad in practice (usually you want this control) but adds a step.
+- **Two-repo cognitive load.** Anyone contributing to both CPC and toolbox has to manage two repos, two commit histories, two PR workflows. Mitigation: most contributors will only touch one or the other.
+- **The "host" pieces still don't have a home.** This ADR doesn't address where systemd/Caddy/cloudflared configs live. They're VPS-specific and don't belong in CPC. A separate decision is needed for the do-box replacement.
+- **Skills location split.** Skills currently live in `~/.claude/skills/` AND `~/claudes-world/.claude/skills/`. Deciding which is canonical and migrating to `claude-pocket-console/skills/` is a follow-up task.
+
+### Neutral
+
+- The user's `~/code/claude-pocket-console` working directory and the GitHub repo will share a name (already the case). Nothing changes locally.
+- The `~/.world/` directory concept (per-project overrides) is orthogonal to this decision and can still be added.
+
+---
+
+## Alternatives Considered
+
+### Alternative 1: Single monorepo containing everything
+
+Move CPC, toolbox, skills, host config, and apps into one new repo at `github.com/{user}/claudes-world`. Each becomes a top-level package.
+
+**Why rejected:**
+- Breaks the existing CPC and toolbox repo histories (or requires complex git filter-repo work)
+- Forces all packages to share a release cadence
+- The "host" pieces (systemd, Caddy) don't belong in a portable repo at all — they're VPS-specific
+- A new monorepo means a new repo name that nobody recognizes
+- Doesn't match how the user actually thinks about the system (CPC is the recognizable thing, everything else supports it)
+
+The original portability design doc proposed this approach. After discussing it with the user, the CPC-as-hub model is a better fit for the actual goal (a shareable artifact for hackathon friends) without the migration cost.
+
+### Alternative 2: Git subtree instead of submodule
+
+Same end state but using `git subtree` to merge toolbox's history into CPC at `tools/`. Consumers don't need `--recursive`.
+
+**Why rejected:**
+- Subtrees are harder to update bidirectionally. Pushing changes from CPC's `tools/` back to the toolbox repo requires `git subtree split` and manual reconciliation.
+- Subtree is less commonly understood than submodule. Most developers know `git submodule update --init --recursive`; fewer know `git subtree pull`.
+- The "no init step" benefit is real but small — a one-line README note solves it.
+- Could revisit if submodule pain proves worse than subtree pain in practice.
+
+### Alternative 3: pnpm workspace / npm package
+
+Publish toolbox to npm and have CPC depend on it via `package.json`. Cleanest from a JS perspective.
+
+**Why rejected:**
+- Toolbox contains a mix of bash, Python, and TypeScript scripts. npm only handles the Node.js subset cleanly.
+- Bash and Python scripts would need wrapper packages or be excluded, fragmenting the toolbox.
+- Versioning becomes a release-management chore — every toolbox change needs a version bump and publish.
+- Adds an external dependency (npm registry) for what should be a self-contained system.
+
+### Alternative 4: Symlinks (do nothing)
+
+The current state. `~/bin` symlinks into `~/code/toolbox`, CPC is a separate repo. No packaging.
+
+**Why rejected:**
+- This is exactly what the user is trying to fix. The current state has no shareable artifact and the relationships are invisible to anyone outside the user's head.
+- Doesn't survive a host migration. Symlinks are filesystem-specific.
+- Doesn't help hackathon friends at all.
+
+---
+
+## Follow-Up Actions
+
+These are not part of this ADR but are needed to execute the decision:
+
+1. **Decide on the host config story** — separate ADR. The do-box replacement (manifest-driven, deterministic rebuild) is its own design problem.
+2. **Decide on skills canonical location** — consolidate `~/.claude/skills/` and `~/claudes-world/.claude/skills/`, then migrate to `claude-pocket-console/skills/`.
+3. **Adopt progressive disclosure docs in CPC** — restructure CPC's existing AGENTS.md and docs into the OmniPass `reference/guides/conventions/` pattern. (See ADR 0002, forthcoming.)
+4. **Submodule integration plan** — actually create the submodule, write the README "first steps" section, set up CI to verify the submodule resolves cleanly.
+5. **Port convention v2** — separate ADR. The current 38xxx/48xxx/58xxx convention is too coarse and caused hackathon collisions.
+6. **Plugin packaging (longer term)** — if CPC grows into a Claude Code plugin, the plugin manifest can reference the same submodule structure. No conflict.
+
+---
+
+## References
+
+- `~/claudes-world/knowledge/claudes-world-portability-design.md` — the broader design doc this ADR resolves
+- `~/code/omnipass-world/AGENTS.md` — the progressive disclosure pattern used as the docs model
+- `~/code/claude-pocket-console/` — the CPC repo to be restructured
+- `~/code/toolbox/` — the toolbox repo to become a submodule
+- [Git submodule docs](https://git-scm.com/book/en/v2/Git-Tools-Submodules)

--- a/apps/web/src/__fixtures__/markdown/11-real-doc-overnight-summary.md
+++ b/apps/web/src/__fixtures__/markdown/11-real-doc-overnight-summary.md
@@ -1,0 +1,236 @@
+# Overnight Final Report — April 6-7, 2026
+
+**Session start:** ~7:30pm ET April 6
+**Session end:** ~9:30pm ET April 6 (this report)
+**Format:** Single document for morning review
+
+---
+
+## TL;DR
+
+**8 PRs open and ready for your review.** None merged. Foundational tools shipped (Scrum button, send-md fix). Three big-picture synthesis docs are ready for morning decisions (reading list, portability, theme). One known issue: the dev tunnel is currently 502 because of agent worktree coordination — fixes itself when you merge PR #21.
+
+---
+
+## What's ready for you to merge (in order)
+
+### Toolbox
+1. **toolbox PR #1** — `tune: reduce heading pauses, speed up body voice`
+   - 6 line edits, body voice 0.95 → 1.05, heading pauses cut ~30%
+   - Verdict: LGTM SHIP IT
+   - Branch: `tune/md-speak-pacing` → `main`
+
+2. **toolbox PR #2** — `feat(hooks): Scrum button + share-doc backtick fix`
+   - Scrum button on launcher keyboard + handler
+   - share-doc dual-mode (file path or inline content) — fixes the backtick truncation bug
+   - Both actively in use this session
+   - Branch: `feat/scrum-button-and-share-doc-fix` → `main`
+
+### CPC (in recommended merge order)
+1. **PR #21** — `fix: allow cpc.claude.do host in Vite dev server`
+   - **MERGE FIRST** — unblocks the dev tunnel which is currently 502
+   - Adds `host: "127.0.0.1"` and `allowedHosts: ["cpc.claude.do"]` to vite.config.ts
+   - Verdict: APPROVE WITH NITS (Gemini suggested also updating proxy + HMR config — see follow-up items)
+
+2. **PR #19** — `feat(links): Companion + T3 app icon links`
+   - Trivial (+12/-0), no risk
+   - Verdict: SHIP IT
+
+3. **PR #18** — `feat: download button in file viewer`
+   - New `/api/files/download` endpoint + FiDownload button in FileViewer
+   - Verdict: APPROVE WITH NITS
+   - **Should-fix items Gemini caught (you decide):**
+     - Use `buf.length` instead of `st.size` for Content-Length (TOCTOU)
+     - Sanitize 500 error messages (don't leak internal paths)
+     - Consider streaming instead of `readFile` for large files (memory pressure)
+   - **Pre-existing security issue Gemini flagged:** `isPathAllowed` uses startsWith — vulnerable to prefix-based path traversal. Affects ALL existing routes (`/list`, `/read`, `/search`, `/upload`) AND this new `/download`. Should be its own hardening PR.
+
+4. **PR #20** — `fix: code block horizontal scroll in markdown viewer`
+   - Two commits: original fix + follow-up addressing Gemini's "right padding lost on scroll" finding
+   - Now includes `width: max-content; min-width: 100%` on `pre code`
+   - Verdict: APPROVE
+
+5. **PR #22** — `feat: render Mermaid diagrams in markdown viewer`
+   - Lazy-loaded mermaid (main bundle stays at 595KB, mermaid in own 652KB chunk)
+   - Two commits: initial component + follow-up wiring (vite.config.ts manualChunks, MarkdownViewer integration, mermaid dependency)
+   - Verdict: pending agent re-review (running)
+
+6. **PR #23** — `feat: file viewer sort control with persistence`
+   - Inline sort control row in FileViewer header
+   - localStorage persistence + SortMode type promotion + sort logic hardening
+   - Verdict: pending agent re-review (running)
+
+---
+
+## Big-picture decisions waiting for your input
+
+These are the three synthesis docs from the devil's advocate sessions. Each has my recommended answers — if you agree with my recs, just say "go" and I'll execute. If you disagree, tell me which.
+
+### Reading list feature
+- **Doc:** `tmp/20260406-reading-list-synthesis.md`
+- **3 reviewers:** Gemini (RETHINK), Codex (NEEDS WORK), Sonnet (NEEDS WORK)
+- **6 decisions to make:**
+  1. Hard delete instead of soft delete (my rec: yes)
+  2. Reject `default` user for reading list endpoints (my rec: yes — security)
+  3. Save button in ActionBar instead of FileViewer header (my rec: yes — consistency)
+  4. `is_saved` piggyback on file read endpoint instead of separate /check (my rec: yes)
+  5. Drop the speculative `note` column (my rec: yes)
+  6. Defer migration system to a separate ADR (my rec: yes)
+
+### Claude's World portability / .world directory
+- **Doc:** `tmp/20260406-portability-synthesis.md`
+- **2 reviewers:** Gemini (RETHINK), Codex (NEEDS WORK)
+- **Key takeaway:** ADR 0001 (CPC + toolbox submodule) already addresses most critiques. The original maximalist monorepo doc has one factual contradiction to fix (don't version live state in git). 5 follow-up ADRs identified.
+- **My rec:** Keep ADR 0001 as Proposed and continue. Update the original design doc to remove the monorepo-version-memory contradiction.
+
+### Light/dark mode
+- **Doc:** `tmp/20260406-theme-synthesis.md`
+- **1 reviewer:** Gemini (RETHINK)
+- **Critical issue:** No accessibility/contrast analysis for the proposed light palette
+- **My rec:** Defer entirely until you have time for a proper week-long migration. The current plan is correct but not a sleep-time job.
+
+---
+
+## Documents shipped to your Telegram tonight
+
+| Doc | Type |
+|-----|------|
+| ADR 0001 — CPC + toolbox submodule packaging | Decision |
+| ADR 0003 — Port allocation v2 / port-for | Decision |
+| Reading list 3-way DA synthesis | Synthesis |
+| Portability 2-way DA synthesis | Synthesis |
+| Theme DA review | Synthesis |
+| PR reviews summary (5 PRs) | Status |
+| Overnight status hour 1 | Status |
+| .world skeleton README | Proposal |
+| .world skeleton AGENTS.md | Proposal |
+| USDX white paper (downloadable) | Re-shared |
+
+All are saved in `~/claudes-world/tmp/` or `~/claudes-world/knowledge/` and can be re-shared via the deep-link system.
+
+---
+
+## Outside-the-box ideas (ranked by ROI × feasibility)
+
+### For Claude's World infrastructure
+
+1. **Morning brief cron job** — runs at 7am ET, sends a markdown doc with overnight git changes, open PRs needing review, weather, calendar (when OAuth wired), memory-based reminders.
+   - ROI: HIGH — zero ongoing effort, captures all the context you'd assemble manually
+   - Feasibility: HIGH — ~1-2 hours of work, all pieces exist
+   - Recommended next step
+
+2. **A "next thing to work on" agent** — ask via Telegram, scans TODO.md / open PRs / recent memories / calendar, suggests highest-leverage next action.
+   - ROI: HIGH — decision fatigue is real
+   - Feasibility: HIGH — small focused skill, 1 hour to write
+
+3. **Sleep-aware agent operation** — agents stop dispatching new high-risk work after midnight ET unless explicitly told. Morning checks are still allowed but mutations are paused.
+   - ROI: MEDIUM-HIGH — prevents bad-overnight surprises
+   - Feasibility: HIGH — trivial guard at agent dispatch
+
+4. **Auto-archive `quarantine/` after 30 days** — cron moves untrusted research artifacts older than 30 days into compressed archive.
+   - ROI: LOW-MEDIUM — keeps active workspace clean
+   - Feasibility: HIGH — 10-line bash + systemd timer
+
+5. **Meta-skill: lints other skills** — periodic agent that scans `~/.claude/skills/` against the skill-authoring-tips guide. Flags any missing descriptions, vague triggers, etc.
+   - ROI: MEDIUM — prevents skill bloat over time
+   - Feasibility: MEDIUM — couple hours
+
+### For your IRL life (Liam)
+
+1. **Conference contact card MVP** (the one we discussed) — single highest-leverage thing you could ship next month for IRL networking. Day or two of work, transforms every conference for you.
+   - ROI: VERY HIGH — every conference becomes 10x more connectable
+   - Feasibility: HIGH — small feature, you already have a Telegram presence
+
+2. **Daily "what did I learn today" capture** — voice memo at end of day → transcription → LLM summary → committed to a personal knowledge base in `claudes-world/journal/`. Compound interest on insights over months.
+   - ROI: HIGH if you actually use it
+   - Feasibility: HIGH — 2 hours, voice-hook already exists
+
+3. **Dev-tunnel uptime monitor** — ntfy hook pings cpc.claude.do/dev every 5 min, notifies if down for 2+ checks. Stops weird issues from going unnoticed.
+   - ROI: MEDIUM — prevents debugging-at-3am
+   - Feasibility: HIGH — 30 minutes
+
+4. **Auto-tagging for shared docs** — share-doc generates audio with rich ID3 metadata via topic detection. Turns your shared docs into a personal podcast feed.
+   - ROI: MEDIUM-HIGH (turns reading queue into listening queue)
+   - Feasibility: HIGH — tag-mp3 binary already supports it
+
+5. **Conference-mode auto-Calendly** — when conference mode is on (the contact card idea), automatically open 15-min "coffee chat" availability.
+   - ROI: HIGH during events, low otherwise
+   - Feasibility: MEDIUM — needs Calendly API
+
+---
+
+## Issues / things to know
+
+### 1. Dev tunnel 502 (worktree coordination)
+
+**Current state:** `https://cpc.claude.do/dev/` returns 502.
+
+**Why:** Multiple agents share `~/code/claude-pocket-console` worktree and check out different feature branches. The cpc-dev.service serves whatever branch is currently checked out. Currently it's on `feat/file-viewer-sort-control` (PR #23's branch), which doesn't have the IPv4 fix. Vite is bound to `[::1]:58830` (IPv6 only), Caddy can't proxy to `127.0.0.1:58830`.
+
+**Fix:** Merge PR #21 to dev. Once IPv4 fix lands on dev, every feature branch will inherit it.
+
+**Lesson learned:** This proves the worktree-aware port allocation idea (ADR 0003) — agents need their own worktrees. I'll avoid launching parallel CPC agents going forward until we have proper isolation.
+
+### 2. Toolbox dirty state (pre-existing)
+
+The toolbox repo has uncommitted changes from before I arrived:
+- `hooks/agent-stop-hook` (small)
+- `hooks/voice-hook` (small)
+- `md-speak/md-speak` (the "end of document" segment block, ~8 lines)
+- `tg-sanitize/` (untracked directory)
+
+I left these alone. They look intentional but are not on any branch. Worth checking what they are and either committing or stashing properly.
+
+### 3. send-md fix branch is currently checked out
+
+Toolbox is currently on `feat/scrum-button-and-share-doc-fix` (toolbox PR #2's branch). This is intentional — that branch has the share-doc Mode 2 fix, which is what's powering the send-md skill right now via the symlink at `~/bin/share-doc`. If you switch toolbox branches, send-md will revert to the old broken behavior until you switch back or merge.
+
+**Recommended:** Merge toolbox PR #2 first thing in the morning to permanently land the share-doc fix.
+
+### 4. Pre-existing isPathAllowed security issue
+
+Gemini flagged this on PR #18 but it's NOT introduced by PR #18 — it's pre-existing in `apps/server/src/routes/files.ts`. The `isPathAllowed` function uses `startsWith` which is vulnerable to prefix-based path traversal. Affects `/list`, `/read`, `/search`, `/upload`, AND the new `/download`.
+
+**My recommendation:** File a separate hardening PR. Should not block PR #18 from merging (the vulnerability exists with or without #18).
+
+---
+
+## Stats
+
+- **PRs opened:** 8 (5 CPC + 3 toolbox*) — *toolbox #1 was opened before this session
+- **PRs reviewed by me:** 7 (all CPC + toolbox #1)
+- **Background agents launched:** ~13
+- **Devil's advocate reviews run:** 6 (3 reading list, 2 portability, 1 theme)
+- **ADRs written:** 2 (0001, 0003)
+- **Synthesis docs:** 3 (reading list, portability, theme)
+- **Skeleton stub files:** 9 in `tmp/world-skeleton/`
+- **TODO items closed:** 6 (the in-flight CPC features)
+- **TODO items added:** 8 (follow-up items + new ADRs to write)
+
+---
+
+## What I plan for hour 2 (and beyond)
+
+The next hour cron will fire at :13 (in ~25 minutes from this writing). When it does, I'll:
+
+1. Check on the in-flight PR reviews for #22 and #23
+2. Address any should-fix items those reviews surface (in same-branch commits)
+3. Update TODO.md if anything new shipped
+4. Send a brief status check-in (probably shorter than this final report)
+
+Beyond that, my plan is to slow down and be conservative. The big shipping push is done. I'll:
+- Watch for incoming Telegram messages from you
+- Continue polishing what's open
+- NOT start any new big features without your approval
+- NOT touch any prod systems
+- NOT merge anything
+
+If you wake up and want to fast-merge everything, the recommended order is at the top of this doc. If you want me to wait, just say so.
+
+---
+
+## Sleep well, Liam.
+
+The system is in good shape. Lots of value sitting in the PR queue waiting for your review. The big architectural conversations have concrete recommendations. The synthesis docs are ready to discuss when you're ready.
+
+— Claude

--- a/apps/web/src/__fixtures__/markdown/12-real-doc-collapsible-headings-plan.md
+++ b/apps/web/src/__fixtures__/markdown/12-real-doc-collapsible-headings-plan.md
@@ -1,0 +1,393 @@
+I have everything I need. Note that mermaid is not rendered interactively — there's no existing post-process pattern in MarkdownViewer using `createRoot`. Now I'll deliver the plan.
+
+---
+
+# Collapsible Heading Sections — Implementation Plan
+
+**Date:** 2026-04-07
+**Feature:** Disclosure triangles next to headings in the CPC markdown viewer that collapse/expand sections, with optional sync to a future TOC drawer.
+**Note on file output:** This planning task is read-only — I cannot save the plan to `tmp/`. The full plan is below; copy/paste it wherever you'd like it to live.
+
+---
+
+## TL;DR
+
+Add disclosure triangles next to every heading in `MarkdownViewer.tsx` so Liam can collapse long sections of a markdown doc. Use **Option A (DOM post-processing via ref)** because the existing component already uses `dangerouslySetInnerHTML`, the change is local, and we don't add a runtime dependency. Store fold state as a `Set<string>` of heading slugs in React state, **lifted to `App.tsx`** so a future `TocSheet` component can share it. Implement collapse via `display: none` on the DOM nodes between a heading and the next same-or-higher-level heading. **Effort: Medium — ~1 day standalone, ~1.5–2 days if shipped together with the TOC drawer (because heading-id assignment, the lift to `App.tsx`, and shared-state plumbing become a single coordinated PR).**
+
+The biggest discovery during scouting: **marked v17 with `gfm: true` does NOT generate `id` attributes on headings.** The v17 default `heading` renderer is literally `` `<h${depth}>${parseInline(tokens)}</h${depth}>` `` (verified in `apps/web/node_modules/marked/lib/marked.esm.js` line 57). The existing TOC proposal (`tmp/20260407-markdown-toc-and-audio-proposals.md` line 71) is wrong about this. Both this feature and the TOC feature need to assign IDs themselves, which is one more reason to ship them together: they share that prep work.
+
+---
+
+## Part 1 — Current state scouting
+
+### How markdown is rendered
+- `apps/web/src/components/MarkdownViewer.tsx` calls `marked.parse(content)` inside a `useMemo`, then injects the result via `dangerouslySetInnerHTML` into a `<div className="md-content">`. The component is otherwise styles + HTML; it has **no ref, no post-processing, no event handlers**.
+- `marked` is configured with `{ gfm: true, breaks: true }` only.
+- The whole `.md-content` div lives inside an outer scrollable wrapper with `overflowY: auto`. Scroll position is managed by the browser.
+- There's no virtual scrolling. Even very long docs render the entire DOM tree once.
+
+### Heading IDs — the load-bearing finding
+Marked v17's default renderer produces headings without `id` attributes. From `marked.esm.js`:
+```
+heading({tokens:e,depth:t}){return`<h${t}>${this.parser.parseInline(e)}</h${t}>\n`}
+```
+So today the rendered HTML for `## Hello world` is just `<h2>Hello world</h2>` — no anchor, no slug. Anything that needs to address headings (this feature, the TOC drawer, hash navigation) has to assign IDs after parse. That can be done either by:
+- A custom marked renderer override (`marked.use({ renderer: { heading(...) {...} } })`) that emits `<h${depth} id="${slug}">...</h${depth}>`, with a small slugger that handles duplicates by appending `-2`, `-3`, etc.
+- Or post-processing the DOM after the inner HTML is set, walking `h1...h6`, generating slugs from `textContent`, and assigning `el.id`.
+
+The renderer-override approach is cleaner and the slug becomes part of the cached HTML (so it survives `useMemo` and stays stable across re-renders). I recommend that.
+
+### How long docs are typically rendered
+- No virtualization.
+- `padding: "16px 16px"` outer wrapper, with the styled `<div class="md-content">` inside.
+- All children of `.md-content` are immediate siblings produced by marked: `h1`, `h2`, `p`, `ul`, `pre`, `blockquote`, `hr`, `table`, etc. **This is critical for the collapse algorithm: section membership is determined by walking siblings, not descendants.**
+
+### Parent component
+- `FileViewer.tsx` hosts `<MarkdownViewer content={fileContent} fileName={fileName} />` only when `fileContent !== null && fileName.endsWith(".md")`.
+- `FileViewer` already maintains a `collapsedRanges: Set<number>` state for **code-file line folding** (line 76). It's per-file (reset in `loadDirectory`/`loadFile`/`handleBack`). That's the right pattern to mirror for markdown fold state, but it should live higher (in `App.tsx`) so the TOC drawer can share it.
+
+### Top-level state
+- `App.tsx` already tracks `viewingFile: { path, name } | null` (line 47), which is the file currently open in the markdown viewer. That's the natural key for fold state.
+
+### BottomSheet primitive
+- `ActionBar.tsx` defines a local `BottomSheet` component (line 57) and uses it for ~10 modals already. The proposed TOC drawer would reuse it. Worth knowing because if/when the TOC ships, sync logic flows through whatever state lives in `App.tsx`.
+
+---
+
+## Part 2 — Design decisions
+
+### 1. Triangle placement
+- **Render position:** outside the heading text, in the left margin. Use a span/button with `position: absolute; left: -20px; top: 50%; transform: translateY(-50%)` against an `h1...h6 { position: relative; padding-left: 0 }`. The viewer's outer wrapper has `padding: "16px 16px"` so there's 16px of room before content clips — enough for a 14px triangle plus a couple of px breathing room. If clipping is a concern on very narrow Telegram screens, bump the wrapper padding-left to 24px and place the triangle at `left: -22px`.
+- **Visual:** triangle character (▼ expanded, ▶ collapsed) at ~14px, color `#565f89` (matches the dim-text color used elsewhere). On hover/focus, brighten to `#7aa2f7`.
+- **Hit area:** 32x32 transparent button centered on the triangle, so it's tappable on mobile. Use `padding` rather than width/height to keep visual size separate from hit area.
+- **Default state:** all expanded. Liam can always tap to collapse, but a doc that opens half-folded is confusing.
+
+### 2. What counts as a "section"
+- An `h${N}` heading's section is **every sibling DOM node after it, up to (but not including) the next sibling that is `h1`...`h${N}`**. So an h2's section ends at the next h1 or h2; any h3/h4/h5/h6 in between belongs to the section.
+- Nested triangles: a collapsed h2 hides everything after it including the h3 elements *and their triangles*. When the h2 expands again, those h3 triangles reappear in whatever state they were in before (if they were also collapsed, they stay collapsed). This falls out for free if the algorithm is just "set `display: none` on the contained DOM nodes" — re-expanding the parent restores the children's prior `display` state only if we're careful (see Part 4).
+- **First H1 special case:** the top-level doc title (the first `h1` in the document) should NOT have a triangle. Collapsing it would hide everything. Detect by "first H1 in the rendered output" and skip it.
+- **Empty section special case:** if the next sibling is already a heading of same/higher level (i.e. the section has zero non-heading content), don't show a triangle for that heading. It would be a no-op.
+
+### 3. State storage
+- `foldedSections: Set<string>` keyed by heading **slug** (not by index — slugs are stable across re-renders, indices aren't if the user scrolls and React re-mounts).
+- **Per-file:** Reset whenever `viewingFile.path` changes. The simplest way is to key the state by file path: `foldedByFile: Map<string, Set<string>>`. Or even simpler: just drop the Set whenever `viewingFile.path` changes.
+- **Persistence:** none. Ephemeral React state. Recreating fold state on revisit is cheap (one tap), and persisting it to localStorage for every doc Liam ever opens would create stale entries forever.
+- **Where it lives:** Lift to `App.tsx`. Pass down to `MarkdownViewer` (which renders triangles + applies display: none) and to the future `TocSheet` (which renders the same fold indicators). See Part 5.
+
+### 4. Animation
+- **v1: instant.** No animation. `display: none` toggles immediately. Animating height is hard with `dangerouslySetInnerHTML` because we'd need to wrap each section in a div with a known height for max-height transitions, which means more DOM mutation.
+- **v2 (defer):** if Liam asks for it, switch to wrapping each section in a `<div data-section-of="${slug}">` during post-processing and animate via `max-height` + `overflow: hidden`. Skip for v1.
+
+### 5. Interaction with the TOC drawer
+- **Tap heading in TOC → expand on the way:** When the user navigates to a heading, walk up its ancestor chain (h3 inside an h2 inside an h1) and remove all of those slugs from `foldedSections` before scrolling. This guarantees the target is visible.
+- **TOC reflects collapse state:** TOC entries whose ancestor heading is collapsed should be visually de-emphasized (grey) and clicking them still works (it expands the ancestor first, then scrolls).
+- **TOC has its own triangles:** Each parent heading row in the TOC gets its own little triangle that toggles the same `foldedSections` set. Tapping the triangle in the TOC collapses the section in the doc as well — they're literally the same state. This is the "sync" requirement and it falls out naturally if state is lifted.
+
+### 6. Click target semantics
+- Click triangle → toggle that section's slug in `foldedSections`.
+- Click heading text → no-op. Don't toggle, don't scroll. Preserves text selection and the natural reading experience.
+- (Optional, defer) Long-press heading → collapse all siblings of same level — "collapse all H2s" gesture. Not in v1.
+
+---
+
+## Part 3 — Technical approach
+
+I evaluated all four options. **Recommend: Option A — post-process the rendered HTML via a ref**, with the small refinement that heading IDs are assigned by a custom marked renderer (not in the post-processing pass), so the slugs are stable and computed once.
+
+### Option A — Post-process the rendered HTML (RECOMMENDED)
+**How:** Keep `marked.parse` + `dangerouslySetInnerHTML` exactly as today. Add a `useRef<HTMLDivElement>` to the `.md-content` div. Add a `useLayoutEffect` that runs after each render: walk the children, find headings, compute each heading's section range (the sibling slice ending at the next same-or-higher heading), and:
+1. Inject a triangle element (a `<button>` created with `document.createElement` is fine; no need for `createRoot` unless we want React to manage events) just before the heading text. Use event delegation on the wrapper div so we only attach one click listener total.
+2. For each heading whose slug is in `foldedSections`, set `style.display = "none"` on every node in its section range.
+3. For headings NOT in the set, ensure those nodes have their original display restored.
+
+**Pros:**
+- Zero new dependencies.
+- Doesn't change the rendering pipeline.
+- Easy to read and debug — the algorithm is one function.
+- Handles the "first H1 = title, no triangle" case trivially.
+- Heading-id assignment can be a one-line marked renderer override, decoupled from the fold logic.
+
+**Cons:**
+- Imperative DOM manipulation feels un-React-ish. Mitigate by keeping it in a single `useLayoutEffect` keyed on `[html, foldedSections]`.
+- If marked re-runs and produces a new innerHTML, we re-walk the whole tree. That's fine — the doc isn't changing during fold/unfold, only fold state is.
+- We have to remember the original `display` of each node we hide. Easiest: don't try to remember. Use a separate CSS class `.cpc-folded { display: none !important }` and toggle the class instead of inline styles. Then re-expanding just removes the class and the original display reappears. **This is the cleanest fix.**
+
+### Option B — marked custom renderer + event delegation
+**How:** `marked.use({ renderer: { heading({ tokens, depth }) { return `<h${depth} id="${slug}"><button class="cpc-toggle" data-slug="${slug}">▼</button>${parseInline(tokens)}</h${depth}>` } } })`. Then in MarkdownViewer, attach one click handler to the wrapper that listens for clicks on `.cpc-toggle`.
+
+**Pros:**
+- The triangle is part of the HTML — no second DOM walk to inject buttons.
+- Handlers are attached via delegation so we still only have one listener.
+
+**Cons:**
+- The triangle is now inside the heading's text flow, not in the margin. To get it back to the margin we'd need absolute positioning anyway, which means CSS that depends on the heading being `position: relative`. Works, but uglier.
+- Still need a separate post-processing pass to apply `display: none` based on fold state, because the renderer runs once at parse time and the fold state changes after.
+- So Option B = Option A's complexity + a renderer override. No win.
+
+### Option C — Switch to react-markdown
+**How:** Replace marked with react-markdown. Headings become real React components that can have interactive children natively.
+
+**Pros:**
+- Idiomatic React. No imperative DOM work.
+- `react-markdown` has a known plugin ecosystem (`rehype-slug` for IDs, `rehype-autolink-headings`, etc.).
+
+**Cons:**
+- New dependency (react-markdown + rehype + remark — meaningfully larger bundle, ~50–80KB minified depending on plugins).
+- Existing styles, table handling, code blocks, GFM behavior all need to be re-verified.
+- It's a much bigger PR with more risk for a feature that doesn't strictly require it.
+- Doesn't solve the "section is the slice of siblings between headings" problem any better — react-markdown still produces a flat list of sibling elements at the top level. You still need to compute section ranges and conditionally hide them.
+
+### Option D — Render token tree manually
+**How:** Use marked's tokenizer to get the AST, then render to React elements ourselves.
+
+**Pros:**
+- Maximum control. Sections could be wrapped in real React components with proper conditional rendering.
+
+**Cons:**
+- Massive scope: re-implementing tables, code blocks, lists, blockquotes, GFM. The current viewer leans on marked's HTML output for all of this.
+- This is not a one-day task. It's a rewrite.
+
+### Recommendation
+Go with **Option A**. The fold logic stays in one `useLayoutEffect` in `MarkdownViewer.tsx`. Heading IDs come from a marked renderer override (the only thing we change about the parse pipeline). Triangles are injected as plain DOM buttons; clicks are handled via event delegation. State lives in `App.tsx`. No new dependencies.
+
+---
+
+## Part 4 — The collapse mechanic
+
+### Algorithm (sibling-slice walk)
+After `marked.parse` runs and the HTML is in the DOM, in a `useLayoutEffect`:
+
+1. Get a flat list of `.md-content`'s direct children: `const nodes = Array.from(rootRef.current.children)`. (They're already in document order — that's how marked emits them.)
+2. Find headings: `const headings = nodes.filter(n => /^H[1-6]$/.test(n.tagName))`. Each heading remembers its index in `nodes` and its level (1–6, parsed from tagName).
+3. Skip the first H1 (the doc title) — no triangle.
+4. For every other heading at index `i` with level `L`:
+   - Find the next heading at index `j > i` with level `<= L`. If none, `j = nodes.length`.
+   - The section is `nodes.slice(i + 1, j)`.
+   - If the section is empty (i.e. `j === i + 1` and the next thing is another heading), this heading is non-foldable: skip injecting a triangle for it.
+   - Otherwise, inject a triangle button just before the heading's first child (or as a positioned-absolute child of the heading), with `data-slug="${heading.id}"`.
+5. After triangles are injected, apply fold state: for each heading whose slug is in `foldedSections`, add `cpc-folded` class to every node in its section. This is what hides them. For each heading NOT in the set, remove the class from its section.
+6. Update each triangle's text content: ▼ if expanded, ▶ if collapsed. Optional: append `(N)` where N is the count of non-empty paragraphs/elements in the section, so collapsed sections show "▶ (12)".
+
+### Hide mechanism: a single CSS class
+Add to the existing `<style>` block:
+```css
+.cpc-folded { display: none !important; }
+.md-content h1, .md-content h2, .md-content h3,
+.md-content h4, .md-content h5, .md-content h6 {
+  position: relative;
+}
+.md-content .cpc-toggle {
+  position: absolute;
+  left: -22px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 32px; height: 32px;
+  display: flex; align-items: center; justify-content: center;
+  background: transparent; border: none; color: #565f89;
+  cursor: pointer; font-size: 14px;
+  /* hit area extends past the visible 14px triangle */
+}
+.md-content .cpc-toggle:hover { color: #7aa2f7; }
+```
+Then `node.classList.add("cpc-folded")` / `removeAttribute("class")` is the entire collapse mechanic. We never touch `style.display`, so we never have to remember original display values. This cleanly handles `display: block`, `display: flex` (none of the markdown elements use it but defensively), `display: table` (for `<table>`), etc.
+
+### Nested fold preservation
+Because hidden ancestors don't run their own fold logic (we just `display: none` everything inside them), a collapsed h3 stays in `foldedSections` even when its parent h2 is also collapsed. When the h2 expands, the h3 remains collapsed because its slug is still in the set and the next post-process pass re-applies it. Exactly what we want.
+
+### Click handling
+Single delegated listener on `rootRef.current`:
+```ts
+const onClick = (e: MouseEvent) => {
+  const btn = (e.target as HTMLElement).closest('.cpc-toggle');
+  if (!btn) return;
+  const slug = btn.getAttribute('data-slug');
+  if (!slug) return;
+  e.preventDefault();
+  e.stopPropagation();
+  toggleFold(slug);
+};
+```
+Where `toggleFold` is a callback passed from `App.tsx` (or `FileViewer`) that updates `foldedSections`.
+
+---
+
+## Part 5 — TOC sync strategy
+
+### State management — recommendation
+**Lift to `App.tsx`.** Add:
+```ts
+const [foldedSections, setFoldedSections] = useState<Set<string>>(new Set());
+
+// Reset whenever the viewing file changes
+useEffect(() => { setFoldedSections(new Set()); }, [viewingFile?.path]);
+
+const toggleFold = useCallback((slug: string) => {
+  setFoldedSections(prev => {
+    const next = new Set(prev);
+    if (next.has(slug)) next.delete(slug); else next.add(slug);
+    return next;
+  });
+}, []);
+
+const expandAncestors = useCallback((slugs: string[]) => {
+  setFoldedSections(prev => {
+    const next = new Set(prev);
+    for (const s of slugs) next.delete(s);
+    return next;
+  });
+}, []);
+```
+
+Pass `foldedSections`, `toggleFold`, `expandAncestors` down to `FileViewer` → `MarkdownViewer`, and (when it ships) to `TocSheet`.
+
+### Why not React Context?
+- Only 2 components need this state. Prop drilling through `FileViewer → MarkdownViewer` is one hop.
+- Context invalidates everything in its tree on every change, causing the whole `FileViewer` to re-render on every fold toggle. Not catastrophic but unnecessary.
+- Explicit props are easier to reason about and easier to remove later if Liam decides he hates this feature.
+
+### Why not a custom event bus?
+- The "shared state" requirement is the whole point. Event buses recreate state by accident and lose it on re-mount. React state is the right tool.
+
+### Sync flow when TOC ships
+1. `TocSheet` parses the headings from the rendered markdown (or receives them as a prop from `MarkdownViewer`, which is cleaner — see "shared headings list" below).
+2. Each parent heading row in TocSheet has a triangle that calls `toggleFold(slug)`.
+3. Each leaf row that's an ancestor-of-folded shows greyed out.
+4. When a row is tapped, TocSheet computes the chain of ancestors (walks up the parsed-headings list to find every heading at a higher level whose section contains this slug), calls `expandAncestors(ancestors)`, and then triggers a smooth scroll to the slug's element. Both sides of the sync share the same `Set`, so the doc reflects the change automatically via `MarkdownViewer`'s `useLayoutEffect`.
+
+### Shared headings list
+To avoid parsing headings twice (once in `MarkdownViewer` for triangles, once in `TocSheet` for the list), have `MarkdownViewer` parse headings during its `useLayoutEffect`, store them in a state variable, and pass them up via an `onHeadingsChange?: (headings: Heading[]) => void` callback. `App.tsx` holds the headings array and passes it into `TocSheet`. This is the same pattern as `onViewChange` already used in `FileViewer.tsx` (line 154).
+
+---
+
+## Part 6 — Edge cases
+
+| Case | Behavior |
+|------|----------|
+| Doc has zero headings | No triangles render. Loop in post-process finds no headings; nothing happens. |
+| First H1 = doc title | Skip injecting triangle for it. Detected as "first heading in document order at level 1". |
+| Heading with no content after it (just another heading) | Section range is empty. Don't inject triangle. The heading still gets an `id` (for TOC linking) but no fold control. |
+| Heading is the very last element | Section is `nodes.slice(i+1, nodes.length)`, which may be empty (no triangle) or contain trailing content. |
+| Two headings with the same text | Slugger appends `-2`, `-3`, etc. for uniqueness. Standard slug behavior. |
+| Markdown contains raw HTML headings (`<h2>...</h2>` typed by user) | Marked passes them through if `gfm` mode allows. They become real `<h2>` elements in the output and get triangles like any other heading. |
+| User collapses a section, then scrolls | No issue. Browser preserves scroll position relative to the document, and when content above the viewport disappears, the scroll position adjusts naturally. (If this looks jumpy in practice, we can record `scrollTop` before the toggle and restore it after — but try without first.) |
+| User switches files | `useEffect([viewingFile.path])` resets `foldedSections` to empty. Fresh slate per file. |
+| User collapses an H2, then collapses its parent H1 | Both slugs are in the set. The H1's hide-pass hides the H2 and everything inside it (the H2's triangle is hidden along with the rest). When the user re-expands the H1, the H2 is still in the set so it stays collapsed and shows ▶. |
+| Hash navigation `#some-heading` | Browser scrolls to the element. If that element is inside a collapsed section, it won't be visible. Solution: on mount and on hash change, walk up from the target heading to find any folded ancestors and remove them. Same `expandAncestors` helper TocSheet uses. |
+| Triangle click also bubbles to heading | The delegated handler calls `e.preventDefault()` and `e.stopPropagation()`. Heading text click does nothing anyway. |
+| Marked renderer override breaks something | Run the existing markdown viewer manually with several test docs (long ADRs, the overnight reports, code-heavy files) to confirm output is unchanged except for the new `id` attributes. |
+
+---
+
+## Part 7 — Scope and effort
+
+### Standalone (no TOC)
+**Medium — about 1 day (6–8 hours).**
+
+Breakdown:
+- 1h: marked renderer override + slugger utility
+- 2h: post-processing logic in `MarkdownViewer` (sibling walk, triangle injection, fold application)
+- 1h: lift fold state to `App.tsx`, prop-drill through `FileViewer`
+- 1h: CSS, visual polish, mobile hit-area testing
+- 1h: edge cases (first H1, empty sections, hash navigation)
+- 1h: manual testing on real docs (overnight reports, ADRs, long synthesis docs)
+
+### With TOC sync (if TOC ships in the same PR or right after)
+**Medium-large — about 1.5–2 days.**
+
+The TOC drawer itself is independently estimated at 4–6 hours in the existing proposal, but it shares a bunch of work with this feature:
+- Heading-ID assignment (do it once in the marked renderer override — both features benefit)
+- Heading parsing (do it once in `MarkdownViewer`, hand the list up via `onHeadingsChange`)
+- Lifted fold state in `App.tsx` (one `useState`)
+
+Combined effort:
+- 6–8h: collapsible headings (above)
+- 4–6h: TOC drawer
+- 2–3h: shared-state plumbing (foldedSections + headings list flowing through both components, the expand-ancestors-on-tap logic, greyed-out leaf rendering)
+- Total: ~12–17h, call it 1.5–2 days
+
+Strong recommendation: **ship them together as one PR** if both are wanted. The shared work (renderer override, heading parsing, lifted state) is half the value, and doing them in two separate PRs duplicates the prep and risks divergent slug schemes.
+
+---
+
+## Open questions
+
+1. **Triangle character or SVG?** Character (▼/▶) is simplest and matches the existing emoji-heavy visual style of the file viewer (📁/📄). SVG would be sharper but adds icon-system overhead. Recommend character for v1.
+2. **Show item count when collapsed?** "▶ (12 items)" is informative but adds clutter. Recommend: skip for v1, add if Liam asks.
+3. **Should the H1 doc title be stylable separately?** The "skip triangle on first H1" rule is content-agnostic — it's positional. If Liam writes a doc that doesn't start with an H1, the first H2 still gets a triangle. Confirm this is fine.
+4. **Per-file persistence?** The recommendation is no persistence. If Liam routinely re-opens the same long doc (an ADR he's reviewing for a week), a localStorage cache keyed by `file path → Set<slug>` would be a small addition. Defer until requested.
+5. **Markdown re-render churn:** the `useMemo` keys on `[content]`, so toggling fold state doesn't re-parse markdown. Triangles persist, fold logic just toggles classes. Confirmed safe.
+6. **Does the existing TOC proposal's effort estimate need updating?** Yes — the proposal claims marked already generates IDs (`tmp/20260407-markdown-toc-and-audio-proposals.md` line 71). It doesn't. Add ~30 minutes to the TOC estimate for the renderer override + slugger.
+7. **Telegram WebApp viewport quirks:** the markdown viewer is inside a Telegram mini app. Triangles positioned absolutely with `left: -22px` need to not get clipped by the outer scrollable container's overflow rules. The current outer wrapper has `overflowX: "auto"` (line 25) — this is fine because the triangles are still inside `.md-content` which has `padding: 16px 16px` (line 23). The 16px of left padding is enough room. Verify on a narrow device.
+8. **Accessibility:** the triangle button needs `aria-expanded={!folded}`, `aria-controls={sectionId}`, and a screen-reader label like `aria-label="Collapse section: {heading text}"`. Add this in v1; it's cheap.
+
+---
+
+## Phased implementation plan
+
+### Phase 0 — Prep (do this first)
+1. Add a slug helper in `MarkdownViewer.tsx` (or a new `lib/slug.ts` if you prefer): `function slugify(text: string, used: Set<string>): string` that lowercases, strips punctuation, replaces whitespace with `-`, and appends `-2`, `-3` for duplicates.
+2. Override marked's heading renderer:
+   ```ts
+   const slugCounts = new Map<string, number>();
+   marked.use({
+     renderer: {
+       heading({ tokens, depth }) {
+         const text = this.parser.parseInline(tokens);
+         const plain = text.replace(/<[^>]*>/g, '');  // strip inline HTML for slug
+         const base = slugify(plain);
+         const n = (slugCounts.get(base) ?? 0) + 1;
+         slugCounts.set(base, n);
+         const slug = n === 1 ? base : `${base}-${n}`;
+         return `<h${depth} id="${slug}">${text}</h${depth}>\n`;
+       }
+     }
+   });
+   ```
+   Important: reset `slugCounts` per `marked.parse` call. Cleanest way: build the override inside the `useMemo` so each parse call gets a fresh Map. Or use a `marked.use` extension hook. (The simplest pattern: declare a renderer object once at module scope but reset its `slugCounts` Map at the start of each `useMemo` body — slightly hacky. The extension hook is cleaner; if it's too fiddly, just call `marked.use` once per parse, which works because `marked.use` is idempotent for renderer overrides.)
+
+### Phase 1 — Visual triangles, no logic
+1. Add `cpc-toggle` and `cpc-folded` CSS to `MarkdownViewer`'s `<style>` block.
+2. Add a `useLayoutEffect` that walks `.md-content` children, finds headings, and injects a triangle button before each heading's content. Skip the first H1.
+3. Verify visually: triangles appear in the left margin of every heading except the doc title.
+4. No fold logic yet. Triangles are inert.
+
+### Phase 2 — Fold logic locally in MarkdownViewer
+1. Add local `useState<Set<string>>` for fold state inside `MarkdownViewer` temporarily.
+2. Compute section ranges (sibling slice between headings) for each heading.
+3. Apply `cpc-folded` class to all nodes in the range when the heading's slug is in the set.
+4. Wire up the delegated click handler so triangles toggle.
+5. Test: collapse h2, collapse nested h3, expand parent h2, confirm h3 stays collapsed.
+6. Test edge cases: first H1, empty sections, last heading.
+
+### Phase 3 — Lift state to App.tsx
+1. Move `foldedSections`, `toggleFold` from `MarkdownViewer` to `App.tsx`.
+2. Add `useEffect([viewingFile?.path])` reset.
+3. Pass through `FileViewer` as props, then to `MarkdownViewer`.
+4. Verify: switching files resets fold state. Switching tabs and back preserves it (unless file changed).
+
+### Phase 4 — Polish
+1. Add `aria-expanded`, `aria-controls`, `aria-label` to triangle buttons.
+2. Test mobile hit area on a real device or browser devtools touch simulator.
+3. Test with the longest markdown docs you can find (overnight reports, ADRs).
+4. Verify hash navigation: `#some-heading-inside-folded-section` should auto-expand ancestors. Add `expandAncestors` walker if not done in Phase 3.
+
+### Phase 5 — TOC sync (only if TOC drawer is in scope)
+1. Add `headings: Heading[]` state in `App.tsx`.
+2. Add `onHeadingsChange` callback in `MarkdownViewer`, fire it from the same `useLayoutEffect` that builds triangles.
+3. Implement `TocSheet` per the existing proposal, but pass it `foldedSections`, `toggleFold`, and `headings`.
+4. In TocSheet, render parent rows with triangles and leaf rows greyed out when an ancestor is folded.
+5. On row tap: compute ancestor slugs, call `expandAncestors`, scroll to slug.
+6. Test the round trip: collapse h2 in doc → its h3 children grey out in TOC. Tap an h3 in TOC → ancestor h2 expands in doc → scroll lands on h3.
+
+### Phase 6 — (Defer) Animation
+Wrap each section in a data-attributed div during post-processing, animate via max-height + overflow. Only do this if Liam asks.
+
+---
+
+## Critical Files for Implementation
+
+- `/home/claude/code/claude-pocket-console/apps/web/src/components/MarkdownViewer.tsx` — primary changes: add ref, useLayoutEffect for triangle injection + fold application, marked renderer override for heading IDs, CSS for `.cpc-toggle` and `.cpc-folded`. Receives `foldedSections` and `toggleFold` as props.
+- `/home/claude/code/claude-pocket-console/apps/web/src/App.tsx` — add `foldedSections: Set<string>` state, `toggleFold` and `expandAncestors` callbacks, reset effect on `viewingFile.path` change. Pass props down through `FileViewer`.
+- `/home/claude/code/claude-pocket-console/apps/web/src/components/FileViewer.tsx` — add prop pass-through for fold state and callbacks; otherwise unchanged. (Already manages its own `collapsedRanges` for code-file folding — that stays separate; markdown fold is a different feature that lives at App level.)
+- `/home/claude/code/claude-pocket-console/apps/web/src/components/ActionBar.tsx` — only relevant if TOC drawer ships in the same pass. Reference for the existing `BottomSheet` component that the future `TocSheet` should reuse.
+- `/home/claude/claudes-world/tmp/20260407-markdown-toc-and-audio-proposals.md` — the related TOC proposal. Note that its claim about marked auto-generating IDs is incorrect; if both features ship, they share the heading-id assignment work described here.

--- a/apps/web/src/__fixtures__/markdown/13-mermaid.md
+++ b/apps/web/src/__fixtures__/markdown/13-mermaid.md
@@ -1,0 +1,21 @@
+# Mermaid Test
+
+This is a quick test of Mermaid rendering in CPC's MarkdownViewer.
+
+## Flowchart
+
+```mermaid
+graph TD
+  A[Start] --> B{Decision}
+  B -->|Yes| C[Continue]
+  B -->|No| D[Stop]
+```
+
+## Regular code block (should stay as code)
+
+```js
+const hello = "world";
+console.log(hello);
+```
+
+Done.

--- a/apps/web/src/__fixtures__/markdown/14-empty.md
+++ b/apps/web/src/__fixtures__/markdown/14-empty.md
@@ -1,0 +1,1 @@
+Just a single line of text and nothing else.

--- a/apps/web/src/__fixtures__/markdown/15-pathological.md
+++ b/apps/web/src/__fixtures__/markdown/15-pathological.md
@@ -1,0 +1,51 @@
+# Pathological shapes
+
+Raw HTML mixed in (marked passes through by default):
+
+<div class="custom-box" style="padding: 8px;">
+  <p>Inline HTML paragraph with <strong>bold</strong> and a <a href="https://example.com">raw anchor</a>.</p>
+</div>
+
+Single-newline-as-break (relies on `breaks: true`):
+Line A
+Line B
+Line C
+
+Deeply nested list (5 levels):
+
+- L1
+  - L2
+    - L3
+      - L4
+        - L5 leaf
+
+Unicode smorgasbord: café, naïve, façade, résumé, 日本語, 中文, العربية, עברית, emoji: hello duck, math: α + β = γ, ∑ x_i, ∫ f(x) dx.
+
+Inline HTML inside a paragraph: this is <span style="color: red;">red text</span> and <code>raw code</code> inside a normal paragraph.
+
+A horizontal rule:
+
+---
+
+A heading immediately after the hr:
+
+## Heading right after hr
+
+Backtick-heavy inline: ``a`b`` and ``` ``nested`` ``` and ```` ```triple``` ````.
+
+Escape sequences: \*not italic\*, \`not code\`, \[not link\](nope).
+
+Empty code block:
+
+```
+```
+
+Code block with no language:
+
+```
+plain text
+multiple lines
+  indented
+```
+
+A paragraph ending without a trailing newline and no more content after it.

--- a/apps/web/src/__tests__/__snapshots__/markdown-snapshots.test.ts.snap
+++ b/apps/web/src/__tests__/__snapshots__/markdown-snapshots.test.ts.snap
@@ -1,0 +1,1182 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`MarkdownViewer (marked baseline) > renders 01-headings.md consistently 1`] = `
+"<h1>Heading Level 1</h1>
+<p>Some content under an h1 with <strong>bold</strong> text.</p>
+<h2>Heading Level 2</h2>
+<p>A paragraph under h2 with <code>inline code</code> and a <a href="https://example.com">link</a>.</p>
+<h3>Heading Level 3</h3>
+<ul>
+<li>A bullet under h3</li>
+<li>Another bullet</li>
+</ul>
+<h4>Heading Level 4</h4>
+<p>Paragraph under h4.</p>
+<h5>Heading Level 5</h5>
+<blockquote>
+<p>A blockquote under h5.</p>
+</blockquote>
+<h6>Heading Level 6</h6>
+<p>Final paragraph under the smallest heading.</p>
+<h2>Another H2 After H6</h2>
+<p>Content to test heading-reset behavior.</p>
+<h3>Nested h3</h3>
+<p>And some trailing content.</p>
+"
+`;
+
+exports[`MarkdownViewer (marked baseline) > renders 02-lists.md consistently 1`] = `
+"<h1>Lists</h1>
+<h2>Unordered</h2>
+<ul>
+<li>Apple</li>
+<li>Banana</li>
+<li>Cherry</li>
+</ul>
+<h2>Ordered</h2>
+<ol>
+<li>First</li>
+<li>Second</li>
+<li>Third</li>
+</ol>
+<h2>Nested (3+ deep)</h2>
+<ul>
+<li>Level 1 item A<ul>
+<li>Level 2 item A.1<ul>
+<li>Level 3 item A.1.a<ul>
+<li>Level 4 item A.1.a.i</li>
+</ul>
+</li>
+<li>Level 3 item A.1.b</li>
+</ul>
+</li>
+<li>Level 2 item A.2</li>
+</ul>
+</li>
+<li>Level 1 item B</li>
+</ul>
+<h2>Task list</h2>
+<ul>
+<li><input disabled="" type="checkbox"> Open task</li>
+<li><input checked="" disabled="" type="checkbox"> Completed task</li>
+<li><input disabled="" type="checkbox"> Another open task<ul>
+<li><input checked="" disabled="" type="checkbox"> Nested completed subtask</li>
+<li><input disabled="" type="checkbox"> Nested open subtask</li>
+</ul>
+</li>
+</ul>
+<h2>Mixed ordered + unordered</h2>
+<ol>
+<li><p>First ordered</p>
+<ul>
+<li>Unordered sub A</li>
+<li>Unordered sub B<ol>
+<li>Re-ordered sub-sub</li>
+<li>Another re-ordered sub-sub</li>
+</ol>
+</li>
+</ul>
+</li>
+<li><p>Second ordered</p>
+</li>
+<li><p>Third ordered with a paragraph.</p>
+<p>Continuation paragraph inside list item.</p>
+</li>
+<li><p>Fourth ordered</p>
+</li>
+</ol>
+"
+`;
+
+exports[`MarkdownViewer (marked baseline) > renders 03-code-block-short.md consistently 1`] = `
+"<h1>Short code block</h1>
+<p>Here is a small TypeScript snippet:</p>
+<pre><code class="language-ts">function greet(name: string): string {
+  return \`Hello, \${name}!\`;
+}
+
+greet(&quot;world&quot;);
+</code></pre>
+<p>And a short bash example:</p>
+<pre><code class="language-bash">pnpm install
+pnpm test
+</code></pre>
+"
+`;
+
+exports[`MarkdownViewer (marked baseline) > renders 04-code-block-wide.md consistently 1`] = `
+"<h1>Wide code block (horizontal scroll target)</h1>
+<p>This fixture exists to pin down the PR #20 regression around wide code blocks and horizontal scrolling.</p>
+<pre><code class="language-ts">// This single line is intentionally very long to force horizontal scrolling inside the rendered &lt;pre&gt;&lt;code&gt; container so we can diff how marked and react-markdown lay out the overflow behavior under the same CSS.
+const veryLongIdentifier = { alpha: 1, beta: 2, gamma: 3, delta: 4, epsilon: 5, zeta: 6, eta: 7, theta: 8, iota: 9, kappa: 10, lambda: 11, mu: 12, nu: 13, xi: 14, omicron: 15, pi: 16, rho: 17, sigma: 18, tau: 19, upsilon: 20, phi: 21, chi: 22, psi: 23, omega: 24 };
+function doSomethingThatTakesAbsurdlyManyArgumentsAndReturnsAnAbsurdlyLongInlineTypeAnnotation(arg1: string, arg2: number, arg3: boolean, arg4: Record&lt;string, unknown&gt;, arg5: Array&lt;{ id: string; value: number; metadata: Record&lt;string, string&gt; }&gt;): Promise&lt;{ ok: true; data: Array&lt;{ id: string; value: number; metadata: Record&lt;string, string&gt; }&gt; } | { ok: false; error: string }&gt; {
+  return Promise.resolve({ ok: true, data: arg5 });
+}
+</code></pre>
+<p>And a short line afterwards to verify the following paragraph wraps normally after a wide code block:</p>
+<pre><code>$ curl -sSL https://example.com/some/very/long/path/that/should/not/wrap/inside/the/pre/block/because/pre/preserves/whitespace/and/horizontal/scroll/should/kick/in?query=param1&amp;query=param2&amp;query=param3
+</code></pre>
+<p>End of wide fixture.</p>
+"
+`;
+
+exports[`MarkdownViewer (marked baseline) > renders 05-table-narrow.md consistently 1`] = `
+"<h1>Narrow table</h1>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th align="right">Count</th>
+</tr>
+</thead>
+<tbody><tr>
+<td>Apples</td>
+<td align="right">3</td>
+</tr>
+<tr>
+<td>Bananas</td>
+<td align="right">12</td>
+</tr>
+<tr>
+<td>Cherries</td>
+<td align="right">47</td>
+</tr>
+</tbody></table>
+<p>A short paragraph after the table.</p>
+"
+`;
+
+exports[`MarkdownViewer (marked baseline) > renders 06-table-wide.md consistently 1`] = `
+"<h1>Wide table</h1>
+<table>
+<thead>
+<tr>
+<th align="left">Column A</th>
+<th align="center">Column B</th>
+<th align="left">Column C (with a long header)</th>
+<th align="right">Column D</th>
+<th>Column E</th>
+<th>Column F</th>
+</tr>
+</thead>
+<tbody><tr>
+<td align="left">alpha</td>
+<td align="center">beta</td>
+<td align="left">this is a fairly long cell value that should push the column width out</td>
+<td align="right">1</td>
+<td>true</td>
+<td><code>code</code></td>
+</tr>
+<tr>
+<td align="left">gamma</td>
+<td align="center">delta</td>
+<td align="left">another long cell with <strong>bold</strong> and <em>italic</em> inline styles interleaved</td>
+<td align="right">22</td>
+<td>false</td>
+<td><a href="https://example.com">link</a></td>
+</tr>
+<tr>
+<td align="left">epsilon</td>
+<td align="center">zeta</td>
+<td align="left">short</td>
+<td align="right">333</td>
+<td>true</td>
+<td>plain</td>
+</tr>
+<tr>
+<td align="left">eta</td>
+<td align="center">theta</td>
+<td align="left">cell with a pipe escape | inside it</td>
+<td align="right">4444</td>
+<td>false</td>
+<td><code>x</code></td>
+</tr>
+<tr>
+<td align="left">iota</td>
+<td align="center">kappa</td>
+<td align="left">final row with a <a href="https://example.com/path?a=1&b=2">link</a> embedded</td>
+<td align="right">55555</td>
+<td>true</td>
+<td>done</td>
+</tr>
+</tbody></table>
+<p>Trailing paragraph to verify flow after a wide table.</p>
+"
+`;
+
+exports[`MarkdownViewer (marked baseline) > renders 07-blockquote.md consistently 1`] = `
+"<h1>Blockquotes</h1>
+<p>Single-level blockquote:</p>
+<blockquote>
+<p>This is a simple single-level blockquote.<br>It spans two lines of markdown source.</p>
+</blockquote>
+<p>With inline formatting:</p>
+<blockquote>
+<p>A blockquote with <strong>bold</strong>, <em>italic</em>, <code>inline code</code>, and a <a href="https://example.com">link</a>.</p>
+</blockquote>
+<p>Nested blockquote:</p>
+<blockquote>
+<p>Outer quote level 1.</p>
+<blockquote>
+<p>Inner quote level 2 with some longer content to make sure wrapping works as expected.</p>
+<blockquote>
+<p>Deepest quote level 3.</p>
+</blockquote>
+<p>Back to level 2.</p>
+</blockquote>
+<p>Back to level 1.</p>
+</blockquote>
+<p>Blockquote containing a list:</p>
+<blockquote>
+<ul>
+<li>Item one inside quote</li>
+<li>Item two inside quote<ul>
+<li>Nested item</li>
+</ul>
+</li>
+<li>Item three inside quote</li>
+</ul>
+</blockquote>
+<p>Blockquote containing a code block:</p>
+<blockquote>
+<pre><code class="language-ts">const quoted = &quot;code inside blockquote&quot;;
+</code></pre>
+</blockquote>
+"
+`;
+
+exports[`MarkdownViewer (marked baseline) > renders 08-mixed-inline.md consistently 1`] = `
+"<h1>Mixed inline formatting</h1>
+<p>A single dense paragraph with <strong>bold</strong>, <em>italic</em>, <em><strong>bold-italic</strong></em>, <code>inline code</code>, <del>strikethrough</del>, and a <a href="https://example.com">link</a> all interleaved into one flowing sentence so the renderer has to deal with many inline transitions in a row without any breaks between them at all.</p>
+<p>Another paragraph that <strong>combines <code>code inside bold</code></strong> and <em><a href="https://example.com">links inside italics</a></em> and <code>**not bold inside code**</code> to verify escape semantics.</p>
+<p>A line with emphasis edges: <strong>bold at start</strong> of a sentence, and another sentence ending with <strong>bold at end</strong>. Also <em>italic at start</em> and <em>italic at end</em>.</p>
+<p>Adjacent inline tokens: <strong>bold</strong><code>code</code> and <em>italic</em><strong>bold</strong> and <code>code</code><a href="https://example.com">link</a>.</p>
+<p>Strikethrough combos: <del>plain strike</del>, <del><strong>bold strike</strong></del>, <del><em>italic strike</em></del>, <del><code>code strike</code></del>.</p>
+<p>Line 1 with trailing spaces to force a soft break<br>Line 2 after the soft break.</p>
+<p>Line A<br>Line B (single newline between — with <code>breaks: true</code>, marked renders this as <code>&lt;br&gt;</code>).</p>
+"
+`;
+
+exports[`MarkdownViewer (marked baseline) > renders 09-link-edge-cases.md consistently 1`] = `
+"<h1>Link edge cases</h1>
+<p>Inline link with parens in URL: <a href="https://en.wikipedia.org/wiki/Markdown_(software)">wiki article</a>.</p>
+<p>Inline link with query + fragment: <a href="https://example.com/path?query=foo&bar=baz#section-2">search</a>.</p>
+<p>Inline link with title: <a href="https://example.com" title="Example title">hover me</a>.</p>
+<p>Autolink: <a href="https://example.com/autolink">https://example.com/autolink</a>.</p>
+<p>Autolink email: <a href="mailto:someone@example.com">someone@example.com</a>.</p>
+<p>Reference-style link: see <a href="https://spec.commonmark.org/0.30/" title="CommonMark 0.30">the spec</a> for details.</p>
+<p>Another reference: <a href="https://example.com/inline-ref">inline ref</a> works too.</p>
+<p>Collapsed reference: <a href="https://example.com/collapsed">collapsed</a>.</p>
+<p>Shortcut reference: <a href="https://example.com/shortcut">shortcut</a>.</p>
+<p>Link with special chars in text: <a href="https://example.com"><code>code</code> in <strong>bold</strong> link text</a>.</p>
+<p>Image: <img src="https://shared.claude.do/public/placeholder.png" alt="alt text" title="image title">.</p>
+<p>Link followed immediately by punctuation: see <a href="https://example.com">example</a>, then continue.</p>
+<p>Bare URL (not autolinked without angle brackets): <a href="https://example.com/bare">https://example.com/bare</a></p>
+"
+`;
+
+exports[`MarkdownViewer (marked baseline) > renders 10-real-doc-adr.md consistently 1`] = `
+"<h1>ADR 0001: Package CPC as the Shareable Hub with Toolbox as a Git Submodule</h1>
+<p><strong>Status:</strong> Proposed<br><strong>Date:</strong> 2026-04-06<br><strong>Deciders:</strong> Liam (Chaintail), Claude<br><strong>Context:</strong> Hackathon friends asked for GitHub links to &quot;what we built.&quot; This forced the question of what artifact best represents Claude&#39;s World as a sharable, runnable system.</p>
+<hr>
+<h2>Context</h2>
+<p>Claude&#39;s World is currently spread across multiple repositories and directories with no single artifact a new user could clone to &quot;get the system&quot;:</p>
+<ul>
+<li><strong>CPC</strong> (<code>~/code/claude-pocket-console</code>) — the Telegram mini app, the most polished and visually impressive piece</li>
+<li><strong>Toolbox</strong> (<code>~/code/toolbox</code>) — reusable scripts (md-speak, share-doc, transcribe, hooks). About 20 of the 40 entries in <code>~/bin</code> are now symlinks into this repo. Migration is in progress.</li>
+<li><strong>Skills</strong> (<code>~/.claude/skills/</code> and <code>~/claudes-world/.claude/skills/</code>) — Claude Code skills, scattered across two locations</li>
+<li><strong>Host config</strong> (<code>~/do-box</code>) — VPS-specific systemd, Caddy, cloudflared (brittle whitelist-driven snapshot)</li>
+<li><strong>Live state</strong> (<code>~/claudes-world/</code>) — working directory, knowledge base, memory, ephemeral files</li>
+</ul>
+<p>When the user&#39;s hackathon friends asked for GitHub links, there was no clean answer. Pointing them to CPC alone misses the supporting infrastructure. Pointing them to multiple repos requires explaining the relationships. A monolithic &quot;everything in one repo&quot; approach was considered but rejected (see Alternatives).</p>
+<p>The user proposed: <strong>what if CPC stays as the primary shareable artifact and toolbox is included as a dependency inside it?</strong> This ADR captures that decision.</p>
+<hr>
+<h2>Decision</h2>
+<p><strong>CPC will be the primary shareable artifact for Claude&#39;s World. Toolbox will be embedded as a git submodule.</strong></p>
+<p>The structure will be:</p>
+<pre><code>claude-pocket-console/             ← what new users clone
+├── README.md                      ← &quot;This is Claude&#39;s World&quot;
+├── apps/web/                      ← React/Vite mini app
+├── apps/server/                   ← Hono API
+├── tools/                         ← git submodule → toolbox repo
+│   ├── md-speak/
+│   ├── share-doc/
+│   ├── transcribe/
+│   └── hooks/
+├── skills/                        ← Claude Code skills (migrated from ~/.claude/skills)
+└── docs/                          ← progressive disclosure (per OmniPass pattern)
+    ├── reference/
+    ├── guides/
+    └── conventions/
+</code></pre>
+<p>A new user would:</p>
+<ol>
+<li><code>git clone --recursive github.com/{user}/claude-pocket-console</code></li>
+<li>Read <code>README.md</code> and <code>AGENTS.md</code> (the index)</li>
+<li>Browse <code>docs/</code> for progressive disclosure on whatever interests them</li>
+<li>Run <code>pnpm install &amp;&amp; pnpm run dev</code> to bring up CPC</li>
+<li>Optionally install the toolbox scripts to their own <code>~/bin</code> for full Claude Code integration</li>
+</ol>
+<p>Toolbox keeps its own repository, its own commit history, and its own lifecycle. CPC pins to a specific toolbox commit via the submodule reference, and bumps that pin intentionally when toolbox ships changes.</p>
+<hr>
+<h2>Consequences</h2>
+<h3>Positive</h3>
+<ul>
+<li><strong>One link to share.</strong> &quot;Check out github.com/{user}/claude-pocket-console&quot; gives someone the whole system. The first impression is the polished mini app, not a wall of bash scripts.</li>
+<li><strong>Toolbox stays portable.</strong> Someone who wants only the scripts can clone toolbox alone without pulling CPC. The two repos serve different audiences (CPC for &quot;show me the system,&quot; toolbox for &quot;give me the tools&quot;).</li>
+<li><strong>Independent lifecycles.</strong> Toolbox can ship breaking changes, ship rapid iterations, or be totally rewritten without forcing a CPC release. CPC pins to a known-good commit and bumps deliberately.</li>
+<li><strong>Smaller blast radius.</strong> A bug in toolbox doesn&#39;t break CPC unless CPC explicitly bumps the submodule. Reverting is one commit away.</li>
+<li><strong>Existing structure preserved.</strong> The toolbox repo doesn&#39;t need restructuring. It just becomes a sub-tree inside CPC at <code>tools/</code>.</li>
+<li><strong>Matches how people discover the project.</strong> &quot;Claude Pocket Console&quot; is the recognizable name. Toolbox is invisible infrastructure. The submodule pattern reflects this asymmetry honestly.</li>
+</ul>
+<h3>Negative</h3>
+<ul>
+<li><strong>Submodule UX is clunky.</strong> New contributors will forget <code>--recursive</code> on clone. They&#39;ll see an empty <code>tools/</code> directory and be confused. Mitigation: README has a &quot;first steps&quot; section that explicitly addresses this, and <code>pnpm install</code> could check for the submodule and warn if missing.</li>
+<li><strong>Submodule pin updates require explicit commits.</strong> When toolbox ships a fix, CPC needs a commit to pull it in. Not bad in practice (usually you want this control) but adds a step.</li>
+<li><strong>Two-repo cognitive load.</strong> Anyone contributing to both CPC and toolbox has to manage two repos, two commit histories, two PR workflows. Mitigation: most contributors will only touch one or the other.</li>
+<li><strong>The &quot;host&quot; pieces still don&#39;t have a home.</strong> This ADR doesn&#39;t address where systemd/Caddy/cloudflared configs live. They&#39;re VPS-specific and don&#39;t belong in CPC. A separate decision is needed for the do-box replacement.</li>
+<li><strong>Skills location split.</strong> Skills currently live in <code>~/.claude/skills/</code> AND <code>~/claudes-world/.claude/skills/</code>. Deciding which is canonical and migrating to <code>claude-pocket-console/skills/</code> is a follow-up task.</li>
+</ul>
+<h3>Neutral</h3>
+<ul>
+<li>The user&#39;s <code>~/code/claude-pocket-console</code> working directory and the GitHub repo will share a name (already the case). Nothing changes locally.</li>
+<li>The <code>~/.world/</code> directory concept (per-project overrides) is orthogonal to this decision and can still be added.</li>
+</ul>
+<hr>
+<h2>Alternatives Considered</h2>
+<h3>Alternative 1: Single monorepo containing everything</h3>
+<p>Move CPC, toolbox, skills, host config, and apps into one new repo at <code>github.com/{user}/claudes-world</code>. Each becomes a top-level package.</p>
+<p><strong>Why rejected:</strong></p>
+<ul>
+<li>Breaks the existing CPC and toolbox repo histories (or requires complex git filter-repo work)</li>
+<li>Forces all packages to share a release cadence</li>
+<li>The &quot;host&quot; pieces (systemd, Caddy) don&#39;t belong in a portable repo at all — they&#39;re VPS-specific</li>
+<li>A new monorepo means a new repo name that nobody recognizes</li>
+<li>Doesn&#39;t match how the user actually thinks about the system (CPC is the recognizable thing, everything else supports it)</li>
+</ul>
+<p>The original portability design doc proposed this approach. After discussing it with the user, the CPC-as-hub model is a better fit for the actual goal (a shareable artifact for hackathon friends) without the migration cost.</p>
+<h3>Alternative 2: Git subtree instead of submodule</h3>
+<p>Same end state but using <code>git subtree</code> to merge toolbox&#39;s history into CPC at <code>tools/</code>. Consumers don&#39;t need <code>--recursive</code>.</p>
+<p><strong>Why rejected:</strong></p>
+<ul>
+<li>Subtrees are harder to update bidirectionally. Pushing changes from CPC&#39;s <code>tools/</code> back to the toolbox repo requires <code>git subtree split</code> and manual reconciliation.</li>
+<li>Subtree is less commonly understood than submodule. Most developers know <code>git submodule update --init --recursive</code>; fewer know <code>git subtree pull</code>.</li>
+<li>The &quot;no init step&quot; benefit is real but small — a one-line README note solves it.</li>
+<li>Could revisit if submodule pain proves worse than subtree pain in practice.</li>
+</ul>
+<h3>Alternative 3: pnpm workspace / npm package</h3>
+<p>Publish toolbox to npm and have CPC depend on it via <code>package.json</code>. Cleanest from a JS perspective.</p>
+<p><strong>Why rejected:</strong></p>
+<ul>
+<li>Toolbox contains a mix of bash, Python, and TypeScript scripts. npm only handles the Node.js subset cleanly.</li>
+<li>Bash and Python scripts would need wrapper packages or be excluded, fragmenting the toolbox.</li>
+<li>Versioning becomes a release-management chore — every toolbox change needs a version bump and publish.</li>
+<li>Adds an external dependency (npm registry) for what should be a self-contained system.</li>
+</ul>
+<h3>Alternative 4: Symlinks (do nothing)</h3>
+<p>The current state. <code>~/bin</code> symlinks into <code>~/code/toolbox</code>, CPC is a separate repo. No packaging.</p>
+<p><strong>Why rejected:</strong></p>
+<ul>
+<li>This is exactly what the user is trying to fix. The current state has no shareable artifact and the relationships are invisible to anyone outside the user&#39;s head.</li>
+<li>Doesn&#39;t survive a host migration. Symlinks are filesystem-specific.</li>
+<li>Doesn&#39;t help hackathon friends at all.</li>
+</ul>
+<hr>
+<h2>Follow-Up Actions</h2>
+<p>These are not part of this ADR but are needed to execute the decision:</p>
+<ol>
+<li><strong>Decide on the host config story</strong> — separate ADR. The do-box replacement (manifest-driven, deterministic rebuild) is its own design problem.</li>
+<li><strong>Decide on skills canonical location</strong> — consolidate <code>~/.claude/skills/</code> and <code>~/claudes-world/.claude/skills/</code>, then migrate to <code>claude-pocket-console/skills/</code>.</li>
+<li><strong>Adopt progressive disclosure docs in CPC</strong> — restructure CPC&#39;s existing AGENTS.md and docs into the OmniPass <code>reference/guides/conventions/</code> pattern. (See ADR 0002, forthcoming.)</li>
+<li><strong>Submodule integration plan</strong> — actually create the submodule, write the README &quot;first steps&quot; section, set up CI to verify the submodule resolves cleanly.</li>
+<li><strong>Port convention v2</strong> — separate ADR. The current 38xxx/48xxx/58xxx convention is too coarse and caused hackathon collisions.</li>
+<li><strong>Plugin packaging (longer term)</strong> — if CPC grows into a Claude Code plugin, the plugin manifest can reference the same submodule structure. No conflict.</li>
+</ol>
+<hr>
+<h2>References</h2>
+<ul>
+<li><code>~/claudes-world/knowledge/claudes-world-portability-design.md</code> — the broader design doc this ADR resolves</li>
+<li><code>~/code/omnipass-world/AGENTS.md</code> — the progressive disclosure pattern used as the docs model</li>
+<li><code>~/code/claude-pocket-console/</code> — the CPC repo to be restructured</li>
+<li><code>~/code/toolbox/</code> — the toolbox repo to become a submodule</li>
+<li><a href="https://git-scm.com/book/en/v2/Git-Tools-Submodules">Git submodule docs</a></li>
+</ul>
+"
+`;
+
+exports[`MarkdownViewer (marked baseline) > renders 11-real-doc-overnight-summary.md consistently 1`] = `
+"<h1>Overnight Final Report — April 6-7, 2026</h1>
+<p><strong>Session start:</strong> ~7:30pm ET April 6<br><strong>Session end:</strong> ~9:30pm ET April 6 (this report)<br><strong>Format:</strong> Single document for morning review</p>
+<hr>
+<h2>TL;DR</h2>
+<p><strong>8 PRs open and ready for your review.</strong> None merged. Foundational tools shipped (Scrum button, send-md fix). Three big-picture synthesis docs are ready for morning decisions (reading list, portability, theme). One known issue: the dev tunnel is currently 502 because of agent worktree coordination — fixes itself when you merge PR #21.</p>
+<hr>
+<h2>What&#39;s ready for you to merge (in order)</h2>
+<h3>Toolbox</h3>
+<ol>
+<li><p><strong>toolbox PR #1</strong> — <code>tune: reduce heading pauses, speed up body voice</code></p>
+<ul>
+<li>6 line edits, body voice 0.95 → 1.05, heading pauses cut ~30%</li>
+<li>Verdict: LGTM SHIP IT</li>
+<li>Branch: <code>tune/md-speak-pacing</code> → <code>main</code></li>
+</ul>
+</li>
+<li><p><strong>toolbox PR #2</strong> — <code>feat(hooks): Scrum button + share-doc backtick fix</code></p>
+<ul>
+<li>Scrum button on launcher keyboard + handler</li>
+<li>share-doc dual-mode (file path or inline content) — fixes the backtick truncation bug</li>
+<li>Both actively in use this session</li>
+<li>Branch: <code>feat/scrum-button-and-share-doc-fix</code> → <code>main</code></li>
+</ul>
+</li>
+</ol>
+<h3>CPC (in recommended merge order)</h3>
+<ol>
+<li><p><strong>PR #21</strong> — <code>fix: allow cpc.claude.do host in Vite dev server</code></p>
+<ul>
+<li><strong>MERGE FIRST</strong> — unblocks the dev tunnel which is currently 502</li>
+<li>Adds <code>host: &quot;127.0.0.1&quot;</code> and <code>allowedHosts: [&quot;cpc.claude.do&quot;]</code> to vite.config.ts</li>
+<li>Verdict: APPROVE WITH NITS (Gemini suggested also updating proxy + HMR config — see follow-up items)</li>
+</ul>
+</li>
+<li><p><strong>PR #19</strong> — <code>feat(links): Companion + T3 app icon links</code></p>
+<ul>
+<li>Trivial (+12/-0), no risk</li>
+<li>Verdict: SHIP IT</li>
+</ul>
+</li>
+<li><p><strong>PR #18</strong> — <code>feat: download button in file viewer</code></p>
+<ul>
+<li>New <code>/api/files/download</code> endpoint + FiDownload button in FileViewer</li>
+<li>Verdict: APPROVE WITH NITS</li>
+<li><strong>Should-fix items Gemini caught (you decide):</strong><ul>
+<li>Use <code>buf.length</code> instead of <code>st.size</code> for Content-Length (TOCTOU)</li>
+<li>Sanitize 500 error messages (don&#39;t leak internal paths)</li>
+<li>Consider streaming instead of <code>readFile</code> for large files (memory pressure)</li>
+</ul>
+</li>
+<li><strong>Pre-existing security issue Gemini flagged:</strong> <code>isPathAllowed</code> uses startsWith — vulnerable to prefix-based path traversal. Affects ALL existing routes (<code>/list</code>, <code>/read</code>, <code>/search</code>, <code>/upload</code>) AND this new <code>/download</code>. Should be its own hardening PR.</li>
+</ul>
+</li>
+<li><p><strong>PR #20</strong> — <code>fix: code block horizontal scroll in markdown viewer</code></p>
+<ul>
+<li>Two commits: original fix + follow-up addressing Gemini&#39;s &quot;right padding lost on scroll&quot; finding</li>
+<li>Now includes <code>width: max-content; min-width: 100%</code> on <code>pre code</code></li>
+<li>Verdict: APPROVE</li>
+</ul>
+</li>
+<li><p><strong>PR #22</strong> — <code>feat: render Mermaid diagrams in markdown viewer</code></p>
+<ul>
+<li>Lazy-loaded mermaid (main bundle stays at 595KB, mermaid in own 652KB chunk)</li>
+<li>Two commits: initial component + follow-up wiring (vite.config.ts manualChunks, MarkdownViewer integration, mermaid dependency)</li>
+<li>Verdict: pending agent re-review (running)</li>
+</ul>
+</li>
+<li><p><strong>PR #23</strong> — <code>feat: file viewer sort control with persistence</code></p>
+<ul>
+<li>Inline sort control row in FileViewer header</li>
+<li>localStorage persistence + SortMode type promotion + sort logic hardening</li>
+<li>Verdict: pending agent re-review (running)</li>
+</ul>
+</li>
+</ol>
+<hr>
+<h2>Big-picture decisions waiting for your input</h2>
+<p>These are the three synthesis docs from the devil&#39;s advocate sessions. Each has my recommended answers — if you agree with my recs, just say &quot;go&quot; and I&#39;ll execute. If you disagree, tell me which.</p>
+<h3>Reading list feature</h3>
+<ul>
+<li><strong>Doc:</strong> <code>tmp/20260406-reading-list-synthesis.md</code></li>
+<li><strong>3 reviewers:</strong> Gemini (RETHINK), Codex (NEEDS WORK), Sonnet (NEEDS WORK)</li>
+<li><strong>6 decisions to make:</strong><ol>
+<li>Hard delete instead of soft delete (my rec: yes)</li>
+<li>Reject <code>default</code> user for reading list endpoints (my rec: yes — security)</li>
+<li>Save button in ActionBar instead of FileViewer header (my rec: yes — consistency)</li>
+<li><code>is_saved</code> piggyback on file read endpoint instead of separate /check (my rec: yes)</li>
+<li>Drop the speculative <code>note</code> column (my rec: yes)</li>
+<li>Defer migration system to a separate ADR (my rec: yes)</li>
+</ol>
+</li>
+</ul>
+<h3>Claude&#39;s World portability / .world directory</h3>
+<ul>
+<li><strong>Doc:</strong> <code>tmp/20260406-portability-synthesis.md</code></li>
+<li><strong>2 reviewers:</strong> Gemini (RETHINK), Codex (NEEDS WORK)</li>
+<li><strong>Key takeaway:</strong> ADR 0001 (CPC + toolbox submodule) already addresses most critiques. The original maximalist monorepo doc has one factual contradiction to fix (don&#39;t version live state in git). 5 follow-up ADRs identified.</li>
+<li><strong>My rec:</strong> Keep ADR 0001 as Proposed and continue. Update the original design doc to remove the monorepo-version-memory contradiction.</li>
+</ul>
+<h3>Light/dark mode</h3>
+<ul>
+<li><strong>Doc:</strong> <code>tmp/20260406-theme-synthesis.md</code></li>
+<li><strong>1 reviewer:</strong> Gemini (RETHINK)</li>
+<li><strong>Critical issue:</strong> No accessibility/contrast analysis for the proposed light palette</li>
+<li><strong>My rec:</strong> Defer entirely until you have time for a proper week-long migration. The current plan is correct but not a sleep-time job.</li>
+</ul>
+<hr>
+<h2>Documents shipped to your Telegram tonight</h2>
+<table>
+<thead>
+<tr>
+<th>Doc</th>
+<th>Type</th>
+</tr>
+</thead>
+<tbody><tr>
+<td>ADR 0001 — CPC + toolbox submodule packaging</td>
+<td>Decision</td>
+</tr>
+<tr>
+<td>ADR 0003 — Port allocation v2 / port-for</td>
+<td>Decision</td>
+</tr>
+<tr>
+<td>Reading list 3-way DA synthesis</td>
+<td>Synthesis</td>
+</tr>
+<tr>
+<td>Portability 2-way DA synthesis</td>
+<td>Synthesis</td>
+</tr>
+<tr>
+<td>Theme DA review</td>
+<td>Synthesis</td>
+</tr>
+<tr>
+<td>PR reviews summary (5 PRs)</td>
+<td>Status</td>
+</tr>
+<tr>
+<td>Overnight status hour 1</td>
+<td>Status</td>
+</tr>
+<tr>
+<td>.world skeleton README</td>
+<td>Proposal</td>
+</tr>
+<tr>
+<td>.world skeleton AGENTS.md</td>
+<td>Proposal</td>
+</tr>
+<tr>
+<td>USDX white paper (downloadable)</td>
+<td>Re-shared</td>
+</tr>
+</tbody></table>
+<p>All are saved in <code>~/claudes-world/tmp/</code> or <code>~/claudes-world/knowledge/</code> and can be re-shared via the deep-link system.</p>
+<hr>
+<h2>Outside-the-box ideas (ranked by ROI × feasibility)</h2>
+<h3>For Claude&#39;s World infrastructure</h3>
+<ol>
+<li><p><strong>Morning brief cron job</strong> — runs at 7am ET, sends a markdown doc with overnight git changes, open PRs needing review, weather, calendar (when OAuth wired), memory-based reminders.</p>
+<ul>
+<li>ROI: HIGH — zero ongoing effort, captures all the context you&#39;d assemble manually</li>
+<li>Feasibility: HIGH — ~1-2 hours of work, all pieces exist</li>
+<li>Recommended next step</li>
+</ul>
+</li>
+<li><p><strong>A &quot;next thing to work on&quot; agent</strong> — ask via Telegram, scans TODO.md / open PRs / recent memories / calendar, suggests highest-leverage next action.</p>
+<ul>
+<li>ROI: HIGH — decision fatigue is real</li>
+<li>Feasibility: HIGH — small focused skill, 1 hour to write</li>
+</ul>
+</li>
+<li><p><strong>Sleep-aware agent operation</strong> — agents stop dispatching new high-risk work after midnight ET unless explicitly told. Morning checks are still allowed but mutations are paused.</p>
+<ul>
+<li>ROI: MEDIUM-HIGH — prevents bad-overnight surprises</li>
+<li>Feasibility: HIGH — trivial guard at agent dispatch</li>
+</ul>
+</li>
+<li><p><strong>Auto-archive <code>quarantine/</code> after 30 days</strong> — cron moves untrusted research artifacts older than 30 days into compressed archive.</p>
+<ul>
+<li>ROI: LOW-MEDIUM — keeps active workspace clean</li>
+<li>Feasibility: HIGH — 10-line bash + systemd timer</li>
+</ul>
+</li>
+<li><p><strong>Meta-skill: lints other skills</strong> — periodic agent that scans <code>~/.claude/skills/</code> against the skill-authoring-tips guide. Flags any missing descriptions, vague triggers, etc.</p>
+<ul>
+<li>ROI: MEDIUM — prevents skill bloat over time</li>
+<li>Feasibility: MEDIUM — couple hours</li>
+</ul>
+</li>
+</ol>
+<h3>For your IRL life (Liam)</h3>
+<ol>
+<li><p><strong>Conference contact card MVP</strong> (the one we discussed) — single highest-leverage thing you could ship next month for IRL networking. Day or two of work, transforms every conference for you.</p>
+<ul>
+<li>ROI: VERY HIGH — every conference becomes 10x more connectable</li>
+<li>Feasibility: HIGH — small feature, you already have a Telegram presence</li>
+</ul>
+</li>
+<li><p><strong>Daily &quot;what did I learn today&quot; capture</strong> — voice memo at end of day → transcription → LLM summary → committed to a personal knowledge base in <code>claudes-world/journal/</code>. Compound interest on insights over months.</p>
+<ul>
+<li>ROI: HIGH if you actually use it</li>
+<li>Feasibility: HIGH — 2 hours, voice-hook already exists</li>
+</ul>
+</li>
+<li><p><strong>Dev-tunnel uptime monitor</strong> — ntfy hook pings cpc.claude.do/dev every 5 min, notifies if down for 2+ checks. Stops weird issues from going unnoticed.</p>
+<ul>
+<li>ROI: MEDIUM — prevents debugging-at-3am</li>
+<li>Feasibility: HIGH — 30 minutes</li>
+</ul>
+</li>
+<li><p><strong>Auto-tagging for shared docs</strong> — share-doc generates audio with rich ID3 metadata via topic detection. Turns your shared docs into a personal podcast feed.</p>
+<ul>
+<li>ROI: MEDIUM-HIGH (turns reading queue into listening queue)</li>
+<li>Feasibility: HIGH — tag-mp3 binary already supports it</li>
+</ul>
+</li>
+<li><p><strong>Conference-mode auto-Calendly</strong> — when conference mode is on (the contact card idea), automatically open 15-min &quot;coffee chat&quot; availability.</p>
+<ul>
+<li>ROI: HIGH during events, low otherwise</li>
+<li>Feasibility: MEDIUM — needs Calendly API</li>
+</ul>
+</li>
+</ol>
+<hr>
+<h2>Issues / things to know</h2>
+<h3>1. Dev tunnel 502 (worktree coordination)</h3>
+<p><strong>Current state:</strong> <code>https://cpc.claude.do/dev/</code> returns 502.</p>
+<p><strong>Why:</strong> Multiple agents share <code>~/code/claude-pocket-console</code> worktree and check out different feature branches. The cpc-dev.service serves whatever branch is currently checked out. Currently it&#39;s on <code>feat/file-viewer-sort-control</code> (PR #23&#39;s branch), which doesn&#39;t have the IPv4 fix. Vite is bound to <code>[::1]:58830</code> (IPv6 only), Caddy can&#39;t proxy to <code>127.0.0.1:58830</code>.</p>
+<p><strong>Fix:</strong> Merge PR #21 to dev. Once IPv4 fix lands on dev, every feature branch will inherit it.</p>
+<p><strong>Lesson learned:</strong> This proves the worktree-aware port allocation idea (ADR 0003) — agents need their own worktrees. I&#39;ll avoid launching parallel CPC agents going forward until we have proper isolation.</p>
+<h3>2. Toolbox dirty state (pre-existing)</h3>
+<p>The toolbox repo has uncommitted changes from before I arrived:</p>
+<ul>
+<li><code>hooks/agent-stop-hook</code> (small)</li>
+<li><code>hooks/voice-hook</code> (small)</li>
+<li><code>md-speak/md-speak</code> (the &quot;end of document&quot; segment block, ~8 lines)</li>
+<li><code>tg-sanitize/</code> (untracked directory)</li>
+</ul>
+<p>I left these alone. They look intentional but are not on any branch. Worth checking what they are and either committing or stashing properly.</p>
+<h3>3. send-md fix branch is currently checked out</h3>
+<p>Toolbox is currently on <code>feat/scrum-button-and-share-doc-fix</code> (toolbox PR #2&#39;s branch). This is intentional — that branch has the share-doc Mode 2 fix, which is what&#39;s powering the send-md skill right now via the symlink at <code>~/bin/share-doc</code>. If you switch toolbox branches, send-md will revert to the old broken behavior until you switch back or merge.</p>
+<p><strong>Recommended:</strong> Merge toolbox PR #2 first thing in the morning to permanently land the share-doc fix.</p>
+<h3>4. Pre-existing isPathAllowed security issue</h3>
+<p>Gemini flagged this on PR #18 but it&#39;s NOT introduced by PR #18 — it&#39;s pre-existing in <code>apps/server/src/routes/files.ts</code>. The <code>isPathAllowed</code> function uses <code>startsWith</code> which is vulnerable to prefix-based path traversal. Affects <code>/list</code>, <code>/read</code>, <code>/search</code>, <code>/upload</code>, AND the new <code>/download</code>.</p>
+<p><strong>My recommendation:</strong> File a separate hardening PR. Should not block PR #18 from merging (the vulnerability exists with or without #18).</p>
+<hr>
+<h2>Stats</h2>
+<ul>
+<li><strong>PRs opened:</strong> 8 (5 CPC + 3 toolbox*) — *toolbox #1 was opened before this session</li>
+<li><strong>PRs reviewed by me:</strong> 7 (all CPC + toolbox #1)</li>
+<li><strong>Background agents launched:</strong> ~13</li>
+<li><strong>Devil&#39;s advocate reviews run:</strong> 6 (3 reading list, 2 portability, 1 theme)</li>
+<li><strong>ADRs written:</strong> 2 (0001, 0003)</li>
+<li><strong>Synthesis docs:</strong> 3 (reading list, portability, theme)</li>
+<li><strong>Skeleton stub files:</strong> 9 in <code>tmp/world-skeleton/</code></li>
+<li><strong>TODO items closed:</strong> 6 (the in-flight CPC features)</li>
+<li><strong>TODO items added:</strong> 8 (follow-up items + new ADRs to write)</li>
+</ul>
+<hr>
+<h2>What I plan for hour 2 (and beyond)</h2>
+<p>The next hour cron will fire at :13 (in ~25 minutes from this writing). When it does, I&#39;ll:</p>
+<ol>
+<li>Check on the in-flight PR reviews for #22 and #23</li>
+<li>Address any should-fix items those reviews surface (in same-branch commits)</li>
+<li>Update TODO.md if anything new shipped</li>
+<li>Send a brief status check-in (probably shorter than this final report)</li>
+</ol>
+<p>Beyond that, my plan is to slow down and be conservative. The big shipping push is done. I&#39;ll:</p>
+<ul>
+<li>Watch for incoming Telegram messages from you</li>
+<li>Continue polishing what&#39;s open</li>
+<li>NOT start any new big features without your approval</li>
+<li>NOT touch any prod systems</li>
+<li>NOT merge anything</li>
+</ul>
+<p>If you wake up and want to fast-merge everything, the recommended order is at the top of this doc. If you want me to wait, just say so.</p>
+<hr>
+<h2>Sleep well, Liam.</h2>
+<p>The system is in good shape. Lots of value sitting in the PR queue waiting for your review. The big architectural conversations have concrete recommendations. The synthesis docs are ready to discuss when you&#39;re ready.</p>
+<p>— Claude</p>
+"
+`;
+
+exports[`MarkdownViewer (marked baseline) > renders 12-real-doc-collapsible-headings-plan.md consistently 1`] = `
+"<p>I have everything I need. Note that mermaid is not rendered interactively — there&#39;s no existing post-process pattern in MarkdownViewer using <code>createRoot</code>. Now I&#39;ll deliver the plan.</p>
+<hr>
+<h1>Collapsible Heading Sections — Implementation Plan</h1>
+<p><strong>Date:</strong> 2026-04-07<br><strong>Feature:</strong> Disclosure triangles next to headings in the CPC markdown viewer that collapse/expand sections, with optional sync to a future TOC drawer.<br><strong>Note on file output:</strong> This planning task is read-only — I cannot save the plan to <code>tmp/</code>. The full plan is below; copy/paste it wherever you&#39;d like it to live.</p>
+<hr>
+<h2>TL;DR</h2>
+<p>Add disclosure triangles next to every heading in <code>MarkdownViewer.tsx</code> so Liam can collapse long sections of a markdown doc. Use <strong>Option A (DOM post-processing via ref)</strong> because the existing component already uses <code>dangerouslySetInnerHTML</code>, the change is local, and we don&#39;t add a runtime dependency. Store fold state as a <code>Set&lt;string&gt;</code> of heading slugs in React state, <strong>lifted to <code>App.tsx</code></strong> so a future <code>TocSheet</code> component can share it. Implement collapse via <code>display: none</code> on the DOM nodes between a heading and the next same-or-higher-level heading. <strong>Effort: Medium — ~1 day standalone, ~1.5–2 days if shipped together with the TOC drawer (because heading-id assignment, the lift to <code>App.tsx</code>, and shared-state plumbing become a single coordinated PR).</strong></p>
+<p>The biggest discovery during scouting: <strong>marked v17 with <code>gfm: true</code> does NOT generate <code>id</code> attributes on headings.</strong> The v17 default <code>heading</code> renderer is literally <code>\`&lt;h\${depth}&gt;\${parseInline(tokens)}&lt;/h\${depth}&gt;\`</code> (verified in <code>apps/web/node_modules/marked/lib/marked.esm.js</code> line 57). The existing TOC proposal (<code>tmp/20260407-markdown-toc-and-audio-proposals.md</code> line 71) is wrong about this. Both this feature and the TOC feature need to assign IDs themselves, which is one more reason to ship them together: they share that prep work.</p>
+<hr>
+<h2>Part 1 — Current state scouting</h2>
+<h3>How markdown is rendered</h3>
+<ul>
+<li><code>apps/web/src/components/MarkdownViewer.tsx</code> calls <code>marked.parse(content)</code> inside a <code>useMemo</code>, then injects the result via <code>dangerouslySetInnerHTML</code> into a <code>&lt;div className=&quot;md-content&quot;&gt;</code>. The component is otherwise styles + HTML; it has <strong>no ref, no post-processing, no event handlers</strong>.</li>
+<li><code>marked</code> is configured with <code>{ gfm: true, breaks: true }</code> only.</li>
+<li>The whole <code>.md-content</code> div lives inside an outer scrollable wrapper with <code>overflowY: auto</code>. Scroll position is managed by the browser.</li>
+<li>There&#39;s no virtual scrolling. Even very long docs render the entire DOM tree once.</li>
+</ul>
+<h3>Heading IDs — the load-bearing finding</h3>
+<p>Marked v17&#39;s default renderer produces headings without <code>id</code> attributes. From <code>marked.esm.js</code>:</p>
+<pre><code>heading({tokens:e,depth:t}){return\`&lt;h\${t}&gt;\${this.parser.parseInline(e)}&lt;/h\${t}&gt;\\n\`}
+</code></pre>
+<p>So today the rendered HTML for <code>## Hello world</code> is just <code>&lt;h2&gt;Hello world&lt;/h2&gt;</code> — no anchor, no slug. Anything that needs to address headings (this feature, the TOC drawer, hash navigation) has to assign IDs after parse. That can be done either by:</p>
+<ul>
+<li>A custom marked renderer override (<code>marked.use({ renderer: { heading(...) {...} } })</code>) that emits <code>&lt;h\${depth} id=&quot;\${slug}&quot;&gt;...&lt;/h\${depth}&gt;</code>, with a small slugger that handles duplicates by appending <code>-2</code>, <code>-3</code>, etc.</li>
+<li>Or post-processing the DOM after the inner HTML is set, walking <code>h1...h6</code>, generating slugs from <code>textContent</code>, and assigning <code>el.id</code>.</li>
+</ul>
+<p>The renderer-override approach is cleaner and the slug becomes part of the cached HTML (so it survives <code>useMemo</code> and stays stable across re-renders). I recommend that.</p>
+<h3>How long docs are typically rendered</h3>
+<ul>
+<li>No virtualization.</li>
+<li><code>padding: &quot;16px 16px&quot;</code> outer wrapper, with the styled <code>&lt;div class=&quot;md-content&quot;&gt;</code> inside.</li>
+<li>All children of <code>.md-content</code> are immediate siblings produced by marked: <code>h1</code>, <code>h2</code>, <code>p</code>, <code>ul</code>, <code>pre</code>, <code>blockquote</code>, <code>hr</code>, <code>table</code>, etc. <strong>This is critical for the collapse algorithm: section membership is determined by walking siblings, not descendants.</strong></li>
+</ul>
+<h3>Parent component</h3>
+<ul>
+<li><code>FileViewer.tsx</code> hosts <code>&lt;MarkdownViewer content={fileContent} fileName={fileName} /&gt;</code> only when <code>fileContent !== null &amp;&amp; fileName.endsWith(&quot;.md&quot;)</code>.</li>
+<li><code>FileViewer</code> already maintains a <code>collapsedRanges: Set&lt;number&gt;</code> state for <strong>code-file line folding</strong> (line 76). It&#39;s per-file (reset in <code>loadDirectory</code>/<code>loadFile</code>/<code>handleBack</code>). That&#39;s the right pattern to mirror for markdown fold state, but it should live higher (in <code>App.tsx</code>) so the TOC drawer can share it.</li>
+</ul>
+<h3>Top-level state</h3>
+<ul>
+<li><code>App.tsx</code> already tracks <code>viewingFile: { path, name } | null</code> (line 47), which is the file currently open in the markdown viewer. That&#39;s the natural key for fold state.</li>
+</ul>
+<h3>BottomSheet primitive</h3>
+<ul>
+<li><code>ActionBar.tsx</code> defines a local <code>BottomSheet</code> component (line 57) and uses it for ~10 modals already. The proposed TOC drawer would reuse it. Worth knowing because if/when the TOC ships, sync logic flows through whatever state lives in <code>App.tsx</code>.</li>
+</ul>
+<hr>
+<h2>Part 2 — Design decisions</h2>
+<h3>1. Triangle placement</h3>
+<ul>
+<li><strong>Render position:</strong> outside the heading text, in the left margin. Use a span/button with <code>position: absolute; left: -20px; top: 50%; transform: translateY(-50%)</code> against an <code>h1...h6 { position: relative; padding-left: 0 }</code>. The viewer&#39;s outer wrapper has <code>padding: &quot;16px 16px&quot;</code> so there&#39;s 16px of room before content clips — enough for a 14px triangle plus a couple of px breathing room. If clipping is a concern on very narrow Telegram screens, bump the wrapper padding-left to 24px and place the triangle at <code>left: -22px</code>.</li>
+<li><strong>Visual:</strong> triangle character (▼ expanded, ▶ collapsed) at ~14px, color <code>#565f89</code> (matches the dim-text color used elsewhere). On hover/focus, brighten to <code>#7aa2f7</code>.</li>
+<li><strong>Hit area:</strong> 32x32 transparent button centered on the triangle, so it&#39;s tappable on mobile. Use <code>padding</code> rather than width/height to keep visual size separate from hit area.</li>
+<li><strong>Default state:</strong> all expanded. Liam can always tap to collapse, but a doc that opens half-folded is confusing.</li>
+</ul>
+<h3>2. What counts as a &quot;section&quot;</h3>
+<ul>
+<li>An <code>h\${N}</code> heading&#39;s section is <strong>every sibling DOM node after it, up to (but not including) the next sibling that is <code>h1</code>...<code>h\${N}</code></strong>. So an h2&#39;s section ends at the next h1 or h2; any h3/h4/h5/h6 in between belongs to the section.</li>
+<li>Nested triangles: a collapsed h2 hides everything after it including the h3 elements <em>and their triangles</em>. When the h2 expands again, those h3 triangles reappear in whatever state they were in before (if they were also collapsed, they stay collapsed). This falls out for free if the algorithm is just &quot;set <code>display: none</code> on the contained DOM nodes&quot; — re-expanding the parent restores the children&#39;s prior <code>display</code> state only if we&#39;re careful (see Part 4).</li>
+<li><strong>First H1 special case:</strong> the top-level doc title (the first <code>h1</code> in the document) should NOT have a triangle. Collapsing it would hide everything. Detect by &quot;first H1 in the rendered output&quot; and skip it.</li>
+<li><strong>Empty section special case:</strong> if the next sibling is already a heading of same/higher level (i.e. the section has zero non-heading content), don&#39;t show a triangle for that heading. It would be a no-op.</li>
+</ul>
+<h3>3. State storage</h3>
+<ul>
+<li><code>foldedSections: Set&lt;string&gt;</code> keyed by heading <strong>slug</strong> (not by index — slugs are stable across re-renders, indices aren&#39;t if the user scrolls and React re-mounts).</li>
+<li><strong>Per-file:</strong> Reset whenever <code>viewingFile.path</code> changes. The simplest way is to key the state by file path: <code>foldedByFile: Map&lt;string, Set&lt;string&gt;&gt;</code>. Or even simpler: just drop the Set whenever <code>viewingFile.path</code> changes.</li>
+<li><strong>Persistence:</strong> none. Ephemeral React state. Recreating fold state on revisit is cheap (one tap), and persisting it to localStorage for every doc Liam ever opens would create stale entries forever.</li>
+<li><strong>Where it lives:</strong> Lift to <code>App.tsx</code>. Pass down to <code>MarkdownViewer</code> (which renders triangles + applies display: none) and to the future <code>TocSheet</code> (which renders the same fold indicators). See Part 5.</li>
+</ul>
+<h3>4. Animation</h3>
+<ul>
+<li><strong>v1: instant.</strong> No animation. <code>display: none</code> toggles immediately. Animating height is hard with <code>dangerouslySetInnerHTML</code> because we&#39;d need to wrap each section in a div with a known height for max-height transitions, which means more DOM mutation.</li>
+<li><strong>v2 (defer):</strong> if Liam asks for it, switch to wrapping each section in a <code>&lt;div data-section-of=&quot;\${slug}&quot;&gt;</code> during post-processing and animate via <code>max-height</code> + <code>overflow: hidden</code>. Skip for v1.</li>
+</ul>
+<h3>5. Interaction with the TOC drawer</h3>
+<ul>
+<li><strong>Tap heading in TOC → expand on the way:</strong> When the user navigates to a heading, walk up its ancestor chain (h3 inside an h2 inside an h1) and remove all of those slugs from <code>foldedSections</code> before scrolling. This guarantees the target is visible.</li>
+<li><strong>TOC reflects collapse state:</strong> TOC entries whose ancestor heading is collapsed should be visually de-emphasized (grey) and clicking them still works (it expands the ancestor first, then scrolls).</li>
+<li><strong>TOC has its own triangles:</strong> Each parent heading row in the TOC gets its own little triangle that toggles the same <code>foldedSections</code> set. Tapping the triangle in the TOC collapses the section in the doc as well — they&#39;re literally the same state. This is the &quot;sync&quot; requirement and it falls out naturally if state is lifted.</li>
+</ul>
+<h3>6. Click target semantics</h3>
+<ul>
+<li>Click triangle → toggle that section&#39;s slug in <code>foldedSections</code>.</li>
+<li>Click heading text → no-op. Don&#39;t toggle, don&#39;t scroll. Preserves text selection and the natural reading experience.</li>
+<li>(Optional, defer) Long-press heading → collapse all siblings of same level — &quot;collapse all H2s&quot; gesture. Not in v1.</li>
+</ul>
+<hr>
+<h2>Part 3 — Technical approach</h2>
+<p>I evaluated all four options. <strong>Recommend: Option A — post-process the rendered HTML via a ref</strong>, with the small refinement that heading IDs are assigned by a custom marked renderer (not in the post-processing pass), so the slugs are stable and computed once.</p>
+<h3>Option A — Post-process the rendered HTML (RECOMMENDED)</h3>
+<p><strong>How:</strong> Keep <code>marked.parse</code> + <code>dangerouslySetInnerHTML</code> exactly as today. Add a <code>useRef&lt;HTMLDivElement&gt;</code> to the <code>.md-content</code> div. Add a <code>useLayoutEffect</code> that runs after each render: walk the children, find headings, compute each heading&#39;s section range (the sibling slice ending at the next same-or-higher heading), and:</p>
+<ol>
+<li>Inject a triangle element (a <code>&lt;button&gt;</code> created with <code>document.createElement</code> is fine; no need for <code>createRoot</code> unless we want React to manage events) just before the heading text. Use event delegation on the wrapper div so we only attach one click listener total.</li>
+<li>For each heading whose slug is in <code>foldedSections</code>, set <code>style.display = &quot;none&quot;</code> on every node in its section range.</li>
+<li>For headings NOT in the set, ensure those nodes have their original display restored.</li>
+</ol>
+<p><strong>Pros:</strong></p>
+<ul>
+<li>Zero new dependencies.</li>
+<li>Doesn&#39;t change the rendering pipeline.</li>
+<li>Easy to read and debug — the algorithm is one function.</li>
+<li>Handles the &quot;first H1 = title, no triangle&quot; case trivially.</li>
+<li>Heading-id assignment can be a one-line marked renderer override, decoupled from the fold logic.</li>
+</ul>
+<p><strong>Cons:</strong></p>
+<ul>
+<li>Imperative DOM manipulation feels un-React-ish. Mitigate by keeping it in a single <code>useLayoutEffect</code> keyed on <code>[html, foldedSections]</code>.</li>
+<li>If marked re-runs and produces a new innerHTML, we re-walk the whole tree. That&#39;s fine — the doc isn&#39;t changing during fold/unfold, only fold state is.</li>
+<li>We have to remember the original <code>display</code> of each node we hide. Easiest: don&#39;t try to remember. Use a separate CSS class <code>.cpc-folded { display: none !important }</code> and toggle the class instead of inline styles. Then re-expanding just removes the class and the original display reappears. <strong>This is the cleanest fix.</strong></li>
+</ul>
+<h3>Option B — marked custom renderer + event delegation</h3>
+<p><strong>How:</strong> <code>marked.use({ renderer: { heading({ tokens, depth }) { return </code>&lt;h\${depth} id=&quot;\${slug}&quot;&gt;<button class="cpc-toggle" data-slug="\${slug}">▼</button>\${parseInline(tokens)}&lt;/h\${depth}&gt;<code> } } })</code>. Then in MarkdownViewer, attach one click handler to the wrapper that listens for clicks on <code>.cpc-toggle</code>.</p>
+<p><strong>Pros:</strong></p>
+<ul>
+<li>The triangle is part of the HTML — no second DOM walk to inject buttons.</li>
+<li>Handlers are attached via delegation so we still only have one listener.</li>
+</ul>
+<p><strong>Cons:</strong></p>
+<ul>
+<li>The triangle is now inside the heading&#39;s text flow, not in the margin. To get it back to the margin we&#39;d need absolute positioning anyway, which means CSS that depends on the heading being <code>position: relative</code>. Works, but uglier.</li>
+<li>Still need a separate post-processing pass to apply <code>display: none</code> based on fold state, because the renderer runs once at parse time and the fold state changes after.</li>
+<li>So Option B = Option A&#39;s complexity + a renderer override. No win.</li>
+</ul>
+<h3>Option C — Switch to react-markdown</h3>
+<p><strong>How:</strong> Replace marked with react-markdown. Headings become real React components that can have interactive children natively.</p>
+<p><strong>Pros:</strong></p>
+<ul>
+<li>Idiomatic React. No imperative DOM work.</li>
+<li><code>react-markdown</code> has a known plugin ecosystem (<code>rehype-slug</code> for IDs, <code>rehype-autolink-headings</code>, etc.).</li>
+</ul>
+<p><strong>Cons:</strong></p>
+<ul>
+<li>New dependency (react-markdown + rehype + remark — meaningfully larger bundle, ~50–80KB minified depending on plugins).</li>
+<li>Existing styles, table handling, code blocks, GFM behavior all need to be re-verified.</li>
+<li>It&#39;s a much bigger PR with more risk for a feature that doesn&#39;t strictly require it.</li>
+<li>Doesn&#39;t solve the &quot;section is the slice of siblings between headings&quot; problem any better — react-markdown still produces a flat list of sibling elements at the top level. You still need to compute section ranges and conditionally hide them.</li>
+</ul>
+<h3>Option D — Render token tree manually</h3>
+<p><strong>How:</strong> Use marked&#39;s tokenizer to get the AST, then render to React elements ourselves.</p>
+<p><strong>Pros:</strong></p>
+<ul>
+<li>Maximum control. Sections could be wrapped in real React components with proper conditional rendering.</li>
+</ul>
+<p><strong>Cons:</strong></p>
+<ul>
+<li>Massive scope: re-implementing tables, code blocks, lists, blockquotes, GFM. The current viewer leans on marked&#39;s HTML output for all of this.</li>
+<li>This is not a one-day task. It&#39;s a rewrite.</li>
+</ul>
+<h3>Recommendation</h3>
+<p>Go with <strong>Option A</strong>. The fold logic stays in one <code>useLayoutEffect</code> in <code>MarkdownViewer.tsx</code>. Heading IDs come from a marked renderer override (the only thing we change about the parse pipeline). Triangles are injected as plain DOM buttons; clicks are handled via event delegation. State lives in <code>App.tsx</code>. No new dependencies.</p>
+<hr>
+<h2>Part 4 — The collapse mechanic</h2>
+<h3>Algorithm (sibling-slice walk)</h3>
+<p>After <code>marked.parse</code> runs and the HTML is in the DOM, in a <code>useLayoutEffect</code>:</p>
+<ol>
+<li>Get a flat list of <code>.md-content</code>&#39;s direct children: <code>const nodes = Array.from(rootRef.current.children)</code>. (They&#39;re already in document order — that&#39;s how marked emits them.)</li>
+<li>Find headings: <code>const headings = nodes.filter(n =&gt; /^H[1-6]$/.test(n.tagName))</code>. Each heading remembers its index in <code>nodes</code> and its level (1–6, parsed from tagName).</li>
+<li>Skip the first H1 (the doc title) — no triangle.</li>
+<li>For every other heading at index <code>i</code> with level <code>L</code>:<ul>
+<li>Find the next heading at index <code>j &gt; i</code> with level <code>&lt;= L</code>. If none, <code>j = nodes.length</code>.</li>
+<li>The section is <code>nodes.slice(i + 1, j)</code>.</li>
+<li>If the section is empty (i.e. <code>j === i + 1</code> and the next thing is another heading), this heading is non-foldable: skip injecting a triangle for it.</li>
+<li>Otherwise, inject a triangle button just before the heading&#39;s first child (or as a positioned-absolute child of the heading), with <code>data-slug=&quot;\${heading.id}&quot;</code>.</li>
+</ul>
+</li>
+<li>After triangles are injected, apply fold state: for each heading whose slug is in <code>foldedSections</code>, add <code>cpc-folded</code> class to every node in its section. This is what hides them. For each heading NOT in the set, remove the class from its section.</li>
+<li>Update each triangle&#39;s text content: ▼ if expanded, ▶ if collapsed. Optional: append <code>(N)</code> where N is the count of non-empty paragraphs/elements in the section, so collapsed sections show &quot;▶ (12)&quot;.</li>
+</ol>
+<h3>Hide mechanism: a single CSS class</h3>
+<p>Add to the existing <code>&lt;style&gt;</code> block:</p>
+<pre><code class="language-css">.cpc-folded { display: none !important; }
+.md-content h1, .md-content h2, .md-content h3,
+.md-content h4, .md-content h5, .md-content h6 {
+  position: relative;
+}
+.md-content .cpc-toggle {
+  position: absolute;
+  left: -22px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 32px; height: 32px;
+  display: flex; align-items: center; justify-content: center;
+  background: transparent; border: none; color: #565f89;
+  cursor: pointer; font-size: 14px;
+  /* hit area extends past the visible 14px triangle */
+}
+.md-content .cpc-toggle:hover { color: #7aa2f7; }
+</code></pre>
+<p>Then <code>node.classList.add(&quot;cpc-folded&quot;)</code> / <code>removeAttribute(&quot;class&quot;)</code> is the entire collapse mechanic. We never touch <code>style.display</code>, so we never have to remember original display values. This cleanly handles <code>display: block</code>, <code>display: flex</code> (none of the markdown elements use it but defensively), <code>display: table</code> (for <code>&lt;table&gt;</code>), etc.</p>
+<h3>Nested fold preservation</h3>
+<p>Because hidden ancestors don&#39;t run their own fold logic (we just <code>display: none</code> everything inside them), a collapsed h3 stays in <code>foldedSections</code> even when its parent h2 is also collapsed. When the h2 expands, the h3 remains collapsed because its slug is still in the set and the next post-process pass re-applies it. Exactly what we want.</p>
+<h3>Click handling</h3>
+<p>Single delegated listener on <code>rootRef.current</code>:</p>
+<pre><code class="language-ts">const onClick = (e: MouseEvent) =&gt; {
+  const btn = (e.target as HTMLElement).closest(&#39;.cpc-toggle&#39;);
+  if (!btn) return;
+  const slug = btn.getAttribute(&#39;data-slug&#39;);
+  if (!slug) return;
+  e.preventDefault();
+  e.stopPropagation();
+  toggleFold(slug);
+};
+</code></pre>
+<p>Where <code>toggleFold</code> is a callback passed from <code>App.tsx</code> (or <code>FileViewer</code>) that updates <code>foldedSections</code>.</p>
+<hr>
+<h2>Part 5 — TOC sync strategy</h2>
+<h3>State management — recommendation</h3>
+<p><strong>Lift to <code>App.tsx</code>.</strong> Add:</p>
+<pre><code class="language-ts">const [foldedSections, setFoldedSections] = useState&lt;Set&lt;string&gt;&gt;(new Set());
+
+// Reset whenever the viewing file changes
+useEffect(() =&gt; { setFoldedSections(new Set()); }, [viewingFile?.path]);
+
+const toggleFold = useCallback((slug: string) =&gt; {
+  setFoldedSections(prev =&gt; {
+    const next = new Set(prev);
+    if (next.has(slug)) next.delete(slug); else next.add(slug);
+    return next;
+  });
+}, []);
+
+const expandAncestors = useCallback((slugs: string[]) =&gt; {
+  setFoldedSections(prev =&gt; {
+    const next = new Set(prev);
+    for (const s of slugs) next.delete(s);
+    return next;
+  });
+}, []);
+</code></pre>
+<p>Pass <code>foldedSections</code>, <code>toggleFold</code>, <code>expandAncestors</code> down to <code>FileViewer</code> → <code>MarkdownViewer</code>, and (when it ships) to <code>TocSheet</code>.</p>
+<h3>Why not React Context?</h3>
+<ul>
+<li>Only 2 components need this state. Prop drilling through <code>FileViewer → MarkdownViewer</code> is one hop.</li>
+<li>Context invalidates everything in its tree on every change, causing the whole <code>FileViewer</code> to re-render on every fold toggle. Not catastrophic but unnecessary.</li>
+<li>Explicit props are easier to reason about and easier to remove later if Liam decides he hates this feature.</li>
+</ul>
+<h3>Why not a custom event bus?</h3>
+<ul>
+<li>The &quot;shared state&quot; requirement is the whole point. Event buses recreate state by accident and lose it on re-mount. React state is the right tool.</li>
+</ul>
+<h3>Sync flow when TOC ships</h3>
+<ol>
+<li><code>TocSheet</code> parses the headings from the rendered markdown (or receives them as a prop from <code>MarkdownViewer</code>, which is cleaner — see &quot;shared headings list&quot; below).</li>
+<li>Each parent heading row in TocSheet has a triangle that calls <code>toggleFold(slug)</code>.</li>
+<li>Each leaf row that&#39;s an ancestor-of-folded shows greyed out.</li>
+<li>When a row is tapped, TocSheet computes the chain of ancestors (walks up the parsed-headings list to find every heading at a higher level whose section contains this slug), calls <code>expandAncestors(ancestors)</code>, and then triggers a smooth scroll to the slug&#39;s element. Both sides of the sync share the same <code>Set</code>, so the doc reflects the change automatically via <code>MarkdownViewer</code>&#39;s <code>useLayoutEffect</code>.</li>
+</ol>
+<h3>Shared headings list</h3>
+<p>To avoid parsing headings twice (once in <code>MarkdownViewer</code> for triangles, once in <code>TocSheet</code> for the list), have <code>MarkdownViewer</code> parse headings during its <code>useLayoutEffect</code>, store them in a state variable, and pass them up via an <code>onHeadingsChange?: (headings: Heading[]) =&gt; void</code> callback. <code>App.tsx</code> holds the headings array and passes it into <code>TocSheet</code>. This is the same pattern as <code>onViewChange</code> already used in <code>FileViewer.tsx</code> (line 154).</p>
+<hr>
+<h2>Part 6 — Edge cases</h2>
+<table>
+<thead>
+<tr>
+<th>Case</th>
+<th>Behavior</th>
+</tr>
+</thead>
+<tbody><tr>
+<td>Doc has zero headings</td>
+<td>No triangles render. Loop in post-process finds no headings; nothing happens.</td>
+</tr>
+<tr>
+<td>First H1 = doc title</td>
+<td>Skip injecting triangle for it. Detected as &quot;first heading in document order at level 1&quot;.</td>
+</tr>
+<tr>
+<td>Heading with no content after it (just another heading)</td>
+<td>Section range is empty. Don&#39;t inject triangle. The heading still gets an <code>id</code> (for TOC linking) but no fold control.</td>
+</tr>
+<tr>
+<td>Heading is the very last element</td>
+<td>Section is <code>nodes.slice(i+1, nodes.length)</code>, which may be empty (no triangle) or contain trailing content.</td>
+</tr>
+<tr>
+<td>Two headings with the same text</td>
+<td>Slugger appends <code>-2</code>, <code>-3</code>, etc. for uniqueness. Standard slug behavior.</td>
+</tr>
+<tr>
+<td>Markdown contains raw HTML headings (<code>&lt;h2&gt;...&lt;/h2&gt;</code> typed by user)</td>
+<td>Marked passes them through if <code>gfm</code> mode allows. They become real <code>&lt;h2&gt;</code> elements in the output and get triangles like any other heading.</td>
+</tr>
+<tr>
+<td>User collapses a section, then scrolls</td>
+<td>No issue. Browser preserves scroll position relative to the document, and when content above the viewport disappears, the scroll position adjusts naturally. (If this looks jumpy in practice, we can record <code>scrollTop</code> before the toggle and restore it after — but try without first.)</td>
+</tr>
+<tr>
+<td>User switches files</td>
+<td><code>useEffect([viewingFile.path])</code> resets <code>foldedSections</code> to empty. Fresh slate per file.</td>
+</tr>
+<tr>
+<td>User collapses an H2, then collapses its parent H1</td>
+<td>Both slugs are in the set. The H1&#39;s hide-pass hides the H2 and everything inside it (the H2&#39;s triangle is hidden along with the rest). When the user re-expands the H1, the H2 is still in the set so it stays collapsed and shows ▶.</td>
+</tr>
+<tr>
+<td>Hash navigation <code>#some-heading</code></td>
+<td>Browser scrolls to the element. If that element is inside a collapsed section, it won&#39;t be visible. Solution: on mount and on hash change, walk up from the target heading to find any folded ancestors and remove them. Same <code>expandAncestors</code> helper TocSheet uses.</td>
+</tr>
+<tr>
+<td>Triangle click also bubbles to heading</td>
+<td>The delegated handler calls <code>e.preventDefault()</code> and <code>e.stopPropagation()</code>. Heading text click does nothing anyway.</td>
+</tr>
+<tr>
+<td>Marked renderer override breaks something</td>
+<td>Run the existing markdown viewer manually with several test docs (long ADRs, the overnight reports, code-heavy files) to confirm output is unchanged except for the new <code>id</code> attributes.</td>
+</tr>
+</tbody></table>
+<hr>
+<h2>Part 7 — Scope and effort</h2>
+<h3>Standalone (no TOC)</h3>
+<p><strong>Medium — about 1 day (6–8 hours).</strong></p>
+<p>Breakdown:</p>
+<ul>
+<li>1h: marked renderer override + slugger utility</li>
+<li>2h: post-processing logic in <code>MarkdownViewer</code> (sibling walk, triangle injection, fold application)</li>
+<li>1h: lift fold state to <code>App.tsx</code>, prop-drill through <code>FileViewer</code></li>
+<li>1h: CSS, visual polish, mobile hit-area testing</li>
+<li>1h: edge cases (first H1, empty sections, hash navigation)</li>
+<li>1h: manual testing on real docs (overnight reports, ADRs, long synthesis docs)</li>
+</ul>
+<h3>With TOC sync (if TOC ships in the same PR or right after)</h3>
+<p><strong>Medium-large — about 1.5–2 days.</strong></p>
+<p>The TOC drawer itself is independently estimated at 4–6 hours in the existing proposal, but it shares a bunch of work with this feature:</p>
+<ul>
+<li>Heading-ID assignment (do it once in the marked renderer override — both features benefit)</li>
+<li>Heading parsing (do it once in <code>MarkdownViewer</code>, hand the list up via <code>onHeadingsChange</code>)</li>
+<li>Lifted fold state in <code>App.tsx</code> (one <code>useState</code>)</li>
+</ul>
+<p>Combined effort:</p>
+<ul>
+<li>6–8h: collapsible headings (above)</li>
+<li>4–6h: TOC drawer</li>
+<li>2–3h: shared-state plumbing (foldedSections + headings list flowing through both components, the expand-ancestors-on-tap logic, greyed-out leaf rendering)</li>
+<li>Total: ~12–17h, call it 1.5–2 days</li>
+</ul>
+<p>Strong recommendation: <strong>ship them together as one PR</strong> if both are wanted. The shared work (renderer override, heading parsing, lifted state) is half the value, and doing them in two separate PRs duplicates the prep and risks divergent slug schemes.</p>
+<hr>
+<h2>Open questions</h2>
+<ol>
+<li><strong>Triangle character or SVG?</strong> Character (▼/▶) is simplest and matches the existing emoji-heavy visual style of the file viewer (📁/📄). SVG would be sharper but adds icon-system overhead. Recommend character for v1.</li>
+<li><strong>Show item count when collapsed?</strong> &quot;▶ (12 items)&quot; is informative but adds clutter. Recommend: skip for v1, add if Liam asks.</li>
+<li><strong>Should the H1 doc title be stylable separately?</strong> The &quot;skip triangle on first H1&quot; rule is content-agnostic — it&#39;s positional. If Liam writes a doc that doesn&#39;t start with an H1, the first H2 still gets a triangle. Confirm this is fine.</li>
+<li><strong>Per-file persistence?</strong> The recommendation is no persistence. If Liam routinely re-opens the same long doc (an ADR he&#39;s reviewing for a week), a localStorage cache keyed by <code>file path → Set&lt;slug&gt;</code> would be a small addition. Defer until requested.</li>
+<li><strong>Markdown re-render churn:</strong> the <code>useMemo</code> keys on <code>[content]</code>, so toggling fold state doesn&#39;t re-parse markdown. Triangles persist, fold logic just toggles classes. Confirmed safe.</li>
+<li><strong>Does the existing TOC proposal&#39;s effort estimate need updating?</strong> Yes — the proposal claims marked already generates IDs (<code>tmp/20260407-markdown-toc-and-audio-proposals.md</code> line 71). It doesn&#39;t. Add ~30 minutes to the TOC estimate for the renderer override + slugger.</li>
+<li><strong>Telegram WebApp viewport quirks:</strong> the markdown viewer is inside a Telegram mini app. Triangles positioned absolutely with <code>left: -22px</code> need to not get clipped by the outer scrollable container&#39;s overflow rules. The current outer wrapper has <code>overflowX: &quot;auto&quot;</code> (line 25) — this is fine because the triangles are still inside <code>.md-content</code> which has <code>padding: 16px 16px</code> (line 23). The 16px of left padding is enough room. Verify on a narrow device.</li>
+<li><strong>Accessibility:</strong> the triangle button needs <code>aria-expanded={!folded}</code>, <code>aria-controls={sectionId}</code>, and a screen-reader label like <code>aria-label=&quot;Collapse section: {heading text}&quot;</code>. Add this in v1; it&#39;s cheap.</li>
+</ol>
+<hr>
+<h2>Phased implementation plan</h2>
+<h3>Phase 0 — Prep (do this first)</h3>
+<ol>
+<li>Add a slug helper in <code>MarkdownViewer.tsx</code> (or a new <code>lib/slug.ts</code> if you prefer): <code>function slugify(text: string, used: Set&lt;string&gt;): string</code> that lowercases, strips punctuation, replaces whitespace with <code>-</code>, and appends <code>-2</code>, <code>-3</code> for duplicates.</li>
+<li>Override marked&#39;s heading renderer:<pre><code class="language-ts">const slugCounts = new Map&lt;string, number&gt;();
+marked.use({
+  renderer: {
+    heading({ tokens, depth }) {
+      const text = this.parser.parseInline(tokens);
+      const plain = text.replace(/&lt;[^&gt;]*&gt;/g, &#39;&#39;);  // strip inline HTML for slug
+      const base = slugify(plain);
+      const n = (slugCounts.get(base) ?? 0) + 1;
+      slugCounts.set(base, n);
+      const slug = n === 1 ? base : \`\${base}-\${n}\`;
+      return \`&lt;h\${depth} id=&quot;\${slug}&quot;&gt;\${text}&lt;/h\${depth}&gt;\\n\`;
+    }
+  }
+});
+</code></pre>
+Important: reset <code>slugCounts</code> per <code>marked.parse</code> call. Cleanest way: build the override inside the <code>useMemo</code> so each parse call gets a fresh Map. Or use a <code>marked.use</code> extension hook. (The simplest pattern: declare a renderer object once at module scope but reset its <code>slugCounts</code> Map at the start of each <code>useMemo</code> body — slightly hacky. The extension hook is cleaner; if it&#39;s too fiddly, just call <code>marked.use</code> once per parse, which works because <code>marked.use</code> is idempotent for renderer overrides.)</li>
+</ol>
+<h3>Phase 1 — Visual triangles, no logic</h3>
+<ol>
+<li>Add <code>cpc-toggle</code> and <code>cpc-folded</code> CSS to <code>MarkdownViewer</code>&#39;s <code>&lt;style&gt;</code> block.</li>
+<li>Add a <code>useLayoutEffect</code> that walks <code>.md-content</code> children, finds headings, and injects a triangle button before each heading&#39;s content. Skip the first H1.</li>
+<li>Verify visually: triangles appear in the left margin of every heading except the doc title.</li>
+<li>No fold logic yet. Triangles are inert.</li>
+</ol>
+<h3>Phase 2 — Fold logic locally in MarkdownViewer</h3>
+<ol>
+<li>Add local <code>useState&lt;Set&lt;string&gt;&gt;</code> for fold state inside <code>MarkdownViewer</code> temporarily.</li>
+<li>Compute section ranges (sibling slice between headings) for each heading.</li>
+<li>Apply <code>cpc-folded</code> class to all nodes in the range when the heading&#39;s slug is in the set.</li>
+<li>Wire up the delegated click handler so triangles toggle.</li>
+<li>Test: collapse h2, collapse nested h3, expand parent h2, confirm h3 stays collapsed.</li>
+<li>Test edge cases: first H1, empty sections, last heading.</li>
+</ol>
+<h3>Phase 3 — Lift state to App.tsx</h3>
+<ol>
+<li>Move <code>foldedSections</code>, <code>toggleFold</code> from <code>MarkdownViewer</code> to <code>App.tsx</code>.</li>
+<li>Add <code>useEffect([viewingFile?.path])</code> reset.</li>
+<li>Pass through <code>FileViewer</code> as props, then to <code>MarkdownViewer</code>.</li>
+<li>Verify: switching files resets fold state. Switching tabs and back preserves it (unless file changed).</li>
+</ol>
+<h3>Phase 4 — Polish</h3>
+<ol>
+<li>Add <code>aria-expanded</code>, <code>aria-controls</code>, <code>aria-label</code> to triangle buttons.</li>
+<li>Test mobile hit area on a real device or browser devtools touch simulator.</li>
+<li>Test with the longest markdown docs you can find (overnight reports, ADRs).</li>
+<li>Verify hash navigation: <code>#some-heading-inside-folded-section</code> should auto-expand ancestors. Add <code>expandAncestors</code> walker if not done in Phase 3.</li>
+</ol>
+<h3>Phase 5 — TOC sync (only if TOC drawer is in scope)</h3>
+<ol>
+<li>Add <code>headings: Heading[]</code> state in <code>App.tsx</code>.</li>
+<li>Add <code>onHeadingsChange</code> callback in <code>MarkdownViewer</code>, fire it from the same <code>useLayoutEffect</code> that builds triangles.</li>
+<li>Implement <code>TocSheet</code> per the existing proposal, but pass it <code>foldedSections</code>, <code>toggleFold</code>, and <code>headings</code>.</li>
+<li>In TocSheet, render parent rows with triangles and leaf rows greyed out when an ancestor is folded.</li>
+<li>On row tap: compute ancestor slugs, call <code>expandAncestors</code>, scroll to slug.</li>
+<li>Test the round trip: collapse h2 in doc → its h3 children grey out in TOC. Tap an h3 in TOC → ancestor h2 expands in doc → scroll lands on h3.</li>
+</ol>
+<h3>Phase 6 — (Defer) Animation</h3>
+<p>Wrap each section in a data-attributed div during post-processing, animate via max-height + overflow. Only do this if Liam asks.</p>
+<hr>
+<h2>Critical Files for Implementation</h2>
+<ul>
+<li><code>/home/claude/code/claude-pocket-console/apps/web/src/components/MarkdownViewer.tsx</code> — primary changes: add ref, useLayoutEffect for triangle injection + fold application, marked renderer override for heading IDs, CSS for <code>.cpc-toggle</code> and <code>.cpc-folded</code>. Receives <code>foldedSections</code> and <code>toggleFold</code> as props.</li>
+<li><code>/home/claude/code/claude-pocket-console/apps/web/src/App.tsx</code> — add <code>foldedSections: Set&lt;string&gt;</code> state, <code>toggleFold</code> and <code>expandAncestors</code> callbacks, reset effect on <code>viewingFile.path</code> change. Pass props down through <code>FileViewer</code>.</li>
+<li><code>/home/claude/code/claude-pocket-console/apps/web/src/components/FileViewer.tsx</code> — add prop pass-through for fold state and callbacks; otherwise unchanged. (Already manages its own <code>collapsedRanges</code> for code-file folding — that stays separate; markdown fold is a different feature that lives at App level.)</li>
+<li><code>/home/claude/code/claude-pocket-console/apps/web/src/components/ActionBar.tsx</code> — only relevant if TOC drawer ships in the same pass. Reference for the existing <code>BottomSheet</code> component that the future <code>TocSheet</code> should reuse.</li>
+<li><code>/home/claude/claudes-world/tmp/20260407-markdown-toc-and-audio-proposals.md</code> — the related TOC proposal. Note that its claim about marked auto-generating IDs is incorrect; if both features ship, they share the heading-id assignment work described here.</li>
+</ul>
+"
+`;
+
+exports[`MarkdownViewer (marked baseline) > renders 13-mermaid.md consistently 1`] = `
+"<h1>Mermaid Test</h1>
+<p>This is a quick test of Mermaid rendering in CPC&#39;s MarkdownViewer.</p>
+<h2>Flowchart</h2>
+<pre><code class="language-mermaid">graph TD
+  A[Start] --&gt; B{Decision}
+  B --&gt;|Yes| C[Continue]
+  B --&gt;|No| D[Stop]
+</code></pre>
+<h2>Regular code block (should stay as code)</h2>
+<pre><code class="language-js">const hello = &quot;world&quot;;
+console.log(hello);
+</code></pre>
+<p>Done.</p>
+"
+`;
+
+exports[`MarkdownViewer (marked baseline) > renders 14-empty.md consistently 1`] = `
+"<p>Just a single line of text and nothing else.</p>
+"
+`;
+
+exports[`MarkdownViewer (marked baseline) > renders 15-pathological.md consistently 1`] = `
+"<h1>Pathological shapes</h1>
+<p>Raw HTML mixed in (marked passes through by default):</p>
+<div class="custom-box" style="padding: 8px;">
+  <p>Inline HTML paragraph with <strong>bold</strong> and a <a href="https://example.com">raw anchor</a>.</p>
+</div>
+
+<p>Single-newline-as-break (relies on <code>breaks: true</code>):<br>Line A<br>Line B<br>Line C</p>
+<p>Deeply nested list (5 levels):</p>
+<ul>
+<li>L1<ul>
+<li>L2<ul>
+<li>L3<ul>
+<li>L4<ul>
+<li>L5 leaf</li>
+</ul>
+</li>
+</ul>
+</li>
+</ul>
+</li>
+</ul>
+</li>
+</ul>
+<p>Unicode smorgasbord: café, naïve, façade, résumé, 日本語, 中文, العربية, עברית, emoji: hello duck, math: α + β = γ, ∑ x_i, ∫ f(x) dx.</p>
+<p>Inline HTML inside a paragraph: this is <span style="color: red;">red text</span> and <code>raw code</code> inside a normal paragraph.</p>
+<p>A horizontal rule:</p>
+<hr>
+<p>A heading immediately after the hr:</p>
+<h2>Heading right after hr</h2>
+<p>Backtick-heavy inline: <code>a\`b</code> and <code>\`\`nested\`\`</code> and <code>\`\`\`triple\`\`\`</code>.</p>
+<p>Escape sequences: *not italic*, \`not code\`, [not link](nope).</p>
+<p>Empty code block:</p>
+<pre><code>
+</code></pre>
+<p>Code block with no language:</p>
+<pre><code>plain text
+multiple lines
+  indented
+</code></pre>
+<p>A paragraph ending without a trailing newline and no more content after it.</p>
+"
+`;

--- a/apps/web/src/__tests__/markdown-snapshots.test.ts
+++ b/apps/web/src/__tests__/markdown-snapshots.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync, readdirSync } from "node:fs";
+import { resolve } from "node:path";
+import { marked } from "marked";
+
+// Mirror MarkdownViewer.tsx settings exactly so these snapshots represent
+// the current production rendering for the marked-based baseline. When the
+// react-markdown migration lands, the follow-up PR will add a parallel test
+// that renders the same fixtures through react-markdown and diffs the
+// output — the diff between these snapshots and that one is the actual
+// visible change the migration ships.
+marked.setOptions({ gfm: true, breaks: true });
+
+const FIXTURE_DIR = resolve(__dirname, "../__fixtures__/markdown");
+
+describe("MarkdownViewer (marked baseline)", () => {
+  const fixtures = readdirSync(FIXTURE_DIR)
+    .filter((f) => f.endsWith(".md"))
+    .sort();
+
+  for (const fixture of fixtures) {
+    it(`renders ${fixture} consistently`, () => {
+      const content = readFileSync(resolve(FIXTURE_DIR, fixture), "utf-8");
+      const html = marked.parse(content);
+      expect(html).toMatchSnapshot();
+    });
+  }
+});

--- a/apps/web/src/__tests__/markdown-snapshots.test.ts
+++ b/apps/web/src/__tests__/markdown-snapshots.test.ts
@@ -1,16 +1,18 @@
 import { describe, it, expect } from "vitest";
 import { readFileSync, readdirSync } from "node:fs";
-import { resolve } from "node:path";
-import { marked } from "marked";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { Marked } from "marked";
 
-// Mirror MarkdownViewer.tsx settings exactly so these snapshots represent
-// the current production rendering for the marked-based baseline. When the
-// react-markdown migration lands, the follow-up PR will add a parallel test
-// that renders the same fixtures through react-markdown and diffs the
-// output — the diff between these snapshots and that one is the actual
-// visible change the migration ships.
-marked.setOptions({ gfm: true, breaks: true });
+// Use the same marked parser options as MarkdownViewer.tsx, but snapshot only
+// the raw HTML emitted by marked.parse(). This is intentionally a parser-level
+// baseline and does not cover any MarkdownViewer post-processing that happens
+// after parsing (for example, React-rendered replacements such as mermaid).
+// When the react-markdown migration lands, a follow-up test can render the
+// same fixtures through the component and compare the resulting DOM output.
+const marked = new Marked({ gfm: true, breaks: true });
 
+const __dirname = dirname(fileURLToPath(import.meta.url));
 const FIXTURE_DIR = resolve(__dirname, "../__fixtures__/markdown");
 
 describe("MarkdownViewer (marked baseline)", () => {

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -12,6 +12,5 @@
     "resolveJsonModule": true,
     "esModuleInterop": true
   },
-  "include": ["src"],
-  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx", "src/__tests__", "src/__fixtures__"]
+  "include": ["src"]
 }

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -12,5 +12,6 @@
     "resolveJsonModule": true,
     "esModuleInterop": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx", "src/__tests__", "src/__fixtures__"]
 }

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: "jsdom",
+    include: ["src/**/*.test.{ts,tsx}"],
+  },
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "claude-pocket-console",
   "private": true,
+  "engines": {
+    "node": ">=20.18.1"
+  },
   "scripts": {
     "dev": "turbo dev",
     "build": "turbo build",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,6 +73,9 @@ importers:
         specifier: ^5.6.0
         version: 5.6.0(react@19.2.4)
     devDependencies:
+      '@types/node':
+        specifier: ^22.19.17
+        version: 22.19.17
       '@types/react':
         specifier: ^19
         version: 19.2.14

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,17 +82,37 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^4
         version: 4.7.0(vite@6.4.2(@types/node@22.19.17)(tsx@4.21.0))
+      '@vitest/ui':
+        specifier: ^4.1.3
+        version: 4.1.3(vitest@4.1.3)
+      jsdom:
+        specifier: ^29.0.2
+        version: 29.0.2
       typescript:
         specifier: ^5
         version: 5.9.3
       vite:
         specifier: ^6
         version: 6.4.2(@types/node@22.19.17)(tsx@4.21.0)
+      vitest:
+        specifier: ^4.1.3
+        version: 4.1.3(@types/node@22.19.17)(@vitest/ui@4.1.3)(jsdom@29.0.2)(vite@6.4.2(@types/node@22.19.17)(tsx@4.21.0))
 
 packages:
 
   '@antfu/install-pkg@1.1.0':
     resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
+
+  '@asamuzakjp/css-color@5.1.8':
+    resolution: {integrity: sha512-OISPR9c2uPo23rUdvfEQiLPjoMLOpEeLNnP5iGkxr6tDDxJd3NjD+6fxY0mdaMbIPUjFGL4HFOJqLvow5q4aqQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/dom-selector@7.0.8':
+    resolution: {integrity: sha512-erMO6FgtM02dC24NGm0xufMzWz5OF0wXKR7BpvGD973bq/GbmR8/DbxNZbj0YevQ5hlToJaWSVK/G9/NDgGEVw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/nwsapi@2.3.9':
+    resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -180,6 +200,10 @@ packages:
   '@braintree/sanitize-url@7.1.2':
     resolution: {integrity: sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==}
 
+  '@bramus/specificity@2.4.2':
+    resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
+    hasBin: true
+
   '@chevrotain/cst-dts-gen@12.0.0':
     resolution: {integrity: sha512-fSL4KXjTl7cDgf0B5Rip9Q05BOrYvkJV/RrBTE/bKDN096E4hN/ySpcBK5B24T76dlQ2i32Zc3PAE27jFnFrKg==}
 
@@ -194,6 +218,42 @@ packages:
 
   '@chevrotain/utils@12.0.0':
     resolution: {integrity: sha512-lB59uJoaGIfOOL9knQqQRfhl9g7x8/wqFkp13zTdkRu1huG9kg6IJs1O8hqj9rs6h7orGxHJUKb+mX3rPbWGhA==}
+
+  '@csstools/color-helpers@6.0.2':
+    resolution: {integrity: sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/css-calc@3.1.1':
+    resolution: {integrity: sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-color-parser@4.0.2':
+    resolution: {integrity: sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.2':
+    resolution: {integrity: sha512-5GkLzz4prTIpoyeUiIu3iV6CSG3Plo7xRVOFPKI7FVEJ3mZ0A8SwK0XU3Gl7xAkiQ+mDyam+NNp875/C5y+jSA==}
+    peerDependencies:
+      css-tree: ^3.2.1
+    peerDependenciesMeta:
+      css-tree:
+        optional: true
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
 
   '@esbuild/aix-ppc64@0.25.12':
     resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
@@ -507,6 +567,15 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@exodus/bytes@1.15.0':
+    resolution: {integrity: sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
+
   '@hono/node-server@1.19.13':
     resolution: {integrity: sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==}
     engines: {node: '>=18.14.1'}
@@ -549,6 +618,9 @@ packages:
     resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
     engines: {node: '>=18'}
     hasBin: true
+
+  '@polka/url@1.0.0-next.29':
+    resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
 
   '@rolldown/pluginutils@1.0.0-beta.27':
     resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
@@ -678,6 +750,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@turbo/darwin-64@2.9.4':
     resolution: {integrity: sha512-ZSlPqJ5Vqg/wgVw8P3AOVCIosnbBilOxLq7TMz3MN/9U46DUYfdG2jtfevNDufyxyrg98pcPs/GBgDRaaids6g==}
     cpu: [x64]
@@ -722,6 +797,9 @@ packages:
 
   '@types/better-sqlite3@7.6.13':
     resolution: {integrity: sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
   '@types/d3-array@3.2.2':
     resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
@@ -816,6 +894,9 @@ packages:
   '@types/d3@7.4.3':
     resolution: {integrity: sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==}
 
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
@@ -845,6 +926,40 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
+  '@vitest/expect@4.1.3':
+    resolution: {integrity: sha512-CW8Q9KMtXDGHj0vCsqui0M5KqRsu0zm0GNDW7Gd3U7nZ2RFpPKSCpeCXoT+/+5zr1TNlsoQRDEz+LzZUyq6gnQ==}
+
+  '@vitest/mocker@4.1.3':
+    resolution: {integrity: sha512-XN3TrycitDQSzGRnec/YWgoofkYRhouyVQj4YNsJ5r/STCUFqMrP4+oxEv3e7ZbLi4og5kIHrZwekDJgw6hcjw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.3':
+    resolution: {integrity: sha512-hYqqwuMbpkkBodpRh4k4cQSOELxXky1NfMmQvOfKvV8zQHz8x8Dla+2wzElkMkBvSAJX5TRGHJAQvK0TcOafwg==}
+
+  '@vitest/runner@4.1.3':
+    resolution: {integrity: sha512-VwgOz5MmT0KhlUj40h02LWDpUBVpflZ/b7xZFA25F29AJzIrE+SMuwzFf0b7t4EXdwRNX61C3B6auIXQTR3ttA==}
+
+  '@vitest/snapshot@4.1.3':
+    resolution: {integrity: sha512-9l+k/J9KG5wPJDX9BcFFzhhwNjwkRb8RsnYhaT1vPY7OufxmQFc9sZzScRCPTiETzl37mrIWVY9zxzmdVeJwDQ==}
+
+  '@vitest/spy@4.1.3':
+    resolution: {integrity: sha512-ujj5Uwxagg4XUIfAUyRQxAg631BP6e9joRiN99mr48Bg9fRs+5mdUElhOoZ6rP5mBr8Bs3lmrREnkrQWkrsTCw==}
+
+  '@vitest/ui@4.1.3':
+    resolution: {integrity: sha512-xBPy+43o1fgMLUDlufUXh7tlT/Es8uS5eiyBY2PyPfFYSGpApZskLw65DROoDz+rgYkPuAmb20Mv9Z9g1WQE7w==}
+    peerDependencies:
+      vitest: 4.1.3
+
+  '@vitest/utils@4.1.3':
+    resolution: {integrity: sha512-Pc/Oexse/khOWsGB+w3q4yzA4te7W4gpZZAvk+fr8qXfTURZUMj5i7kuxsNK5mP/dEB6ao3jfr0rs17fHhbHdw==}
+
   '@xterm/addon-fit@0.10.0':
     resolution: {integrity: sha512-UFYkDm4HUahf2lnEyHvio51TNGiLK66mqP2JoATy7hRZeXaGMRDr00JiSF7m63vR5WKATF605yEggJKsw0JpMQ==}
     peerDependencies:
@@ -863,6 +978,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
@@ -874,6 +993,9 @@ packages:
   better-sqlite3@12.8.0:
     resolution: {integrity: sha512-RxD2Vd96sQDjQr20kdP+F+dK/1OUNiVOl200vKBZY8u0vTwysfolF6Hq+3ZK2+h8My9YvZhHsF+RSGZW2VYrPQ==}
     engines: {node: 20.x || 22.x || 23.x || 24.x || 25.x}
+
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
   bindings@1.5.0:
     resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
@@ -891,6 +1013,10 @@ packages:
 
   caniuse-lite@1.0.30001786:
     resolution: {integrity: sha512-4oxTZEvqmLLrERwxO76yfKM7acZo310U+v4kqexI2TL1DkkUEMT8UijrxxcnVdxR3qkVf5awGRX+4Z6aPHVKrA==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chevrotain-allstar@0.4.1:
     resolution: {integrity: sha512-PvVJm3oGqrveUVW2Vt/eZGeiAIsJszYweUcYwcskg9e+IubNYKKD+rHHem7A6XVO22eDAL+inxNIGAzZ/VIWlA==}
@@ -923,6 +1049,10 @@ packages:
 
   cose-base@2.2.0:
     resolution: {integrity: sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==}
+
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
@@ -1083,6 +1213,10 @@ packages:
   dagre-d3-es@7.0.14:
     resolution: {integrity: sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==}
 
+  data-urls@7.0.0:
+    resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   dayjs@1.11.20:
     resolution: {integrity: sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==}
 
@@ -1094,6 +1228,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
   decompress-response@6.0.0:
     resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
@@ -1119,6 +1256,13 @@ packages:
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
+
+  es-module-lexer@2.0.0:
+    resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
+
   esbuild@0.25.12:
     resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
     engines: {node: '>=18'}
@@ -1133,9 +1277,16 @@ packages:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   expand-template@2.0.3:
     resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
     engines: {node: '>=6'}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -1146,8 +1297,14 @@ packages:
       picomatch:
         optional: true
 
+  fflate@0.8.2:
+    resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
+
   file-uri-to-path@1.0.0:
     resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
+
+  flatted@3.4.2:
+    resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
@@ -1179,6 +1336,10 @@ packages:
     resolution: {integrity: sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==}
     engines: {node: '>=16.9.0'}
 
+  html-encoding-sniffer@6.0.0:
+    resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
@@ -1199,8 +1360,20 @@ packages:
     resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
     engines: {node: '>=12'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  jsdom@29.0.2:
+    resolution: {integrity: sha512-9VnGEBosc/ZpwyOsJBCQ/3I5p7Q5ngOY14a9bf5btenAORmZfDse1ZEheMiWcJ3h81+Fv7HmJFdS0szo/waF2w==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24.0.0}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
@@ -1232,8 +1405,15 @@ packages:
   lodash-es@4.18.1:
     resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
 
+  lru-cache@11.3.2:
+    resolution: {integrity: sha512-wgWa6FWQ3QRRJbIjbsldRJZxdxYngT/dO0I5Ynmlnin8qy7tC6xYzbcJjtN4wHLXtkbVwHzk0C+OejVw1XM+DQ==}
+    engines: {node: 20 || >=22}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
   marked@16.4.2:
     resolution: {integrity: sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==}
@@ -1244,6 +1424,9 @@ packages:
     resolution: {integrity: sha512-gB0gkNafnonOw0obSTEGZTT86IuhILt2Wfx0mWH/1Au83kybTayroZ/V6nS25mN7u8ASy+5fMhgB3XPNrOZdmA==}
     engines: {node: '>= 20'}
     hasBin: true
+
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
   mermaid@11.14.0:
     resolution: {integrity: sha512-GSGloRsBs+JINmmhl0JDwjpuezCsHB4WGI4NASHxL3fHo3o/BRXTxhDLKnln8/Q0lRFRyDdEjmk1/d5Sn1Xz8g==}
@@ -1260,6 +1443,10 @@ packages:
 
   mlly@1.8.2:
     resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
+
+  mrmime@2.0.1:
+    resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
+    engines: {node: '>=10'}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -1284,11 +1471,17 @@ packages:
   node-releases@2.0.37:
     resolution: {integrity: sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==}
 
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
   package-manager-detector@1.6.0:
     resolution: {integrity: sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==}
+
+  parse5@8.0.0:
+    resolution: {integrity: sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==}
 
   path-data-parser@0.1.0:
     resolution: {integrity: sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==}
@@ -1335,6 +1528,10 @@ packages:
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
 
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
+
   rc@1.2.8:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
     hasBin: true
@@ -1361,6 +1558,10 @@ packages:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
     engines: {node: '>= 6'}
 
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
@@ -1384,6 +1585,10 @@ packages:
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
+
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
@@ -1396,15 +1601,28 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   simple-concat@1.0.1:
     resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
 
   simple-get@4.0.1:
     resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
 
+  sirv@3.0.2:
+    resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
+    engines: {node: '>=18'}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.0.0:
+    resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
 
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
@@ -1416,12 +1634,18 @@ packages:
   stylis@4.3.6:
     resolution: {integrity: sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==}
 
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
   tar-fs@2.1.4:
     resolution: {integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==}
 
   tar-stream@2.2.0:
     resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
     engines: {node: '>=6'}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
   tinyexec@1.1.1:
     resolution: {integrity: sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==}
@@ -1430,6 +1654,29 @@ packages:
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
+
+  tldts-core@7.0.28:
+    resolution: {integrity: sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==}
+
+  tldts@7.0.28:
+    resolution: {integrity: sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==}
+    hasBin: true
+
+  totalist@3.0.1:
+    resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
+    engines: {node: '>=6'}
+
+  tough-cookie@6.0.1:
+    resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
+    engines: {node: '>=16'}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
 
   ts-dedent@2.2.0:
     resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
@@ -1457,6 +1704,10 @@ packages:
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  undici@7.24.7:
+    resolution: {integrity: sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ==}
+    engines: {node: '>=20.18.1'}
 
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
@@ -1511,6 +1762,47 @@ packages:
       yaml:
         optional: true
 
+  vitest@4.1.3:
+    resolution: {integrity: sha512-DBc4Tx0MPNsqb9isoyOq00lHftVx/KIU44QOm2q59npZyLUkENn8TMFsuzuO+4U2FUa9rgbbPt3udrP25GcjXw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.3
+      '@vitest/browser-preview': 4.1.3
+      '@vitest/browser-webdriverio': 4.1.3
+      '@vitest/coverage-istanbul': 4.1.3
+      '@vitest/coverage-v8': 4.1.3
+      '@vitest/ui': 4.1.3
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   vscode-jsonrpc@8.2.0:
     resolution: {integrity: sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==}
     engines: {node: '>=14.0.0'}
@@ -1531,6 +1823,27 @@ packages:
   vscode-uri@3.1.0:
     resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
+
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
+    engines: {node: '>=20'}
+
+  whatwg-url@16.0.1:
+    resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
@@ -1546,6 +1859,13 @@ packages:
       utf-8-validate:
         optional: true
 
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
@@ -1555,6 +1875,22 @@ snapshots:
     dependencies:
       package-manager-detector: 1.6.0
       tinyexec: 1.1.1
+
+  '@asamuzakjp/css-color@5.1.8':
+    dependencies:
+      '@csstools/css-calc': 3.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.0.2(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@asamuzakjp/dom-selector@7.0.8':
+    dependencies:
+      '@asamuzakjp/nwsapi': 2.3.9
+      bidi-js: 1.0.3
+      css-tree: 3.2.1
+      is-potential-custom-element-name: 1.0.1
+
+  '@asamuzakjp/nwsapi@2.3.9': {}
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -1670,6 +2006,10 @@ snapshots:
 
   '@braintree/sanitize-url@7.1.2': {}
 
+  '@bramus/specificity@2.4.2':
+    dependencies:
+      css-tree: 3.2.1
+
   '@chevrotain/cst-dts-gen@12.0.0':
     dependencies:
       '@chevrotain/gast': 12.0.0
@@ -1684,6 +2024,30 @@ snapshots:
   '@chevrotain/types@12.0.0': {}
 
   '@chevrotain/utils@12.0.0': {}
+
+  '@csstools/color-helpers@6.0.2': {}
+
+  '@csstools/css-calc@3.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-color-parser@4.0.2(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/color-helpers': 6.0.2
+      '@csstools/css-calc': 3.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.2(css-tree@3.2.1)':
+    optionalDependencies:
+      css-tree: 3.2.1
+
+  '@csstools/css-tokenizer@4.0.0': {}
 
   '@esbuild/aix-ppc64@0.25.12':
     optional: true
@@ -1841,6 +2205,8 @@ snapshots:
   '@esbuild/win32-x64@0.27.7':
     optional: true
 
+  '@exodus/bytes@1.15.0': {}
+
   '@hono/node-server@1.19.13(hono@4.12.12)':
     dependencies:
       hono: 4.12.12
@@ -1888,6 +2254,8 @@ snapshots:
   '@playwright/test@1.59.1':
     dependencies:
       playwright: 1.59.1
+
+  '@polka/url@1.0.0-next.29': {}
 
   '@rolldown/pluginutils@1.0.0-beta.27': {}
 
@@ -1966,6 +2334,8 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.60.1':
     optional: true
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@turbo/darwin-64@2.9.4':
     optional: true
 
@@ -2008,6 +2378,11 @@ snapshots:
   '@types/better-sqlite3@7.6.13':
     dependencies:
       '@types/node': 22.19.17
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
 
   '@types/d3-array@3.2.2': {}
 
@@ -2126,6 +2501,8 @@ snapshots:
       '@types/d3-transition': 3.0.9
       '@types/d3-zoom': 3.0.8
 
+  '@types/deep-eql@4.0.2': {}
+
   '@types/estree@1.0.8': {}
 
   '@types/geojson@7946.0.16': {}
@@ -2162,6 +2539,58 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@vitest/expect@4.1.3':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.3
+      '@vitest/utils': 4.1.3
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.3(vite@6.4.2(@types/node@22.19.17)(tsx@4.21.0))':
+    dependencies:
+      '@vitest/spy': 4.1.3
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 6.4.2(@types/node@22.19.17)(tsx@4.21.0)
+
+  '@vitest/pretty-format@4.1.3':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.3':
+    dependencies:
+      '@vitest/utils': 4.1.3
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.3':
+    dependencies:
+      '@vitest/pretty-format': 4.1.3
+      '@vitest/utils': 4.1.3
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.3': {}
+
+  '@vitest/ui@4.1.3(vitest@4.1.3)':
+    dependencies:
+      '@vitest/utils': 4.1.3
+      fflate: 0.8.2
+      flatted: 3.4.2
+      pathe: 2.0.3
+      sirv: 3.0.2
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.1.0
+      vitest: 4.1.3(@types/node@22.19.17)(@vitest/ui@4.1.3)(jsdom@29.0.2)(vite@6.4.2(@types/node@22.19.17)(tsx@4.21.0))
+
+  '@vitest/utils@4.1.3':
+    dependencies:
+      '@vitest/pretty-format': 4.1.3
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
   '@xterm/addon-fit@0.10.0(@xterm/xterm@5.5.0)':
     dependencies:
       '@xterm/xterm': 5.5.0
@@ -2174,6 +2603,8 @@ snapshots:
 
   acorn@8.16.0: {}
 
+  assertion-error@2.0.1: {}
+
   base64-js@1.5.1: {}
 
   baseline-browser-mapping@2.10.16: {}
@@ -2182,6 +2613,10 @@ snapshots:
     dependencies:
       bindings: 1.5.0
       prebuild-install: 7.1.3
+
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
 
   bindings@1.5.0:
     dependencies:
@@ -2207,6 +2642,8 @@ snapshots:
       ieee754: 1.2.1
 
   caniuse-lite@1.0.30001786: {}
+
+  chai@6.2.2: {}
 
   chevrotain-allstar@0.4.1(chevrotain@12.0.0):
     dependencies:
@@ -2238,6 +2675,11 @@ snapshots:
   cose-base@2.2.0:
     dependencies:
       layout-base: 2.0.1
+
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
 
   csstype@3.2.3: {}
 
@@ -2425,11 +2867,20 @@ snapshots:
       d3: 7.9.0
       lodash-es: 4.18.1
 
+  data-urls@7.0.0:
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   dayjs@1.11.20: {}
 
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js@10.6.0: {}
 
   decompress-response@6.0.0:
     dependencies:
@@ -2452,6 +2903,10 @@ snapshots:
   end-of-stream@1.4.5:
     dependencies:
       once: 1.4.0
+
+  entities@6.0.1: {}
+
+  es-module-lexer@2.0.0: {}
 
   esbuild@0.25.12:
     optionalDependencies:
@@ -2513,13 +2968,23 @@ snapshots:
 
   escalade@3.2.0: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
   expand-template@2.0.3: {}
+
+  expect-type@1.3.0: {}
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
 
+  fflate@0.8.2: {}
+
   file-uri-to-path@1.0.0: {}
+
+  flatted@3.4.2: {}
 
   fs-constants@1.0.0: {}
 
@@ -2541,6 +3006,12 @@ snapshots:
 
   hono@4.12.12: {}
 
+  html-encoding-sniffer@6.0.0:
+    dependencies:
+      '@exodus/bytes': 1.15.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   iconv-lite@0.6.3:
     dependencies:
       safer-buffer: 2.1.2
@@ -2555,7 +3026,35 @@ snapshots:
 
   internmap@2.0.3: {}
 
+  is-potential-custom-element-name@1.0.1: {}
+
   js-tokens@4.0.0: {}
+
+  jsdom@29.0.2:
+    dependencies:
+      '@asamuzakjp/css-color': 5.1.8
+      '@asamuzakjp/dom-selector': 7.0.8
+      '@bramus/specificity': 2.4.2
+      '@csstools/css-syntax-patches-for-csstree': 1.1.2(css-tree@3.2.1)
+      '@exodus/bytes': 1.15.0
+      css-tree: 3.2.1
+      data-urls: 7.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.3.2
+      parse5: 8.0.0
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.1
+      undici: 7.24.7
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   jsesc@3.1.0: {}
 
@@ -2582,13 +3081,21 @@ snapshots:
 
   lodash-es@4.18.1: {}
 
+  lru-cache@11.3.2: {}
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
 
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
   marked@16.4.2: {}
 
   marked@17.0.6: {}
+
+  mdn-data@2.27.1: {}
 
   mermaid@11.14.0:
     dependencies:
@@ -2627,6 +3134,8 @@ snapshots:
       pkg-types: 1.3.1
       ufo: 1.6.3
 
+  mrmime@2.0.1: {}
+
   ms@2.1.3: {}
 
   nanoid@3.3.11: {}
@@ -2641,11 +3150,17 @@ snapshots:
 
   node-releases@2.0.37: {}
 
+  obug@2.1.1: {}
+
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
 
   package-manager-detector@1.6.0: {}
+
+  parse5@8.0.0:
+    dependencies:
+      entities: 6.0.1
 
   path-data-parser@0.1.0: {}
 
@@ -2702,6 +3217,8 @@ snapshots:
       end-of-stream: 1.4.5
       once: 1.4.0
 
+  punycode@2.3.1: {}
+
   rc@1.2.8:
     dependencies:
       deep-extend: 0.6.0
@@ -2727,6 +3244,8 @@ snapshots:
       inherits: 2.0.4
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
+
+  require-from-string@2.0.2: {}
 
   resolve-pkg-maps@1.0.0: {}
 
@@ -2776,11 +3295,17 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
+
   scheduler@0.27.0: {}
 
   semver@6.3.1: {}
 
   semver@7.7.4: {}
+
+  siginfo@2.0.0: {}
 
   simple-concat@1.0.1: {}
 
@@ -2790,7 +3315,17 @@ snapshots:
       once: 1.4.0
       simple-concat: 1.0.1
 
+  sirv@3.0.2:
+    dependencies:
+      '@polka/url': 1.0.0-next.29
+      mrmime: 2.0.1
+      totalist: 3.0.1
+
   source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  std-env@4.0.0: {}
 
   string_decoder@1.3.0:
     dependencies:
@@ -2799,6 +3334,8 @@ snapshots:
   strip-json-comments@2.0.1: {}
 
   stylis@4.3.6: {}
+
+  symbol-tree@3.2.4: {}
 
   tar-fs@2.1.4:
     dependencies:
@@ -2815,12 +3352,32 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
+  tinybench@2.9.0: {}
+
   tinyexec@1.1.1: {}
 
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
+
+  tinyrainbow@3.1.0: {}
+
+  tldts-core@7.0.28: {}
+
+  tldts@7.0.28:
+    dependencies:
+      tldts-core: 7.0.28
+
+  totalist@3.0.1: {}
+
+  tough-cookie@6.0.1:
+    dependencies:
+      tldts: 7.0.28
+
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
 
   ts-dedent@2.2.0: {}
 
@@ -2850,6 +3407,8 @@ snapshots:
 
   undici-types@6.21.0: {}
 
+  undici@7.24.7: {}
+
   update-browserslist-db@1.2.3(browserslist@4.28.2):
     dependencies:
       browserslist: 4.28.2
@@ -2873,6 +3432,35 @@ snapshots:
       fsevents: 2.3.3
       tsx: 4.21.0
 
+  vitest@4.1.3(@types/node@22.19.17)(@vitest/ui@4.1.3)(jsdom@29.0.2)(vite@6.4.2(@types/node@22.19.17)(tsx@4.21.0)):
+    dependencies:
+      '@vitest/expect': 4.1.3
+      '@vitest/mocker': 4.1.3(vite@6.4.2(@types/node@22.19.17)(tsx@4.21.0))
+      '@vitest/pretty-format': 4.1.3
+      '@vitest/runner': 4.1.3
+      '@vitest/snapshot': 4.1.3
+      '@vitest/spy': 4.1.3
+      '@vitest/utils': 4.1.3
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.0.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.1
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.1.0
+      vite: 6.4.2(@types/node@22.19.17)(tsx@4.21.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.19.17
+      '@vitest/ui': 4.1.3(vitest@4.1.3)
+      jsdom: 29.0.2
+    transitivePeerDependencies:
+      - msw
+
   vscode-jsonrpc@8.2.0: {}
 
   vscode-languageserver-protocol@3.17.5:
@@ -2890,8 +3478,33 @@ snapshots:
 
   vscode-uri@3.1.0: {}
 
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
+  webidl-conversions@8.0.1: {}
+
+  whatwg-mimetype@5.0.0: {}
+
+  whatwg-url@16.0.1:
+    dependencies:
+      '@exodus/bytes': 1.15.0
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
   wrappy@1.0.2: {}
 
   ws@8.20.0: {}
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   yallist@3.1.1: {}


### PR DESCRIPTION
Reopened after closing PR #34 to retrigger fresh Gemini + Copilot review on the combined code.

## What's in this PR
- `c587d2d` — original snapshot fixture corpus + Vitest config
- `a7723d3` — fixup that installed `@types/node` properly instead of excluding tests from `tsc`
- `4220e5b` — fix from PR #35 addressing all 3 review items: ESM `__dirname` via `import.meta.url`, `new Marked()` instance for test isolation, comment reword

## Review history
- **PR #34** — original. Copilot caught the `__dirname` ESM bug + comment mismatch; Gemini suggested the local Marked instance. All addressed in PR #35.
- **PR #35** — fix PR. Both reviewers came back with **zero inline comments**. Merged into `prep/markdown-snapshot-fixtures`.

## Test plan
- [x] `pnpm --filter @cpc/web run test` — 15 baseline snapshots pass with zero drift
- [ ] After this PR clears review, merge to `dev`

This is the second-round PR per the project's feature → fix → close → reopen → re-review cycle.