### PR TITLE
fix(web): render BottomSheet via portal to escape transformed ancestor

### DIFF
--- a/apps/web/src/components/BottomSheet.tsx
+++ b/apps/web/src/components/BottomSheet.tsx
@@ -1,4 +1,5 @@
 import { useState, useRef, useCallback, useEffect } from "react";
+import { createPortal } from "react-dom";
 
 /** Hook: swipe-down-to-close — ONLY from header/drag handle area */
 function useSwipeDown(onClose: () => void, threshold = 80) {
@@ -63,7 +64,22 @@ export function BottomSheet({ onClose, title, children }: BottomSheetProps) {
     };
   }, []);
 
-  return (
+  // Render via portal into document.body so the modal escapes any transformed
+  // ancestor in the React tree. The App's tab strip uses
+  // `transform: translateX(...)` to slide between Terminal/Files/Links/Voice
+  // panes, which makes any descendant `position: fixed` element be positioned
+  // relative to the transformed strip (4x viewport width) instead of the
+  // viewport itself. The result was a sheet that visually anchored off-screen
+  // to the left and showed only its empty dark background in the visible Files
+  // pane. createPortal moves the DOM nodes out of the strip entirely so
+  // `position: fixed` resolves to the real viewport again.
+  // See: https://developer.mozilla.org/en-US/docs/Web/CSS/position#fixed
+  //
+  // SSR guard: CPC is a Vite SPA with no server render path, but the
+  // `typeof document` check makes the component safe to drop into a Next.js
+  // or Remix consumer in the future without crashing during prerender.
+  if (typeof document === "undefined") return null;
+  return createPortal(
     <div
       style={{
         position: "fixed",
@@ -110,6 +126,7 @@ export function BottomSheet({ onClose, title, children }: BottomSheetProps) {
         </div>
       </div>
       <style>{`@keyframes slideUp { from { transform: translateY(100%); } to { transform: translateY(0); } }`}</style>
-    </div>
+    </div>,
+    document.body,
   );
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   testDir: "./tests",
   timeout: 30000,
   use: {
-    baseURL: "http://localhost:38830",
+    baseURL: process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:38830",
     screenshot: "on",
     trace: "retain-on-failure",
   },

--- a/tests/paste-sheet-repro.spec.ts
+++ b/tests/paste-sheet-repro.spec.ts
@@ -1,0 +1,84 @@
+import { test, expect } from "@playwright/test";
+
+// Validates the paste-to-upload BottomSheet renders its form controls
+// inside the visible viewport (regression test for the v1.8.0 black-screen
+// bug where the sheet anchored off-screen because of a transformed ancestor).
+
+test.describe("Paste sheet visibility", () => {
+  test("paste sheet form controls are visible after opening", async ({ page }) => {
+    // iPhone-ish viewport that matches the Telegram mini app
+    await page.setViewportSize({ width: 390, height: 844 });
+
+    // Stub auth so the API calls have a token even though we never let
+    // them succeed (we mock the list endpoint below).
+    await page.addInitScript(() => {
+      try {
+        window.localStorage.setItem("cpc-session-token", "test-token");
+      } catch {}
+    });
+
+    // Mock /api/files/list so the FileViewer renders without a real backend.
+    // Returns a tiny fake listing rooted at /home/claude/claudes-world.
+    await page.route("**/api/files/list**", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          path: "/home/claude/claudes-world",
+          parent: "/home/claude",
+          items: [
+            { name: "AGENTS.md", type: "file", size: 1024, mtime: Date.now() / 1000 },
+            { name: "TODO.md", type: "file", size: 512, mtime: Date.now() / 1000 },
+          ],
+        }),
+      });
+    });
+
+    // Branch endpoint — the FileViewer fetches it but it's optional.
+    await page.route("**/api/git/branch**", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ branch: "main", treeType: "main" }),
+      });
+    });
+
+    await page.goto("/");
+
+    // Click into the Files tab. Tab button DOM text is lowercase ("files");
+    // CSS text-transform capitalizes it visually but Playwright matches the DOM.
+    const filesTab = page.locator("button", { hasText: /^files$/ });
+    await filesTab.click();
+    await page.waitForTimeout(800);
+
+    await page.screenshot({ path: "test-results/paste-before-open.png" });
+
+    // Click the "+ Paste" button — it lives in the directory listing area.
+    const pasteBtn = page.locator("button", { hasText: /Paste/ }).first();
+    await expect(pasteBtn).toBeVisible({ timeout: 5000 });
+    await pasteBtn.click();
+    await page.waitForTimeout(400);
+
+    await page.screenshot({ path: "test-results/paste-after-open.png" });
+
+    // The textarea inside the sheet should be visible AND inside the viewport.
+    const textarea = page.locator('textarea[placeholder*="Paste markdown"]');
+    await expect(textarea).toBeVisible({ timeout: 3000 });
+
+    const box = await textarea.boundingBox();
+    expect(box).not.toBeNull();
+    if (!box) throw new Error("textarea has no bounding box");
+
+    // The textarea must be within viewport horizontally. The original bug
+    // anchored it at x ~= -25% of viewport width (off-screen left).
+    expect(box.x).toBeGreaterThanOrEqual(-1);
+    expect(box.x + box.width).toBeLessThanOrEqual(391);
+    expect(box.width).toBeGreaterThan(100);
+
+    // Save / Cancel buttons should also be visible
+    const saveBtn = page.locator("button", { hasText: /^Save$/ });
+    await expect(saveBtn).toBeVisible();
+    const cancelBtn = page.locator("button", { hasText: /^Cancel$/ });
+    await expect(cancelBtn).toBeVisible();
+  });
+});

--- a/tests/paste-sheet-repro.spec.ts
+++ b/tests/paste-sheet-repro.spec.ts
@@ -96,7 +96,7 @@ test.describe("Paste sheet visibility", () => {
     if (!viewportSize) throw new Error("page has no viewport size");
     const viewportEpsilon = 1; // allow subpixel rounding
 
-    expect(box.x).toBeGreaterThanOrEqual(-1);
+    expect(box.x).toBeGreaterThanOrEqual(-viewportEpsilon);
     expect(box.x + box.width).toBeLessThanOrEqual(viewportSize.width + viewportEpsilon);
     expect(box.width).toBeGreaterThan(100);
 

--- a/tests/paste-sheet-repro.spec.ts
+++ b/tests/paste-sheet-repro.spec.ts
@@ -18,8 +18,12 @@ test.describe("Paste sheet visibility", () => {
     });
 
     // Mock /api/files/list so the FileViewer renders without a real backend.
-    // Returns a tiny fake listing rooted at /home/claude/claudes-world.
+    // The items shape must match the real server response at
+    // apps/server/src/routes/files.ts — { name, path, type, size, modified }.
+    // FileViewer uses entry.path as a React key, so missing path fields
+    // cause key collisions. (Copilot round-2 review.)
     await page.route("**/api/files/list**", async (route) => {
+      const nowIso = new Date().toISOString();
       await route.fulfill({
         status: 200,
         contentType: "application/json",
@@ -27,15 +31,29 @@ test.describe("Paste sheet visibility", () => {
           path: "/home/claude/claudes-world",
           parent: "/home/claude",
           items: [
-            { name: "AGENTS.md", type: "file", size: 1024, mtime: Date.now() / 1000 },
-            { name: "TODO.md", type: "file", size: 512, mtime: Date.now() / 1000 },
+            {
+              name: "AGENTS.md",
+              path: "/home/claude/claudes-world/AGENTS.md",
+              type: "file",
+              size: 1024,
+              modified: nowIso,
+            },
+            {
+              name: "TODO.md",
+              path: "/home/claude/claudes-world/TODO.md",
+              type: "file",
+              size: 512,
+              modified: nowIso,
+            },
           ],
         }),
       });
     });
 
-    // Branch endpoint — the FileViewer fetches it but it's optional.
-    await page.route("**/api/git/branch**", async (route) => {
+    // Branch endpoint — FileViewer actually fetches /api/terminal/dir-branch,
+    // not /api/git/branch. (Copilot round-2 review pointed out the earlier
+    // stub was a no-op.)
+    await page.route("**/api/terminal/dir-branch**", async (route) => {
       await route.fulfill({
         status: 200,
         contentType: "application/json",
@@ -49,15 +67,15 @@ test.describe("Paste sheet visibility", () => {
     // CSS text-transform capitalizes it visually but Playwright matches the DOM.
     const filesTab = page.locator("button", { hasText: /^files$/ });
     await filesTab.click();
-    await page.waitForTimeout(800);
 
     await page.screenshot({ path: "test-results/paste-before-open.png" });
 
     // Click the "+ Paste" button — it lives in the directory listing area.
+    // Playwright's web-first assertions auto-retry, so no explicit timeouts
+    // are needed. (Gemini round-2 review: waitForTimeout is flaky.)
     const pasteBtn = page.locator("button", { hasText: /Paste/ }).first();
     await expect(pasteBtn).toBeVisible({ timeout: 5000 });
     await pasteBtn.click();
-    await page.waitForTimeout(400);
 
     await page.screenshot({ path: "test-results/paste-after-open.png" });
 
@@ -70,9 +88,16 @@ test.describe("Paste sheet visibility", () => {
     if (!box) throw new Error("textarea has no bounding box");
 
     // The textarea must be within viewport horizontally. The original bug
-    // anchored it at x ~= -25% of viewport width (off-screen left).
+    // anchored it at x ~= -25% of viewport width (off-screen left). Derive
+    // the viewport width from page state instead of hardcoding it so this
+    // stays self-consistent if the setViewportSize call above is changed.
+    const viewportSize = page.viewportSize();
+    expect(viewportSize).not.toBeNull();
+    if (!viewportSize) throw new Error("page has no viewport size");
+    const viewportEpsilon = 1; // allow subpixel rounding
+
     expect(box.x).toBeGreaterThanOrEqual(-1);
-    expect(box.x + box.width).toBeLessThanOrEqual(391);
+    expect(box.x + box.width).toBeLessThanOrEqual(viewportSize.width + viewportEpsilon);
     expect(box.width).toBeGreaterThan(100);
 
     // Save / Cancel buttons should also be visible


### PR DESCRIPTION
## Summary

Fixes the paste-to-upload UI regression Liam reported in v1.8.0: opening the paste sheet on iOS Telegram (and headless chromium) shows an empty black area instead of the form controls.

## Root cause

`BottomSheet` (extracted in #77) uses `position: fixed; inset: 0`. The App tab strip in `apps/web/src/App.tsx` (lines 291-314) uses `transform: translateX(...)` to slide between Terminal/Files/Links/Voice panes. Per CSS spec, a `position: fixed` descendant of a transformed element is positioned relative to that element, not the viewport. The backdrop's `inset: 0` therefore resolves into the strip's coordinate system (4x viewport wide, translated to show the Files pane), and the inner sheet div — having no explicit width — stretches to the full strip width.

The form controls render at `x = -374px` (off-screen left of the visible Files pane) while the visible Files pane shows only the sheet's `#1a1b26` background. This matches Liam's screenshot exactly:

- File list dimmed at top (backdrop is over the Files pane)
- Large empty dark area (sheet background, controls off-screen)
- Action bar visible below (it's a sibling of the strip viewport, outside the transformed ancestor)
- iOS keyboard up (textarea autofocus fired even though it rendered off-screen)

A playwright repro on prod (v1.8.0) confirmed the bounding box:
`textarea bbox = {x: -374, y: 335, width: 1528, height: 180}`

## Fix

Render the `BottomSheet` via `createPortal(..., document.body)`. This relocates the DOM nodes out of the transformed strip so `position: fixed` resolves against the real viewport. React events still flow through the React tree (so swipe-to-close, backdrop click, save/cancel, textarea autofocus all keep working).

`ActionBar`'s consumers of `BottomSheet` (FileOptionsSheet, FileSearchSheet, TldrSheet, AudioGenSheet) continue working unchanged — they were already rendered outside the transformed strip, so the portal move is a no-op for them.

Added a `typeof document` SSR guard so future Next.js / Remix consumers don't crash during prerender. CPC itself has no SSR path; the guard is forward-compat.

## Test plan

- [x] `pnpm run build` clean
- [x] New playwright spec `tests/paste-sheet-repro.spec.ts` opens the paste sheet against a mocked files API and asserts the textarea bbox is inside the viewport. Passes on this branch, fails on v1.8.0.
- [x] Visual screenshot diff: post-fix sheet renders title, textarea, filename input, save destination, and Cancel/Save buttons.
- [x] Local 3-tier swarm review: Claude inline + Codex CLI + Gemini flash. Only finding was SSR safety (medium/low) — addressed with `typeof document` guard.
- [ ] Verify on iOS Telegram once dev server picks up the build (needs Liam to retest after `systemctl --user restart cpc.service` on the dev tier — prod stays on v1.8.0 until next tagged release per the CPC release SOP)

## Files

- `apps/web/src/components/BottomSheet.tsx` — wrap return in `createPortal(..., document.body)` with `typeof document` guard
- `playwright.config.ts` — accept `PLAYWRIGHT_BASE_URL` env var so the regression test can target any preview server
- `tests/paste-sheet-repro.spec.ts` — new regression test

## Notes

- The regression was hidden in #77 because the BottomSheet abstraction was tested via ActionBar's consumers, which are rendered OUTSIDE the transformed strip and worked fine. FileViewer is the first consumer rendered INSIDE the transformed ancestor, so the bug only surfaces from the paste-to-upload entry point.
- Subtle behavioral change: with the portal, the sheet is now anchored to the viewport regardless of which tab the user swipes to. Before the fix, the sheet would slide off-screen with the Files pane. The new behavior is arguably more correct (modal blocks all tabs), and the user can still dismiss with Cancel or backdrop click.

🤖 Generated with [Claude Code](https://claude.com/claude-code)