### PR TITLE
fix(file-viewer): restore overflowX hidden on markdown wrapper (regression from #20)

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -726,7 +726,7 @@ export function FileViewer({ onClose, initialFile, showHidden = false, sortMode 
 
       {/* File content view */}
       {fileContent !== null && !loading && fileName.endsWith(".md") && (
-        <div style={{ flex: 1, overflow: "auto" }}>
+        <div style={{ flex: 1, overflow: "auto", overflowX: "hidden" }}>
           <MarkdownViewer content={fileContent} fileName={fileName} />
         </div>
       )}


### PR DESCRIPTION
## Summary
- Restores the one-property safety clip removed by PR #20 (d9d2b03)
- Fixes the iOS Safari subpixel horizontal scroll Liam reported on 2026-04-08
- One character-accurate regression undo

## Diagnosis

See `~/claudes-world/tmp/20260408-file-viewer-hscroll-diagnosis.md` (HIGH confidence, git-traceable).

Root cause: PR #20 removed `overflowX: "hidden"` from the FileViewer markdown wrapper based on a misunderstanding that `overflow: "auto"` covered both axes. It didn't — the outer wrapper needed the explicit clip to hard-cap the iOS subpixel bleed from the nested MarkdownViewer's `<pre>` elements (which intentionally use `width: max-content` for code-block scrolling).

Git evidence:
```
198c38b Add markdown rendering ...          <-- introduced wrapper as overflow: "auto"
625d074 Fix file viewer horizontal overflow <-- ADDED overflowX: "hidden" ("tiny jiggle")
d9d2b03 fix: code block horizontal scroll (#20) <-- REMOVED overflowX: "hidden" (regression)
```

## Local swarm review

- Codex CLI: CLEAN
- Gemini 2.5 flash: CLEAN

## Test plan
- [ ] Open file viewer on a long markdown file in CPC mini app on iPhone
- [ ] Confirm no horizontal scroll on the page itself
- [ ] Confirm long code blocks STILL scroll horizontally inside their `<pre>` (PR #20 fix preserved)
- [ ] Vertical scroll still works
- [ ] No regression on desktop / tablet viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)