### PR TITLE
feat(search): Search UX bundle (split C1: backdrop opacity)

### DIFF
--- a/apps/web/src/components/BottomSheet.tsx
+++ b/apps/web/src/components/BottomSheet.tsx
@@ -84,7 +84,7 @@ export function BottomSheet({ onClose, title, children }: BottomSheetProps) {
       style={{
         position: "fixed",
         inset: 0,
-        background: "rgba(0,0,0,0.6)",
+        background: "rgba(0,0,0,0.85)",
         zIndex: 1000,
         display: "flex",
         flexDirection: "column",


### PR DESCRIPTION
## Summary
- Bump BottomSheet backdrop opacity from `rgba(0,0,0,0.6)` to `rgba(0,0,0,0.85)` so the file search sheet feels like a focused modal
- Reported via UAT 2026-04-08 by Liam: file browser tabs and sort row visible bleeding through at the top

## Test plan
- [ ] Open file search in CPC mini app
- [ ] Confirm backdrop is now opaque enough that tabs/sort row are not visible
- [ ] Confirm the sheet content above the backdrop is unaffected

## Related
Part of the Search UX bundle. C2 (file-type icons) and C3 (current-folder-only toggle) will follow as separate PRs into the same branch.

Generated with [Claude Code](https://claude.com/claude-code)