### PR TITLE
feat(web): add /reload-plugins to slash command popup

### DIFF
--- a/apps/web/src/components/ActionBar.tsx
+++ b/apps/web/src/components/ActionBar.tsx
@@ -424,6 +424,13 @@ export function ActionBar({ onReconnect, connected, activeTab, fileShowHidden, s
               /compact
               <div style={{ fontSize: 10, color: "#4a5a8a", marginTop: 1 }}>Compress conversation context</div>
             </button>
+            <button
+              onClick={() => { setModal(null); handleAction("/api/terminal/reload-plugins", "Reload plugins"); }}
+              style={{ ...btnStyle, padding: "4px 12px", textAlign: "left" as const, fontFamily: "monospace" }}
+            >
+              /reload-plugins
+              <div style={{ fontSize: 10, color: "#565f89", marginTop: 1 }}>Reload installed plugins, skills, and agents</div>
+            </button>
           </div>
         </BottomSheet>
       )}


### PR DESCRIPTION
## Summary
- Adds a `/reload-plugins` button to the Commands bottom sheet in `ActionBar.tsx`
- The button calls the existing `POST /api/terminal/reload-plugins` endpoint, which forwards `/reload-plugins` through the PTY to the Claude CLI
- Restores an entry that was missing from the popup compared to what the user expected to see when typing `/`

## Why
Liam noticed `/reload-plugins` was missing from the slash-command popup visible from the mini app's Terminal tab. The matching server route already exists (`apps/server/src/routes/terminal/slash-commands.ts`), so this is purely a UI wiring fix.

## Changes
- `apps/web/src/components/ActionBar.tsx`: one new `<button>` after `/compact`, styled to match the existing neutral entries (`/branch`, `/rename`)

## Test plan
- [x] `pnpm --filter @cpc/web run build` succeeds
- [ ] After deploy, open the mini app, tap `/commands`, confirm `/reload-plugins` row is visible
- [ ] Tap `/reload-plugins` and confirm Claude CLI receives the command (status pill shows "Reload plugins: OK" or similar)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>