### PR TITLE
fix(web): correct Tokyo Night palette to match actual inline-style usage (round 2)

### DIFF
--- a/apps/web/src/components/ErrorBoundary.tsx
+++ b/apps/web/src/components/ErrorBoundary.tsx
@@ -183,7 +183,7 @@ function ErrorFallback({ error, onRetry, onReload }: ErrorFallbackProps) {
           width: "100%",
           maxWidth: 480,
           background: "#16161e",
-          border: "1px solid #292e42",
+          border: "1px solid #2a2b3d",
           borderRadius: 8,
           padding: 12,
         }}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -13,7 +13,12 @@
   --color-muted: #565f89;
   --color-border: #2a2b3d;
   --color-border-alt: #414868;
-  --color-fg-subtle: #3b3d57;
+
+  /* Multi-purpose neutral: used as text, border, background, and stroke
+     across ActionBar, VoiceRecorder, WaveformVisualizer, and App version label.
+     Named --color-subtle (not --color-fg-subtle) so text-subtle, border-subtle,
+     bg-subtle all derive from one token. */
+  --color-subtle: #3b3d57;
 
   --color-accent-blue: #7aa2f7;
   --color-accent-purple: #bb9af7;

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -11,8 +11,9 @@
   --color-fg: #c0caf5;
   --color-fg-muted: #a9b1d6;
   --color-muted: #565f89;
-  --color-border: #292e42;
+  --color-border: #2a2b3d;
   --color-border-alt: #414868;
+  --color-fg-subtle: #3b3d57;
 
   --color-accent-blue: #7aa2f7;
   --color-accent-purple: #bb9af7;


### PR DESCRIPTION
Reopened to get fresh reviews on round-2 commit `8b5b1d41`.

## What's in this PR
- `3e864679` — round 1: corrected `--color-border` to `#2a2b3d`, added `--color-fg-subtle: #3b3d57`
- `8b5b1d41` — round 2: renamed `--color-fg-subtle` → `--color-subtle` (since `#3b3d57` is used for text + border + bg + stroke across 13 sites in 4 components, not just fg), and normalized `ErrorBoundary.tsx` from `#292e42` to `#2a2b3d`

Variable ordering nit (Gemini, medium) deferred to a follow-up cleanup PR.