### PR TITLE
fix(server): /reload-plugins now actually delivers slash command to tmux

### DIFF
--- a/apps/server/src/routes/terminal-ws.ts
+++ b/apps/server/src/routes/terminal-ws.ts
@@ -1,8 +1,12 @@
 import { spawn, execSync } from "node:child_process";
 import type { WSContext } from "hono/ws";
 import { checkAuth, validateSession, validateJwtToken, getAllowedUsers } from "../auth.js";
-
-const TMUX_SESSION = process.env.TMUX_SESSION || "claudes-world";
+// Import the validated TMUX_SESSION from routes/utils so we inherit the
+// `/^[A-Za-z0-9_-]+$/` character-set check that runs once at module load.
+// Keeping a local unvalidated copy would bypass that fence and leave the
+// execSync call below vulnerable to env-var shell injection. Flagged
+// security-high by cloud Gemini Code Assist on round-2 review of PR #85.
+import { TMUX_SESSION } from "./utils.js";
 
 function getPaneDimensions(): { cols: number; rows: number } {
   try {

--- a/apps/server/src/routes/utils.ts
+++ b/apps/server/src/routes/utils.ts
@@ -10,8 +10,9 @@ const execFileAsync = promisify(execFile);
 // malicious `process.env.TMUX_SESSION` like `foo; rm -rf /` would break
 // the fence. Validate once at module load against the canonical tmux
 // session-name charset (alphanumerics, hyphens, underscores) and refuse
-// to start otherwise. Flagged security-critical by cloud Gemini Code
-// Assist reviewer on PR #85.
+// to start otherwise. Every TMUX_SESSION consumer in the codebase (this
+// module + terminal-ws.ts) must import THIS constant rather than reading
+// process.env directly so the validation is unbypassable.
 const _rawTmuxSession = process.env.TMUX_SESSION || "claudes-world";
 if (!/^[A-Za-z0-9_-]+$/.test(_rawTmuxSession)) {
   throw new Error(
@@ -43,7 +44,10 @@ export const SESSION_NAMES_FILE = join(CLAUDES_WORLD, ".cpc-session-names");
  * arbitrary user input.
  */
 export async function sendToTmux(keys: string) {
-  await execFileAsync("tmux", ["send-keys", "-t", TMUX_SESSION, "-l", keys]);
+  // The `--` separator stops tmux from interpreting `keys` as an option
+  // if the first character is a hyphen. execFile already prevents shell
+  // injection but this also prevents tmux-level argument confusion.
+  await execFileAsync("tmux", ["send-keys", "-t", TMUX_SESSION, "-l", "--", keys]);
   await execFileAsync("tmux", ["send-keys", "-t", TMUX_SESSION, "Enter"]);
 }
 

--- a/apps/server/src/routes/utils.ts
+++ b/apps/server/src/routes/utils.ts
@@ -7,12 +7,12 @@ export const execAsync = promisify(exec);
 const execFileAsync = promisify(execFile);
 
 // TMUX_SESSION is consumed by execAsync (shell) in several helpers, so a
-// malicious `process.env.TMUX_SESSION` like `foo; rm -rf /` would break
-// the fence. Validate once at module load against the canonical tmux
-// session-name charset (alphanumerics, hyphens, underscores) and refuse
-// to start otherwise. Every TMUX_SESSION consumer in the codebase (this
-// module + terminal-ws.ts) must import THIS constant rather than reading
-// process.env directly so the validation is unbypassable.
+// malicious `process.env.TMUX_SESSION` would break the fence. Validate
+// once at module load against the canonical tmux session-name charset
+// (alphanumerics, hyphens, underscores) and refuse to start otherwise.
+// Every TMUX_SESSION consumer in the codebase must import THIS constant
+// rather than reading process.env directly so the validation is
+// unbypassable.
 const _rawTmuxSession = process.env.TMUX_SESSION || "claudes-world";
 if (!/^[A-Za-z0-9_-]+$/.test(_rawTmuxSession)) {
   throw new Error(
@@ -43,12 +43,24 @@ export const SESSION_NAMES_FILE = join(CLAUDES_WORLD, ".cpc-session-names");
  * tries to interpret `keys` as key names, which can reject or buffer
  * arbitrary user input.
  */
+// 5-second cap on each tmux invocation. Prevents the hang-forever failure
+// mode that originally motivated this PR — if tmux send-keys ever stalls
+// again, the promise rejects after 5s instead of wedging the HTTP handler.
+// On timeout execFile SIGTERMs the child and surfaces the rejection to
+// the caller; the catch in the /reload-plugins route already handles that
+// path and returns a non-OK JSON response to the client.
+const TMUX_TIMEOUT_MS = 5_000;
+
 export async function sendToTmux(keys: string) {
   // The `--` separator stops tmux from interpreting `keys` as an option
   // if the first character is a hyphen. execFile already prevents shell
   // injection but this also prevents tmux-level argument confusion.
-  await execFileAsync("tmux", ["send-keys", "-t", TMUX_SESSION, "-l", "--", keys]);
-  await execFileAsync("tmux", ["send-keys", "-t", TMUX_SESSION, "Enter"]);
+  await execFileAsync("tmux", ["send-keys", "-t", TMUX_SESSION, "-l", "--", keys], {
+    timeout: TMUX_TIMEOUT_MS,
+  });
+  await execFileAsync("tmux", ["send-keys", "-t", TMUX_SESSION, "Enter"], {
+    timeout: TMUX_TIMEOUT_MS,
+  });
 }
 
 /** Load OpenAI key from secrets file if not already in env */

--- a/apps/server/src/routes/utils.ts
+++ b/apps/server/src/routes/utils.ts
@@ -1,11 +1,25 @@
-import { exec } from "node:child_process";
+import { exec, execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
 export const execAsync = promisify(exec);
+const execFileAsync = promisify(execFile);
 
-export const TMUX_SESSION = process.env.TMUX_SESSION || "claudes-world";
+// TMUX_SESSION is consumed by execAsync (shell) in several helpers, so a
+// malicious `process.env.TMUX_SESSION` like `foo; rm -rf /` would break
+// the fence. Validate once at module load against the canonical tmux
+// session-name charset (alphanumerics, hyphens, underscores) and refuse
+// to start otherwise. Flagged security-critical by cloud Gemini Code
+// Assist reviewer on PR #85.
+const _rawTmuxSession = process.env.TMUX_SESSION || "claudes-world";
+if (!/^[A-Za-z0-9_-]+$/.test(_rawTmuxSession)) {
+  throw new Error(
+    `Invalid TMUX_SESSION name: ${JSON.stringify(_rawTmuxSession)}. ` +
+      `Only alphanumerics, hyphens, and underscores are allowed.`,
+  );
+}
+export const TMUX_SESSION = _rawTmuxSession;
 export const HOME = process.env.HOME || "/home/claude";
 export const CLAUDES_WORLD = join(HOME, "claudes-world");
 export const SESSION_NAMES_FILE = join(CLAUDES_WORLD, ".cpc-session-names");
@@ -13,24 +27,24 @@ export const SESSION_NAMES_FILE = join(CLAUDES_WORLD, ".cpc-session-names");
 /**
  * Send literal text to the tmux session and submit it with Enter.
  *
- * Uses the same proven pattern as the /compact endpoint:
- *   1. `-l` (literal) flag so tmux does not try to interpret the string as
- *      key names — this matters for any text containing `/`, `;`, or other
- *      tokens tmux might otherwise reject or buffer.
- *   2. `JSON.stringify` for shell escaping — survives quotes, backslashes,
- *      and embedded `$`/backtick safely.
- *   3. Text and Enter sent as two separate send-keys calls so the literal
- *      text is fully flushed before the submit key is delivered.
+ * Uses `execFile` (no shell) with an argv array so `keys` cannot inject
+ * shell metacharacters — we do not rely on `JSON.stringify` as a shell
+ * quoting strategy (it doesn't escape `$VAR`, backticks, or `$(...)` inside
+ * double-quotes). Two separate calls so the literal text is fully flushed
+ * before the Enter key is delivered.
  *
  * The previous implementation `tmux send-keys -t SESSION "${keys}" Enter`
- * (no `-l`, single call, raw shell interpolation) was observed to hang
- * indefinitely against the live `claudes-world` session when invoked from
- * the /reload-plugins endpoint, leaving zombie tmux clients in the cpc.service
- * cgroup and never delivering the slash command to Claude CLI.
+ * (raw shell interpolation, no `-l`, single call via exec) was observed to
+ * hang indefinitely against the live `claudes-world` tmux session when
+ * invoked from the /reload-plugins endpoint, leaving hung tmux clients in
+ * the cpc.service cgroup and never delivering the slash command to Claude
+ * CLI. The `-l` (literal) flag also matters on its own: without it, tmux
+ * tries to interpret `keys` as key names, which can reject or buffer
+ * arbitrary user input.
  */
 export async function sendToTmux(keys: string) {
-  await execAsync(`tmux send-keys -t ${TMUX_SESSION} -l ${JSON.stringify(keys)}`);
-  await execAsync(`tmux send-keys -t ${TMUX_SESSION} Enter`);
+  await execFileAsync("tmux", ["send-keys", "-t", TMUX_SESSION, "-l", keys]);
+  await execFileAsync("tmux", ["send-keys", "-t", TMUX_SESSION, "Enter"]);
 }
 
 /** Load OpenAI key from secrets file if not already in env */

--- a/apps/server/src/routes/utils.ts
+++ b/apps/server/src/routes/utils.ts
@@ -10,9 +10,27 @@ export const HOME = process.env.HOME || "/home/claude";
 export const CLAUDES_WORLD = join(HOME, "claudes-world");
 export const SESSION_NAMES_FILE = join(CLAUDES_WORLD, ".cpc-session-names");
 
-/** Send keys to the tmux session */
+/**
+ * Send literal text to the tmux session and submit it with Enter.
+ *
+ * Uses the same proven pattern as the /compact endpoint:
+ *   1. `-l` (literal) flag so tmux does not try to interpret the string as
+ *      key names — this matters for any text containing `/`, `;`, or other
+ *      tokens tmux might otherwise reject or buffer.
+ *   2. `JSON.stringify` for shell escaping — survives quotes, backslashes,
+ *      and embedded `$`/backtick safely.
+ *   3. Text and Enter sent as two separate send-keys calls so the literal
+ *      text is fully flushed before the submit key is delivered.
+ *
+ * The previous implementation `tmux send-keys -t SESSION "${keys}" Enter`
+ * (no `-l`, single call, raw shell interpolation) was observed to hang
+ * indefinitely against the live `claudes-world` session when invoked from
+ * the /reload-plugins endpoint, leaving zombie tmux clients in the cpc.service
+ * cgroup and never delivering the slash command to Claude CLI.
+ */
 export async function sendToTmux(keys: string) {
-  await execAsync(`tmux send-keys -t ${TMUX_SESSION} "${keys}" Enter`);
+  await execAsync(`tmux send-keys -t ${TMUX_SESSION} -l ${JSON.stringify(keys)}`);
+  await execAsync(`tmux send-keys -t ${TMUX_SESSION} Enter`);
 }
 
 /** Load OpenAI key from secrets file if not already in env */


### PR DESCRIPTION
## Bug

The /reload-plugins button in CPC's slash command popup (added in #64) returned `ok:true` from the API and showed `"Reload plugins: OK"` in the status line, but the slash command never actually reached the Claude CLI in the live tmux session.

## Investigation (live evidence)

Checked `systemctl --user status cpc.service` and found two zombie children parented to the running cpc node process:

```
1398641 /bin/sh -c "tmux send-keys -t claudes-world \"/reload-plugins\" Enter"
1398642 tmux send-keys -t claudes-world /reload-plugins Enter
```

Both had been sleeping (`State: S`, `wchan: do_sys_poll`) for 5+ minutes. The `tmux: client` was connected to the live tmux server's unix socket but the syscall (poll) never returned. Empty `tmux send-keys -t claudes-world` from a separate shell completed instantly, and the same shell command against a fresh test session completed fine — so the hang was specific to the combination of (live claudes-world session) + (this exact send-keys form) + (running under Node's `child_process.exec`).

## Root cause

`apps/server/src/routes/utils.ts` line 14 — the shared `sendToTmux` helper:

```ts
export async function sendToTmux(keys: string) {
  await execAsync(`tmux send-keys -t ${TMUX_SESSION} "${keys}" Enter`);
}
```

Three issues, in increasing severity:

1. **No `-l` (literal) flag** — tmux tries to interpret `/reload-plugins` as a sequence of key tokens. Tmux usually falls through to literal characters when no key name matches, but the parsing path is materially different from the literal path used by `/compact` and `/api/terminal/send-keys`, both of which work reliably.
2. **Raw shell interpolation `"${keys}"`** — vulnerable to shell injection or quoting breakage if `keys` ever contains a `"`, backtick, or `$`.
3. **Text + Enter combined in one tmux send-keys call** — the input gets buffered and the submit may race the literal text under load.

The `/compact` endpoint at `apps/server/src/routes/terminal/slash-commands.ts:34-35` does it the right way and has been rock solid:

```ts
await execAsync(`tmux send-keys -t ${TMUX_SESSION} -l ${JSON.stringify(message)}`);
await execAsync(`tmux send-keys -t ${TMUX_SESSION} Enter`);
```

## Fix

Rewrite `sendToTmux` to use the proven `/compact` pattern: `-l` flag, `JSON.stringify` for shell escaping, separate Enter call. `/reload-plugins` is the only caller of `sendToTmux` in the codebase, so the blast radius equals the bug being fixed.

## How to verify on dev

1. Pull this branch into the dev worktree, `pnpm run build && systemctl --user restart cpc.service` (or whatever the dev service is).
2. Open the CPC mini app, open the `/commands` sheet, tap `/reload-plugins`.
3. The Claude CLI input box should briefly show `/reload-plugins`, then submit, and the CLI should respond as if you'd typed it manually.
4. Sanity check: `systemctl --user status cpc.service` should show no lingering `tmux send-keys` processes in the cgroup after the click.

## Confidence

Medium-high.

- High on the fix being safer and matching the known-working sibling endpoint.
- High on the live hang being real (zombie processes were directly observed in the cpc.service cgroup).
- Medium on whether the `-l` change is THE specific reason the hang stops, vs whether the two-call split is the deciding factor — both are possible and both are addressed by this patch.
- Verifying live on dev before promoting to prod is recommended.

## Cleanup note for Liam

The current prod cpc.service still has the zombie sh+tmux processes from the original click. They are harmless but worth clearing on next deploy. A `systemctl --user restart cpc.service` after the prod deploy will reap them.