### PR TITLE
fix(action-bar): reset to file-browser buttons when leaving file viewer

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -425,6 +425,11 @@ export function FileViewer({ onClose, initialFile, showHidden = false, sortMode 
       setFileContent(null);
       setFileName("");
       setCollapsedRanges(new Set());
+      // Notify parent we're no longer viewing a file so ActionBar
+      // swaps back to the file-browser button set. Without this,
+      // loadDirectory's onViewChange(null) never fires on back-out
+      // and the viewer action buttons stay stuck on screen.
+      onViewChange?.(null);
     } else if (parentPath) {
       loadDirectory(parentPath);
     }

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -425,10 +425,7 @@ export function FileViewer({ onClose, initialFile, showHidden = false, sortMode 
       setFileContent(null);
       setFileName("");
       setCollapsedRanges(new Set());
-      // Notify parent we're no longer viewing a file so ActionBar
-      // swaps back to the file-browser button set. Without this,
-      // loadDirectory's onViewChange(null) never fires on back-out
-      // and the viewer action buttons stay stuck on screen.
+      // Notify parent that file view has ended to reset the ActionBar.
       onViewChange?.(null);
     } else if (parentPath) {
       loadDirectory(parentPath);


### PR DESCRIPTION
## Bug (reported in v1.8.0 UAT)

> When I am in file viewer and click back, the action bar buttons don't change to properly be the file browser options.

The bottom ActionBar stayed stuck on the file-viewer button set (Download / TL;DR / Copy / Back) after backing out of a file, instead of swapping back to the file-browser set (Upload / Search / Options). A refresh fixed it.

## Root cause

`apps/web/src/components/FileViewer.tsx` line 423 — `handleBack()`.

The ActionBar button set is driven by a parent-level `viewingFile` state in `App.tsx` (line 47), fed through the `onViewChange` callback prop passed to `FileViewer` (line 306). ActionBar toggles between button sets with `activeTab === "files" && !viewingFile` vs `activeTab === "files" && viewingFile` (ActionBar.tsx lines 1115 and 1125).

Every code path that changes file-view state consistently notified the parent — **except** `handleBack`:

- `loadDirectory` (line 331) clears local `fileContent` AND calls `onViewChange?.(null)` — correct.
- `loadFile` (line 356) sets local `fileContent` AND calls `onViewChange?.({ path, name })` — correct.
- `handleBack` (line 423) cleared `fileContent` / `fileName` / `collapsedRanges` but forgot the `onViewChange` call. The parent's `viewingFile` state stayed pointing at the last viewed file, so ActionBar kept rendering the viewer button set.

## Fix

One-line addition inside the `fileContent !== null` branch of `handleBack`:

```tsx
const handleBack = () => {
  if (fileContent !== null) {
    setFileContent(null);
    setFileName("");
    setCollapsedRanges(new Set());
    onViewChange?.(null); // <-- added: keep parent viewingFile in sync
  } else if (parentPath) {
    loadDirectory(parentPath);
  }
};
```

Optional chaining (`?.`) preserves the no-op behavior for any FileViewer consumer that doesn't pass `onViewChange`.

## Scope / non-goals

- Does NOT touch ActionBar. The button-selection logic there is correct; it was receiving stale parent state.
- Does NOT touch the parent-down flow from `App.tsx`. Bug was strictly in the child's back-out notification.
- Does NOT fix the unrelated download-button bug (separate PR).

## Verification

- `pnpm run build` - passes (14.9s, all 2 workspaces built, no type errors).
- `pnpm --filter @cpc/web run test` - 15/15 vitest suites green.
- Local pre-push swarm review (Codex CLI + Gemini 2.5 Flash):
  - **Gemini flash:** clean pass — "correctly calls `onViewChange(null)`, optional chaining prevents regressions, change is isolated and directly addresses the reported bug."
  - **Codex CLI:** clean pass on the normal browse-open-back path. Flagged one orthogonal, **pre-existing** concern (see below).

## Known pre-existing issue (NOT caused by this PR)

Codex noted that on the deep-link path (App.tsx line 23 parses `#file=...` from the URL hash and passes it as `initialFile`), FileViewer's mount effect (line 380) calls `loadFile(...)` **without** first populating directory state for the file's parent. On back, `handleBack` now correctly resets the ActionBar (the target of this PR) but the fall-through directory view still uses the component's default `currentPath` — so the user lands in a potentially wrong/stale directory listing. This behavior is **unchanged** by this PR, was present before, and would need a separate fix to `handleBack` (compute `dirname(initialFile)` and `loadDirectory(...)`) or to the mount effect (pre-load the parent dir). Filing as a follow-up.

## Test plan

- [x] Build passes
- [x] Unit tests pass
- [x] Swarm pre-push review
- [ ] Manual UAT after merge to dev: click into a file in the file browser, click back, confirm ActionBar shows Upload / Search / Options (file-browser set), not the viewer buttons.

## Confidence

**High** on the fix correctness for the reported bug. The diff is 1 load-bearing line + 4 lines of explanatory comment, symmetric with the two sibling code paths that were already correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)