### PR TITLE
fix(server): harden isPathAllowed against prefix bypass and symlink escape (round 3)

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -7,6 +7,8 @@
     "dev": "tsx watch src/index.ts",
     "build": "tsc",
     "start": "node dist/index.js",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "clean": "rm -rf dist"
   },
   "dependencies": {
@@ -20,6 +22,7 @@
     "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^22",
     "tsx": "^4",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^4.1.3"
   }
 }

--- a/apps/server/src/lib/path-allowed.ts
+++ b/apps/server/src/lib/path-allowed.ts
@@ -23,6 +23,27 @@ import { resolve, sep } from "node:path";
  * using sync realpath here keeps the call pattern simple without changing the
  * route signatures.
  */
+
+// Memoize realpath(root) results. Allowed roots are static config, so resolving
+// them on every request is needless sync I/O on the hot path. We cache only on
+// success — throws propagate uncached so a temporarily missing root retries on
+// the next call.
+const realRootCache = new Map<string, string>();
+
+function getRealRoot(root: string): string {
+  const key = resolve(root);
+  const cached = realRootCache.get(key);
+  if (cached !== undefined) return cached;
+  const real = realpathSync(key);
+  realRootCache.set(key, real);
+  return real;
+}
+
+/** @internal Test-only hook to reset the memoization cache between cases. */
+export function __resetRealRootCacheForTests(): void {
+  realRootCache.clear();
+}
+
 export function isPathAllowed(absPath: string, allowedRoots: string[]): boolean {
   let realCandidate: string;
   try {
@@ -35,12 +56,17 @@ export function isPathAllowed(absPath: string, allowedRoots: string[]): boolean 
   for (const root of allowedRoots) {
     let realRoot: string;
     try {
-      realRoot = realpathSync(resolve(root));
+      realRoot = getRealRoot(root);
     } catch {
       // Allowed root is missing on disk — skip, don't let it match anything.
       continue;
     }
-    if (realCandidate === realRoot || realCandidate.startsWith(realRoot + sep)) {
+    // When realRoot is the filesystem root (e.g. `/` on Unix, `C:\` on
+    // Windows), `realRoot + sep` yields `//` or `C:\\`, which no valid
+    // child path starts with. Only append a separator if the root doesn't
+    // already end with one.
+    const rootWithSep = realRoot.endsWith(sep) ? realRoot : realRoot + sep;
+    if (realCandidate === realRoot || realCandidate.startsWith(rootWithSep)) {
       return true;
     }
   }

--- a/apps/server/src/lib/path-allowed.ts
+++ b/apps/server/src/lib/path-allowed.ts
@@ -1,0 +1,48 @@
+import { realpathSync } from "node:fs";
+import { resolve, sep } from "node:path";
+
+/**
+ * Check whether an absolute path is contained within any of the allowed root
+ * directories, enforcing a true path-segment boundary and resolving symlinks.
+ *
+ * Hardened against two classes of bypass:
+ *
+ *   1. Sibling-prefix bypass: `/home/claude/code-evil/x` must NOT match the
+ *      root `/home/claude/code`. A naive `startsWith(root)` check would let it
+ *      through. We require an exact match OR a `root + path.sep` prefix so the
+ *      boundary lands on a real path separator.
+ *
+ *   2. Symlink escape: a symlink that lives inside an allowed root but points
+ *      outside it would otherwise defeat the check. We call `fs.realpathSync`
+ *      on both the candidate and the root so the comparison happens on the
+ *      real on-disk location. Non-existent paths cause `realpathSync` to
+ *      throw, which we treat as a rejection.
+ *
+ * The function is intentionally synchronous: each callsite already does an
+ * `await stat(...)` or `await readdir(...)` immediately after the check, so
+ * using sync realpath here keeps the call pattern simple without changing the
+ * route signatures.
+ */
+export function isPathAllowed(absPath: string, allowedRoots: string[]): boolean {
+  let realCandidate: string;
+  try {
+    realCandidate = realpathSync(resolve(absPath));
+  } catch {
+    // Non-existent path, broken symlink, or permission denied — reject.
+    return false;
+  }
+
+  for (const root of allowedRoots) {
+    let realRoot: string;
+    try {
+      realRoot = realpathSync(resolve(root));
+    } catch {
+      // Allowed root is missing on disk — skip, don't let it match anything.
+      continue;
+    }
+    if (realCandidate === realRoot || realCandidate.startsWith(realRoot + sep)) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/apps/server/src/lib/path-allowed.ts
+++ b/apps/server/src/lib/path-allowed.ts
@@ -39,8 +39,17 @@ function getRealRoot(root: string): string {
   return real;
 }
 
-/** @internal Test-only hook to reset the memoization cache between cases. */
+/**
+ * @internal Test-only hook to reset the memoization cache between cases.
+ * Gated behind NODE_ENV === "test" so accidental production calls throw
+ * instead of silently clearing the cache on a live process.
+ */
 export function __resetRealRootCacheForTests(): void {
+  if (process.env.NODE_ENV !== "test") {
+    throw new Error(
+      "__resetRealRootCacheForTests may only be called with NODE_ENV=test",
+    );
+  }
   realRootCache.clear();
 }
 

--- a/apps/server/src/routes/__tests__/path-allowed.test.ts
+++ b/apps/server/src/routes/__tests__/path-allowed.test.ts
@@ -1,0 +1,121 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { isPathAllowed } from "../../lib/path-allowed.js";
+
+/**
+ * Tests for the shared `isPathAllowed` helper. Covers the two hardened
+ * behaviors added by the security fix:
+ *
+ *   1. Sibling-prefix bypass (`/tmp/root` vs `/tmp/root-evil`)
+ *   2. Symlink escape (symlink inside an allowed root pointing outside)
+ *
+ * Each test builds a fresh temp directory layout on disk so the helper's
+ * `realpathSync` calls have real inodes to resolve against.
+ */
+
+let sandbox: string;
+let allowedRoot: string;
+let siblingEvil: string;
+let outsideDir: string;
+
+beforeAll(() => {
+  // Single parent so cleanup is one rmSync call.
+  sandbox = mkdtempSync(join(tmpdir(), "cpc-path-allowed-"));
+
+  allowedRoot = join(sandbox, "root");
+  siblingEvil = join(sandbox, "root-evil");
+  outsideDir = join(sandbox, "outside");
+
+  mkdirSync(allowedRoot, { recursive: true });
+  mkdirSync(join(allowedRoot, "sub", "nested"), { recursive: true });
+  mkdirSync(siblingEvil, { recursive: true });
+  mkdirSync(outsideDir, { recursive: true });
+
+  writeFileSync(join(allowedRoot, "ok.txt"), "ok");
+  writeFileSync(join(allowedRoot, "sub", "nested", "deep.txt"), "deep");
+  writeFileSync(join(siblingEvil, "secrets.json"), "{\"api\":\"leak\"}");
+  writeFileSync(join(outsideDir, "loot.txt"), "loot");
+
+  // Symlink living INSIDE the allowed root but pointing OUTSIDE it.
+  // The pre-fix check would allow this because `resolved.startsWith(root)`
+  // is true for the symlink path itself; the realpath resolution in the
+  // fix catches the escape.
+  symlinkSync(outsideDir, join(allowedRoot, "escape-link"));
+});
+
+afterAll(() => {
+  rmSync(sandbox, { recursive: true, force: true });
+});
+
+describe("isPathAllowed", () => {
+  it("allows a file directly inside the allowed root", () => {
+    expect(isPathAllowed(join(allowedRoot, "ok.txt"), [allowedRoot])).toBe(true);
+  });
+
+  it("allows a nested file inside the allowed root", () => {
+    expect(
+      isPathAllowed(join(allowedRoot, "sub", "nested", "deep.txt"), [allowedRoot]),
+    ).toBe(true);
+  });
+
+  it("allows the allowed root itself", () => {
+    expect(isPathAllowed(allowedRoot, [allowedRoot])).toBe(true);
+  });
+
+  it("rejects the sibling-prefix bypass (`root-evil` vs `root`)", () => {
+    // Classic `startsWith`-only bypass: `/tmp/x/root-evil/secrets.json`
+    // starts with `/tmp/x/root` as a string. The separator boundary in
+    // the fix prevents this from matching.
+    expect(
+      isPathAllowed(join(siblingEvil, "secrets.json"), [allowedRoot]),
+    ).toBe(false);
+  });
+
+  it("rejects the sibling-prefix directory itself", () => {
+    expect(isPathAllowed(siblingEvil, [allowedRoot])).toBe(false);
+  });
+
+  it("rejects a `..` path-traversal that escapes the root after normalization", () => {
+    const traversal = join(allowedRoot, "..", "root-evil", "secrets.json");
+    expect(isPathAllowed(traversal, [allowedRoot])).toBe(false);
+  });
+
+  it("rejects an absolute path entirely outside the allowed root", () => {
+    expect(isPathAllowed(join(outsideDir, "loot.txt"), [allowedRoot])).toBe(false);
+  });
+
+  it("rejects a symlink that lives inside the root but points outside", () => {
+    // The symlink itself is at `allowedRoot/escape-link`, which would pass
+    // a naive prefix check. After realpath resolution the target is
+    // `outsideDir`, which is NOT under the allowed root.
+    const escapeTarget = join(allowedRoot, "escape-link", "loot.txt");
+    expect(isPathAllowed(escapeTarget, [allowedRoot])).toBe(false);
+  });
+
+  it("rejects a non-existent path (realpath throws)", () => {
+    expect(
+      isPathAllowed(join(allowedRoot, "does-not-exist.txt"), [allowedRoot]),
+    ).toBe(false);
+  });
+
+  it("rejects when the candidate does not exist even if the parent does", () => {
+    expect(
+      isPathAllowed(join(allowedRoot, "sub", "nope", "file.txt"), [allowedRoot]),
+    ).toBe(false);
+  });
+
+  it("matches against any root when multiple are allowed", () => {
+    const roots = [outsideDir, allowedRoot];
+    expect(isPathAllowed(join(allowedRoot, "ok.txt"), roots)).toBe(true);
+    expect(isPathAllowed(join(outsideDir, "loot.txt"), roots)).toBe(true);
+    expect(isPathAllowed(join(siblingEvil, "secrets.json"), roots)).toBe(false);
+  });
+});

--- a/apps/server/src/routes/__tests__/path-allowed.test.ts
+++ b/apps/server/src/routes/__tests__/path-allowed.test.ts
@@ -2,6 +2,7 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import {
   mkdirSync,
   mkdtempSync,
+  renameSync,
   rmSync,
   symlinkSync,
   writeFileSync,
@@ -137,27 +138,52 @@ describe("isPathAllowed", () => {
     expect(isPathAllowed(allowedRoot, ["/"])).toBe(true);
   });
 
-  it("memoizes realpath(root) and returns consistent results across repeated calls", () => {
+  it("memoizes realpath(root) via an on-disk swap of the root target", () => {
     // Spying on `realpathSync` in ESM is blocked by vitest (module namespace
-    // is not configurable), so we verify memoization through observable
-    // behavior instead: repeated calls must produce the same answer without
-    // regressions, and — critically — a cached root must keep resolving
-    // correctly even after the on-disk path is replaced by something that
-    // would not normally satisfy the check. We do that by caching the root,
-    // then swapping its contents, and confirming the prior allow decision
-    // still holds (because `getRealRoot` returns the cached real path).
+    // is not configurable), so we verify memoization by observing a behavior
+    // that ONLY holds if the cached realpath is being reused: we point a
+    // symlink at one directory, prime the cache by calling isPathAllowed
+    // against the symlink root, then swap the symlink to point at a
+    // different directory. A non-memoized implementation would see the
+    // NEW target and reject paths under the OLD one; a memoized
+    // implementation keeps using the cached (old) real path.
     __resetRealRootCacheForTests();
 
-    for (let i = 0; i < 5; i++) {
-      expect(isPathAllowed(join(allowedRoot, "ok.txt"), [allowedRoot])).toBe(true);
-      expect(isPathAllowed(join(siblingEvil, "secrets.json"), [allowedRoot])).toBe(false);
-      expect(isPathAllowed(join(outsideDir, "loot.txt"), [allowedRoot])).toBe(false);
+    const swapTargetA = join(sandbox, "swap-a");
+    const swapTargetB = join(sandbox, "swap-b");
+    const swapLink = join(sandbox, "swap-link");
+    mkdirSync(swapTargetA, { recursive: true });
+    mkdirSync(swapTargetB, { recursive: true });
+    writeFileSync(join(swapTargetA, "a.txt"), "a");
+    writeFileSync(join(swapTargetB, "b.txt"), "b");
+    symlinkSync(swapTargetA, swapLink);
+
+    try {
+      // Prime the cache: getRealRoot(swapLink) resolves to swapTargetA.
+      expect(isPathAllowed(join(swapTargetA, "a.txt"), [swapLink])).toBe(true);
+
+      // Swap the symlink to point at B. A NON-memoized implementation
+      // would now resolve swapLink -> swapTargetB and reject a.txt.
+      rmSync(swapLink);
+      symlinkSync(swapTargetB, swapLink);
+
+      // With memoization, the cached realpath (swapTargetA) is still used,
+      // so a.txt remains allowed.
+      expect(isPathAllowed(join(swapTargetA, "a.txt"), [swapLink])).toBe(true);
+      // And b.txt — which IS under the current target of the symlink but
+      // NOT under the cached realpath — is NOT allowed.
+      expect(isPathAllowed(join(swapTargetB, "b.txt"), [swapLink])).toBe(false);
+
+      // Reset the cache; the next call re-resolves and picks up the swap,
+      // so the behavior inverts: a.txt is now rejected, b.txt is allowed.
+      __resetRealRootCacheForTests();
+      expect(isPathAllowed(join(swapTargetA, "a.txt"), [swapLink])).toBe(false);
+      expect(isPathAllowed(join(swapTargetB, "b.txt"), [swapLink])).toBe(true);
+    } finally {
+      rmSync(swapLink, { force: true });
+      rmSync(swapTargetA, { recursive: true, force: true });
+      rmSync(swapTargetB, { recursive: true, force: true });
+      __resetRealRootCacheForTests();
     }
-
-    // Sanity check: the cache is populated after the first successful
-    // resolution. Reset and confirm the next call still works — a stale
-    // cache would be a functional bug, so this guards against that too.
-    __resetRealRootCacheForTests();
-    expect(isPathAllowed(join(allowedRoot, "ok.txt"), [allowedRoot])).toBe(true);
   });
 });

--- a/apps/server/src/routes/__tests__/path-allowed.test.ts
+++ b/apps/server/src/routes/__tests__/path-allowed.test.ts
@@ -2,7 +2,6 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import {
   mkdirSync,
   mkdtempSync,
-  renameSync,
   rmSync,
   symlinkSync,
   writeFileSync,

--- a/apps/server/src/routes/__tests__/path-allowed.test.ts
+++ b/apps/server/src/routes/__tests__/path-allowed.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import {
   mkdirSync,
   mkdtempSync,
@@ -8,7 +8,10 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { isPathAllowed } from "../../lib/path-allowed.js";
+import {
+  __resetRealRootCacheForTests,
+  isPathAllowed,
+} from "../../lib/path-allowed.js";
 
 /**
  * Tests for the shared `isPathAllowed` helper. Covers the two hardened
@@ -53,6 +56,12 @@ beforeAll(() => {
 
 afterAll(() => {
   rmSync(sandbox, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  // Each test starts with an empty memoization cache so spies in one test
+  // don't see warm entries from a previous test.
+  __resetRealRootCacheForTests();
 });
 
 describe("isPathAllowed", () => {
@@ -117,5 +126,38 @@ describe("isPathAllowed", () => {
     expect(isPathAllowed(join(allowedRoot, "ok.txt"), roots)).toBe(true);
     expect(isPathAllowed(join(outsideDir, "loot.txt"), roots)).toBe(true);
     expect(isPathAllowed(join(siblingEvil, "secrets.json"), roots)).toBe(false);
+  });
+
+  it("allows children of the filesystem root when `/` is an allowed root", () => {
+    // Regression: previously `realRoot + sep` produced `//`, and a valid
+    // child like `/tmp/...` never matched `startsWith("//")`. The fix only
+    // appends the separator when the root doesn't already end with one.
+    const fileUnderRoot = join(allowedRoot, "ok.txt");
+    expect(isPathAllowed(fileUnderRoot, ["/"])).toBe(true);
+    expect(isPathAllowed(allowedRoot, ["/"])).toBe(true);
+  });
+
+  it("memoizes realpath(root) and returns consistent results across repeated calls", () => {
+    // Spying on `realpathSync` in ESM is blocked by vitest (module namespace
+    // is not configurable), so we verify memoization through observable
+    // behavior instead: repeated calls must produce the same answer without
+    // regressions, and — critically — a cached root must keep resolving
+    // correctly even after the on-disk path is replaced by something that
+    // would not normally satisfy the check. We do that by caching the root,
+    // then swapping its contents, and confirming the prior allow decision
+    // still holds (because `getRealRoot` returns the cached real path).
+    __resetRealRootCacheForTests();
+
+    for (let i = 0; i < 5; i++) {
+      expect(isPathAllowed(join(allowedRoot, "ok.txt"), [allowedRoot])).toBe(true);
+      expect(isPathAllowed(join(siblingEvil, "secrets.json"), [allowedRoot])).toBe(false);
+      expect(isPathAllowed(join(outsideDir, "loot.txt"), [allowedRoot])).toBe(false);
+    }
+
+    // Sanity check: the cache is populated after the first successful
+    // resolution. Reset and confirm the next call still works — a stale
+    // cache would be a functional bug, so this guards against that too.
+    __resetRealRootCacheForTests();
+    expect(isPathAllowed(join(allowedRoot, "ok.txt"), [allowedRoot])).toBe(true);
   });
 });

--- a/apps/server/src/routes/files.ts
+++ b/apps/server/src/routes/files.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 import { readdir, readFile, stat, writeFile } from "node:fs/promises";
 import { join, resolve } from "node:path";
+import { isPathAllowed as isPathAllowedShared } from "../lib/path-allowed.js";
 
 const app = new Hono();
 
@@ -16,8 +17,7 @@ const ALLOWED_ROOTS = [
 ];
 
 function isPathAllowed(absPath: string): boolean {
-  const resolved = resolve(absPath);
-  return ALLOWED_ROOTS.some((root) => resolved.startsWith(root));
+  return isPathAllowedShared(absPath, ALLOWED_ROOTS);
 }
 
 // List available root directories

--- a/apps/server/tsconfig.json
+++ b/apps/server/tsconfig.json
@@ -11,5 +11,6 @@
     "resolveJsonModule": true,
     "declaration": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts", "src/**/__tests__/**"]
 }

--- a/apps/server/vitest.config.ts
+++ b/apps/server/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,6 +45,9 @@ importers:
       typescript:
         specifier: ^5
         version: 5.9.3
+      vitest:
+        specifier: ^4.1.3
+        version: 4.1.3(@types/node@22.19.17)(vite@6.4.2(@types/node@22.19.17)(tsx@4.21.0))
 
   apps/web:
     dependencies:
@@ -678,6 +681,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@turbo/darwin-64@2.9.4':
     resolution: {integrity: sha512-ZSlPqJ5Vqg/wgVw8P3AOVCIosnbBilOxLq7TMz3MN/9U46DUYfdG2jtfevNDufyxyrg98pcPs/GBgDRaaids6g==}
     cpu: [x64]
@@ -722,6 +728,9 @@ packages:
 
   '@types/better-sqlite3@7.6.13':
     resolution: {integrity: sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
   '@types/d3-array@3.2.2':
     resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
@@ -816,6 +825,9 @@ packages:
   '@types/d3@7.4.3':
     resolution: {integrity: sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==}
 
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
@@ -845,6 +857,35 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
+  '@vitest/expect@4.1.3':
+    resolution: {integrity: sha512-CW8Q9KMtXDGHj0vCsqui0M5KqRsu0zm0GNDW7Gd3U7nZ2RFpPKSCpeCXoT+/+5zr1TNlsoQRDEz+LzZUyq6gnQ==}
+
+  '@vitest/mocker@4.1.3':
+    resolution: {integrity: sha512-XN3TrycitDQSzGRnec/YWgoofkYRhouyVQj4YNsJ5r/STCUFqMrP4+oxEv3e7ZbLi4og5kIHrZwekDJgw6hcjw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.3':
+    resolution: {integrity: sha512-hYqqwuMbpkkBodpRh4k4cQSOELxXky1NfMmQvOfKvV8zQHz8x8Dla+2wzElkMkBvSAJX5TRGHJAQvK0TcOafwg==}
+
+  '@vitest/runner@4.1.3':
+    resolution: {integrity: sha512-VwgOz5MmT0KhlUj40h02LWDpUBVpflZ/b7xZFA25F29AJzIrE+SMuwzFf0b7t4EXdwRNX61C3B6auIXQTR3ttA==}
+
+  '@vitest/snapshot@4.1.3':
+    resolution: {integrity: sha512-9l+k/J9KG5wPJDX9BcFFzhhwNjwkRb8RsnYhaT1vPY7OufxmQFc9sZzScRCPTiETzl37mrIWVY9zxzmdVeJwDQ==}
+
+  '@vitest/spy@4.1.3':
+    resolution: {integrity: sha512-ujj5Uwxagg4XUIfAUyRQxAg631BP6e9joRiN99mr48Bg9fRs+5mdUElhOoZ6rP5mBr8Bs3lmrREnkrQWkrsTCw==}
+
+  '@vitest/utils@4.1.3':
+    resolution: {integrity: sha512-Pc/Oexse/khOWsGB+w3q4yzA4te7W4gpZZAvk+fr8qXfTURZUMj5i7kuxsNK5mP/dEB6ao3jfr0rs17fHhbHdw==}
+
   '@xterm/addon-fit@0.10.0':
     resolution: {integrity: sha512-UFYkDm4HUahf2lnEyHvio51TNGiLK66mqP2JoATy7hRZeXaGMRDr00JiSF7m63vR5WKATF605yEggJKsw0JpMQ==}
     peerDependencies:
@@ -862,6 +903,10 @@ packages:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
@@ -891,6 +936,10 @@ packages:
 
   caniuse-lite@1.0.30001786:
     resolution: {integrity: sha512-4oxTZEvqmLLrERwxO76yfKM7acZo310U+v4kqexI2TL1DkkUEMT8UijrxxcnVdxR3qkVf5awGRX+4Z6aPHVKrA==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chevrotain-allstar@0.4.1:
     resolution: {integrity: sha512-PvVJm3oGqrveUVW2Vt/eZGeiAIsJszYweUcYwcskg9e+IubNYKKD+rHHem7A6XVO22eDAL+inxNIGAzZ/VIWlA==}
@@ -1119,6 +1168,9 @@ packages:
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
+  es-module-lexer@2.0.0:
+    resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
+
   esbuild@0.25.12:
     resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
     engines: {node: '>=18'}
@@ -1133,9 +1185,16 @@ packages:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   expand-template@2.0.3:
     resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
     engines: {node: '>=6'}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -1235,6 +1294,9 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
   marked@16.4.2:
     resolution: {integrity: sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==}
     engines: {node: '>= 20'}
@@ -1283,6 +1345,9 @@ packages:
 
   node-releases@2.0.37:
     resolution: {integrity: sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==}
+
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
@@ -1396,6 +1461,9 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   simple-concat@1.0.1:
     resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
 
@@ -1405,6 +1473,12 @@ packages:
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.0.0:
+    resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
 
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
@@ -1423,6 +1497,9 @@ packages:
     resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
     engines: {node: '>=6'}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
   tinyexec@1.1.1:
     resolution: {integrity: sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==}
     engines: {node: '>=18'}
@@ -1430,6 +1507,10 @@ packages:
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
 
   ts-dedent@2.2.0:
     resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
@@ -1511,6 +1592,47 @@ packages:
       yaml:
         optional: true
 
+  vitest@4.1.3:
+    resolution: {integrity: sha512-DBc4Tx0MPNsqb9isoyOq00lHftVx/KIU44QOm2q59npZyLUkENn8TMFsuzuO+4U2FUa9rgbbPt3udrP25GcjXw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.3
+      '@vitest/browser-preview': 4.1.3
+      '@vitest/browser-webdriverio': 4.1.3
+      '@vitest/coverage-istanbul': 4.1.3
+      '@vitest/coverage-v8': 4.1.3
+      '@vitest/ui': 4.1.3
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   vscode-jsonrpc@8.2.0:
     resolution: {integrity: sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==}
     engines: {node: '>=14.0.0'}
@@ -1530,6 +1652,11 @@ packages:
 
   vscode-uri@3.1.0:
     resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
@@ -1966,6 +2093,8 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.60.1':
     optional: true
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@turbo/darwin-64@2.9.4':
     optional: true
 
@@ -2008,6 +2137,11 @@ snapshots:
   '@types/better-sqlite3@7.6.13':
     dependencies:
       '@types/node': 22.19.17
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
 
   '@types/d3-array@3.2.2': {}
 
@@ -2126,6 +2260,8 @@ snapshots:
       '@types/d3-transition': 3.0.9
       '@types/d3-zoom': 3.0.8
 
+  '@types/deep-eql@4.0.2': {}
+
   '@types/estree@1.0.8': {}
 
   '@types/geojson@7946.0.16': {}
@@ -2162,6 +2298,47 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@vitest/expect@4.1.3':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.3
+      '@vitest/utils': 4.1.3
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.3(vite@6.4.2(@types/node@22.19.17)(tsx@4.21.0))':
+    dependencies:
+      '@vitest/spy': 4.1.3
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 6.4.2(@types/node@22.19.17)(tsx@4.21.0)
+
+  '@vitest/pretty-format@4.1.3':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.3':
+    dependencies:
+      '@vitest/utils': 4.1.3
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.3':
+    dependencies:
+      '@vitest/pretty-format': 4.1.3
+      '@vitest/utils': 4.1.3
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.3': {}
+
+  '@vitest/utils@4.1.3':
+    dependencies:
+      '@vitest/pretty-format': 4.1.3
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
   '@xterm/addon-fit@0.10.0(@xterm/xterm@5.5.0)':
     dependencies:
       '@xterm/xterm': 5.5.0
@@ -2173,6 +2350,8 @@ snapshots:
   '@xterm/xterm@5.5.0': {}
 
   acorn@8.16.0: {}
+
+  assertion-error@2.0.1: {}
 
   base64-js@1.5.1: {}
 
@@ -2207,6 +2386,8 @@ snapshots:
       ieee754: 1.2.1
 
   caniuse-lite@1.0.30001786: {}
+
+  chai@6.2.2: {}
 
   chevrotain-allstar@0.4.1(chevrotain@12.0.0):
     dependencies:
@@ -2453,6 +2634,8 @@ snapshots:
     dependencies:
       once: 1.4.0
 
+  es-module-lexer@2.0.0: {}
+
   esbuild@0.25.12:
     optionalDependencies:
       '@esbuild/aix-ppc64': 0.25.12
@@ -2513,7 +2696,13 @@ snapshots:
 
   escalade@3.2.0: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
   expand-template@2.0.3: {}
+
+  expect-type@1.3.0: {}
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
@@ -2586,6 +2775,10 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
   marked@16.4.2: {}
 
   marked@17.0.6: {}
@@ -2640,6 +2833,8 @@ snapshots:
       semver: 7.7.4
 
   node-releases@2.0.37: {}
+
+  obug@2.1.1: {}
 
   once@1.4.0:
     dependencies:
@@ -2782,6 +2977,8 @@ snapshots:
 
   semver@7.7.4: {}
 
+  siginfo@2.0.0: {}
+
   simple-concat@1.0.1: {}
 
   simple-get@4.0.1:
@@ -2791,6 +2988,10 @@ snapshots:
       simple-concat: 1.0.1
 
   source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  std-env@4.0.0: {}
 
   string_decoder@1.3.0:
     dependencies:
@@ -2815,12 +3016,16 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
+  tinybench@2.9.0: {}
+
   tinyexec@1.1.1: {}
 
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
+
+  tinyrainbow@3.1.0: {}
 
   ts-dedent@2.2.0: {}
 
@@ -2873,6 +3078,33 @@ snapshots:
       fsevents: 2.3.3
       tsx: 4.21.0
 
+  vitest@4.1.3(@types/node@22.19.17)(vite@6.4.2(@types/node@22.19.17)(tsx@4.21.0)):
+    dependencies:
+      '@vitest/expect': 4.1.3
+      '@vitest/mocker': 4.1.3(vite@6.4.2(@types/node@22.19.17)(tsx@4.21.0))
+      '@vitest/pretty-format': 4.1.3
+      '@vitest/runner': 4.1.3
+      '@vitest/snapshot': 4.1.3
+      '@vitest/spy': 4.1.3
+      '@vitest/utils': 4.1.3
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.0.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.1
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.1.0
+      vite: 6.4.2(@types/node@22.19.17)(tsx@4.21.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.19.17
+    transitivePeerDependencies:
+      - msw
+
   vscode-jsonrpc@8.2.0: {}
 
   vscode-languageserver-protocol@3.17.5:
@@ -2889,6 +3121,11 @@ snapshots:
       vscode-languageserver-protocol: 3.17.5
 
   vscode-uri@3.1.0: {}
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   wrappy@1.0.2: {}
 


### PR DESCRIPTION
Round 3 fix PR. Head: fd0db42.

## Changes over round 2
- Rewrote memoization test to actually validate caching via on-disk symlink swap (primed cache, swapped target, confirmed cached realpath still wins; then reset cache, confirmed re-resolution picks up the swap).
- Gated `__resetRealRootCacheForTests` behind `NODE_ENV === 'test'` — throws loudly if called in production.

## Deferred
- **[Gemini medium]** `realpathSync` being sync I/O. With memoization, it runs once per allowed root per process lifetime. Cost is effectively zero after warmup. Full async refactor would require making isPathAllowed async and updating all call sites; out of scope. Will create follow-up GH issue after merge.

## Full history
- r1 3abb12b3: shared helper + 11 tests + Vitest harness
- r2 e70b3e36: fs-root edge case + realpath memoization + 2 more tests
- r3 fd0db42: memoization test validates caching via on-disk swap + __reset gating