### PR TITLE
feat(tldr): add loading animation for the 15-20s generation window

### DIFF
--- a/apps/web/src/components/ActionBar.tsx
+++ b/apps/web/src/components/ActionBar.tsx
@@ -958,9 +958,75 @@ export function ActionBar({ onReconnect, connected, activeTab, fileShowHidden, s
             {viewingFile.name}
           </div>
           {tldrLoading && (
-            <div style={{ fontSize: 13, color: "#565f89", padding: 16, textAlign: "center" }}>
-              Summarizing…
-            </div>
+            <>
+              {/* Loading animation for the 15-20s LLM generation window.
+                  Pure CSS keyframes (no new deps). Three signals so the UI
+                  never looks frozen: (1) a rotating teal spinner, (2) a
+                  pulsing "Generating summary…" label, and (3) three
+                  bouncing dots. Tokyo Night palette: bg #1a1b26, text
+                  #c0caf5, accent #7dcfff. */}
+              <style>{`
+                @keyframes tldr-spin { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
+                @keyframes tldr-pulse { 0%, 100% { opacity: 0.55; } 50% { opacity: 1; } }
+                @keyframes tldr-bounce {
+                  0%, 80%, 100% { transform: translateY(0); opacity: 0.35; }
+                  40%           { transform: translateY(-4px); opacity: 1; }
+                }
+                @media (prefers-reduced-motion: reduce) {
+                  [data-tldr-spinner], [data-tldr-label], [data-tldr-dot] {
+                    animation: none !important;
+                  }
+                  [data-tldr-spinner] { border-top-color: #7dcfff; }
+                  [data-tldr-label]   { opacity: 1; }
+                  [data-tldr-dot]     { opacity: 0.9; }
+                }
+              `}</style>
+              <div
+                role="status"
+                aria-live="polite"
+                aria-label="Generating summary"
+                style={{
+                  display: "flex",
+                  flexDirection: "column",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  gap: 12,
+                  padding: "28px 16px",
+                  minHeight: 140,
+                }}
+              >
+                <div
+                  data-tldr-spinner=""
+                  aria-hidden="true"
+                  style={{
+                    width: 32,
+                    height: 32,
+                    borderRadius: "50%",
+                    border: "3px solid #2a2b3d",
+                    borderTopColor: "#7dcfff",
+                    animation: "tldr-spin 0.9s linear infinite",
+                  }}
+                />
+                <div
+                  data-tldr-label=""
+                  style={{
+                    fontSize: 13,
+                    color: "#c0caf5",
+                    animation: "tldr-pulse 1.6s ease-in-out infinite",
+                  }}
+                >
+                  Generating summary…
+                </div>
+                <div aria-hidden="true" style={{ display: "flex", gap: 5 }}>
+                  <span data-tldr-dot="" style={{ width: 6, height: 6, borderRadius: "50%", background: "#7dcfff", animation: "tldr-bounce 1.2s ease-in-out 0s infinite" }} />
+                  <span data-tldr-dot="" style={{ width: 6, height: 6, borderRadius: "50%", background: "#7dcfff", animation: "tldr-bounce 1.2s ease-in-out 0.15s infinite" }} />
+                  <span data-tldr-dot="" style={{ width: 6, height: 6, borderRadius: "50%", background: "#7dcfff", animation: "tldr-bounce 1.2s ease-in-out 0.3s infinite" }} />
+                </div>
+                <div style={{ fontSize: 11, color: "#a9b1d6" }}>
+                  typically 15-20 seconds
+                </div>
+              </div>
+            </>
           )}
           {!tldrLoading && tldrError && (
             <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>

--- a/apps/web/src/components/ActionBar.tsx
+++ b/apps/web/src/components/ActionBar.tsx
@@ -1018,9 +1018,19 @@ export function ActionBar({ onReconnect, connected, activeTab, fileShowHidden, s
                   Generating summary…
                 </div>
                 <div aria-hidden="true" style={{ display: "flex", gap: 5 }}>
-                  <span data-tldr-dot="" style={{ width: 6, height: 6, borderRadius: "50%", background: "#7dcfff", animation: "tldr-bounce 1.2s ease-in-out 0s infinite" }} />
-                  <span data-tldr-dot="" style={{ width: 6, height: 6, borderRadius: "50%", background: "#7dcfff", animation: "tldr-bounce 1.2s ease-in-out 0.15s infinite" }} />
-                  <span data-tldr-dot="" style={{ width: 6, height: 6, borderRadius: "50%", background: "#7dcfff", animation: "tldr-bounce 1.2s ease-in-out 0.3s infinite" }} />
+                  {[0, 0.15, 0.3].map((delay) => (
+                    <span
+                      key={delay}
+                      data-tldr-dot=""
+                      style={{
+                        width: 6,
+                        height: 6,
+                        borderRadius: "50%",
+                        background: "#7dcfff",
+                        animation: `tldr-bounce 1.2s ease-in-out ${delay}s infinite`,
+                      }}
+                    />
+                  ))}
                 </div>
                 <div style={{ fontSize: 11, color: "#a9b1d6" }}>
                   typically 15-20 seconds


### PR DESCRIPTION
## What

Replaces the plain ``Summarizing…`` text in the TL;DR modal loading state with an animated indicator so the 15-20 second LLM generation window never looks frozen.

**File:** ``apps/web/src/components/ActionBar.tsx`` (lines 960-1029, ``tldrLoading`` branch of the TL;DR modal body)

## Why

User report: *"TLDR takes a very long time. This is okay but let's show an animation to indicate it is loading."* Real-world latency is 15-20s+ (a recent screenshot showed ``fresh (19454ms)``). Without motion, users could reasonably assume the mini app had frozen and close or retry.

## The animation

Three simultaneous signals so the UI has multiple things to watch:

1. **Rotating spinner** — 32px ring, Tokyo Night teal ``#7dcfff`` top border on a ``#2a2b3d`` base, ``tldr-spin 0.9s linear infinite``
2. **Pulsing label** — "Generating summary…" in ``#c0caf5``, opacity ``0.55 -> 1 -> 0.55`` via ``tldr-pulse 1.6s ease-in-out``
3. **Three bouncing dots** — 6px teal dots with staggered 0 / 0.15 / 0.3s delays via ``tldr-bounce 1.2s ease-in-out``
4. Helper copy "typically 15-20 seconds" in ``#a9b1d6`` so users know the expected duration

I picked a 3-signal combo rather than a single spinner because a spinner alone can feel hypnotic and unchanging over a 15-20s window — the pulsing label and staggered dots give the eye something new to land on each second.

## Implementation notes

- **Pure CSS, no new deps.** Uses inline ``<style>{...}</style>`` with ``@keyframes``, following the existing pattern already used by ``BottomSheet.tsx`` and ``VoiceRecorder.tsx``.
- **Tokyo Night palette:** bg ``#1a1b26``, text ``#c0caf5``, accent ``#7dcfff``, base ``#2a2b3d``.
- **Keyframe names are prefixed with ``tldr-``** to avoid any collision with the global ``slideUp`` (BottomSheet) or ``vr-*`` (VoiceRecorder) keyframes. Verified clean with grep.
- **The loading branch is still mutually exclusive** with the error and summary branches (``{tldrLoading &&}``, ``{!tldrLoading && tldrError &&}``, ``{!tldrLoading && !tldrError && tldrSummary &&}``). No stale summary is ever shown alongside the spinner.
- **No other file was touched.** Copy button, Regenerate button, abort logic, request-id scoping, and the ``<pre>``-based XSS defense are all untouched.

## Accessibility

- Container has ``role="status"`` + ``aria-live="polite"`` + ``aria-label="Generating summary"`` so screen readers announce the state
- Decorative spinner and bounce dots are marked ``aria-hidden="true"``
- **``prefers-reduced-motion: reduce`` media query** disables all three animations via ``data-tldr-*`` attribute selectors, leaving static versions visible (spinner with a static teal arc, label at full opacity, dots at 0.9 opacity). Motion-sensitive users get a calm static indicator instead of continuous motion.
- **Helper copy contrast**: ``#a9b1d6`` on ``#1a1b26`` is ~8.9:1 (passes WCAG AAA). The initial draft used ``#565f89`` but swarm review flagged that as ~2.76:1 — I switched to the ``#a9b1d6`` already used on the filename label directly above the spinner, which is both more readable and already the convention elsewhere in this modal.

## Verification

- ``pnpm run build`` from the worktree root — clean, ``index`` bundle grew ~0.5kB
- **Pre-push local swarm review** (Codex CLI + Gemini flash) on the first draft:
  - Codex flagged: (1) missing ``prefers-reduced-motion`` fallback [MEDIUM]; (2) ``#565f89`` contrast fail on helper copy [LOW]. **Both fixed** before push. Also confirmed no keyframe name collisions in the repo.
  - Gemini flagged: same ``prefers-reduced-motion`` concern. Other Gemini findings (inline ``<style>`` tag, inline ``style`` props generally) were nitpicks against a codebase-wide convention — skipped.
- No cloud review yet; cloud swarm will run on PR open.

## Out of scope (intentional)

- Not switching TL;DR rendering to react-markdown (separate TODO, needs security review)
- Not touching Copy/Regenerate button behavior
- Not touching any other file