### PR TITLE
feat(search): 'current folder only' toggle (Search UX C3)

### DIFF
--- a/apps/server/src/routes/files.ts
+++ b/apps/server/src/routes/files.ts
@@ -8,7 +8,7 @@ import {
   unlink,
   writeFile,
 } from "node:fs/promises";
-import { basename, join, resolve } from "node:path";
+import { basename, join, resolve, sep } from "node:path";
 import { constants as fsConstants } from "node:fs";
 import { isPathAllowed as isPathAllowedShared } from "../lib/path-allowed.js";
 
@@ -249,17 +249,46 @@ app.get("/download", async (c) => {
   }
 });
 
-// Fuzzy file/path search — BFS across all allowed roots
+// Fuzzy file/path search — BFS across all allowed roots.
+//
+// Optional `scope` query param narrows the walk to a single folder (Search
+// UX C3: the "current folder only" toggle in the file-search sheet). The
+// scope is subjected to the same `isPathAllowed` check as every other file
+// route so a client can't pass `../../etc` and escape the allowlist. When
+// present we seed the BFS queue with just that folder instead of every
+// allowed root, which is faster AND avoids results leaking in from siblings.
 app.get("/search", async (c) => {
   const qRaw = c.req.query("q")?.toLowerCase() || "";
   if (qRaw.length < 2) return c.json({ results: [] });
   const q = qRaw;
 
+  const scopeRaw = c.req.query("scope");
+  let roots: string[] = ALLOWED_ROOTS;
+  if (scopeRaw) {
+    const scopeResolved = resolve(scopeRaw);
+    // Reject scopes that aren't inside an allowed root. Same check as every
+    // other file route — realpath-canonicalizing both sides and enforcing a
+    // true path-segment boundary — so a symlink escape or sibling-prefix
+    // bypass can't smuggle an out-of-tree path in via `?scope=`.
+    if (!(await isPathAllowed(scopeResolved))) {
+      return c.json({ error: "Access denied" }, 403);
+    }
+    roots = [scopeResolved];
+  }
+
   const results: { name: string; path: string; type: string; relPath: string }[] = [];
   const MAX = 25;
 
   // BFS queue: [dirPath, depth]
-  const queue: [string, number][] = ALLOWED_ROOTS.map((r) => [r, 0]);
+  const queue: [string, number][] = roots.map((r) => [r, 0]);
+
+  // Pre-compute the scope prefix (with trailing separator so we get a true
+  // path-segment boundary and `/a/b-evil` can't match scope `/a/b`). The
+  // scope itself is also a valid match, so we check for equality separately.
+  const scopeMatchRoot = scopeRaw ? resolve(scopeRaw) : null;
+  const scopeMatchPrefix = scopeMatchRoot
+    ? (scopeMatchRoot.endsWith(sep) ? scopeMatchRoot : scopeMatchRoot + sep)
+    : null;
 
   while (queue.length > 0 && results.length < MAX) {
     const [dir, depth] = queue.shift()!;
@@ -271,8 +300,15 @@ app.get("/search", async (c) => {
         if (e.name.startsWith(".") && !e.name.startsWith(".claude")) continue;
         const full = join(dir, e.name);
         const relPath = full.replace("/home/claude/", "~/");
+        // Defence in depth: even though the BFS is seeded from the scope
+        // root, also drop anything whose path doesn't start with the scope
+        // (with a trailing-separator boundary). A compromised readdir or
+        // weird symlink can't then leak siblings into a scoped query.
+        const inScope = scopeMatchPrefix === null
+          || full === scopeMatchRoot
+          || full.startsWith(scopeMatchPrefix);
         // Match against filename OR relative path (supports partial paths)
-        if (e.name.toLowerCase().includes(q) || relPath.toLowerCase().includes(q)) {
+        if (inScope && (e.name.toLowerCase().includes(q) || relPath.toLowerCase().includes(q))) {
           results.push({
             name: e.name,
             path: full,

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -45,6 +45,7 @@ export function App() {
     try { localStorage.setItem(HIDDEN_KEY, fileShowHidden ? "1" : "0"); } catch { /* ignore */ }
   }, [fileShowHidden]);
   const [viewingFile, setViewingFile] = useState<{ path: string; name: string } | null>(null);
+  const [currentFolder, setCurrentFolder] = useState<string | null>(null);
   const [cpcBranch, setCpcBranch] = useState<string | null>(null);
 
   const onConnectionChange = useCallback((c: boolean) => setConnected(c), []);
@@ -303,7 +304,7 @@ export function App() {
             <Terminal key={reconnectKey} onConnectionChange={onConnectionChange} />
           </div>
           <div style={{ width: `${100 / TABS.length}%`, height: "100%", flexShrink: 0 }}>
-            <FileViewer onClose={() => setActiveTab("terminal")} initialFile={initialFilePath} showHidden={fileShowHidden} sortMode={fileSortMode} onSortModeChange={setFileSortMode} onViewChange={setViewingFile} />
+            <FileViewer onClose={() => setActiveTab("terminal")} initialFile={initialFilePath} showHidden={fileShowHidden} sortMode={fileSortMode} onSortModeChange={setFileSortMode} onViewChange={setViewingFile} onPathChange={setCurrentFolder} />
           </div>
           <div style={{ width: `${100 / TABS.length}%`, height: "100%", flexShrink: 0 }}>
             <Links onClose={() => setActiveTab("terminal")} />
@@ -325,6 +326,7 @@ export function App() {
           fileSortMode={fileSortMode}
           setFileSortMode={setFileSortMode}
           viewingFile={viewingFile}
+          currentFolder={currentFolder}
         />
       </div>
     </div>

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -93,6 +93,7 @@ interface FileViewerProps {
   sortMode?: SortMode;
   onSortModeChange?: (mode: SortMode) => void;
   onViewChange?: (file: { path: string; name: string } | null) => void;
+  onPathChange?: (path: string) => void;
 }
 
 const EXT_LANG: Record<string, string> = {
@@ -125,7 +126,7 @@ function formatSize(bytes: number): string {
   return `${(bytes / (1024 * 1024)).toFixed(1)}M`;
 }
 
-export function FileViewer({ onClose, initialFile, showHidden = false, sortMode = "name-asc", onSortModeChange, onViewChange }: FileViewerProps) {
+export function FileViewer({ onClose, initialFile, showHidden = false, sortMode = "name-asc", onSortModeChange, onViewChange, onPathChange }: FileViewerProps) {
   const [currentPath, setCurrentPath] = useState("/home/claude/claudes-world");
   const [entries, setEntries] = useState<FileEntry[]>([]);
   const [parentPath, setParentPath] = useState<string | null>(null);
@@ -401,11 +402,27 @@ export function FileViewer({ onClose, initialFile, showHidden = false, sortMode 
   useEffect(() => {
     if (initialFile) {
       const name = initialFile.split("/").pop() || "file";
+      // Seed currentPath to the file's parent directory so features that
+      // depend on "what folder am I in right now" (e.g. the Search UX C3
+      // "current folder only" scope) don't stay stuck on the default
+      // `/home/claude/claudes-world` root while the user is actually
+      // viewing a file that lives elsewhere. Codex round-1 flagged this
+      // as a stale-scope bug after a hash-nav reload from search results.
+      const lastSlash = initialFile.lastIndexOf("/");
+      if (lastSlash > 0) {
+        setCurrentPath(initialFile.slice(0, lastSlash));
+      }
       loadFile(initialFile, name);
     } else {
       loadDirectory(currentPath);
     }
   }, []);
+
+  // Notify parent of the browsed directory so features like file search can
+  // scope themselves to the folder the user is currently looking at.
+  useEffect(() => {
+    onPathChange?.(currentPath);
+  }, [currentPath, onPathChange]);
 
   // Fetch git branch for the current directory
   useEffect(() => {

--- a/apps/web/src/components/action-bar/ActionBar.tsx
+++ b/apps/web/src/components/action-bar/ActionBar.tsx
@@ -16,7 +16,9 @@ import { StatusLine } from "./StatusLine";
 import { btnStyle, type ActionBarProps, type AudioStatus, type GitBranch, type Modal, type SearchResult, type SessionName } from "./types";
 import { checkAudio, deleteSessionName, fetchGitBranch, fetchGitStatus, fetchSessionNames, fetchTodo, generateAudio, postAction, renameSession, restartSession, runGitCommand, searchFiles, sendAudioTelegram, sendCompactCommand, sendFileToChat, sendToTmux } from "./api";
 
-export function ActionBar({ onReconnect, connected, activeTab, fileShowHidden, setFileShowHidden, fileSortMode, setFileSortMode, viewingFile }: ActionBarProps) {
+const SEARCH_SCOPE_KEY = "cpc:search:currentFolderOnly";
+
+export function ActionBar({ onReconnect, connected, activeTab, fileShowHidden, setFileShowHidden, fileSortMode, setFileSortMode, viewingFile, currentFolder }: ActionBarProps) {
   const [status, setStatus] = useState<string | null>(null);
   const [modal, setModal] = useState<Modal>(null);
   const [compactFocus, setCompactFocus] = useState("");
@@ -29,6 +31,27 @@ export function ActionBar({ onReconnect, connected, activeTab, fileShowHidden, s
   const [deleteTarget, setDeleteTarget] = useState<SessionName | null>(null);
   const [searchQuery, setSearchQuery] = useState("");
   const [searchResults, setSearchResults] = useState<SearchResult[]>([]);
+  // "Current folder only" search toggle — default ON, persisted per-user via
+  // localStorage. When ON we pass the folder the user is browsing as a
+  // `scope` query param; when OFF the server falls back to the old global
+  // search across all allowed roots. (Search UX C3.)
+  const [searchCurrentFolderOnly, setSearchCurrentFolderOnly] = useState<boolean>(() => {
+    try {
+      // Default to true unless explicitly set to "false" — so a fresh user
+      // gets the scoped behavior we actually want as the default.
+      return localStorage.getItem(SEARCH_SCOPE_KEY) !== "false";
+    } catch {
+      return true;
+    }
+  });
+  useEffect(() => {
+    try { localStorage.setItem(SEARCH_SCOPE_KEY, String(searchCurrentFolderOnly)); } catch { /* ignore */ }
+  }, [searchCurrentFolderOnly]);
+  // Keep the latest scope value in a ref so the debounced search callback
+  // (which is a useCallback with a stable identity) can read the freshest
+  // toggle + folder without needing to rebuild on every change.
+  const searchScopeRef = useRef<string | null>(null);
+  searchScopeRef.current = searchCurrentFolderOnly && currentFolder ? currentFolder : null;
   const [audioStatus, setAudioStatus] = useState<AudioStatus | null>(null);
   const [audioLoading, setAudioLoading] = useState(false);
   const [gitBranch, setGitBranch] = useState<GitBranch | null>(null);
@@ -121,6 +144,12 @@ export function ActionBar({ onReconnect, connected, activeTab, fileShowHidden, s
     setSearchResults([]);
   }, []);
 
+  // Ref to the search input handler so an effect below can re-trigger the
+  // debounced search when the scope toggle changes without the effect
+  // having to depend on `handleSearchInput` itself (which would thrash
+  // whenever any of its deps changed).
+  const handleSearchInputRef = useRef<((query: string) => void) | null>(null);
+
   const handleSearchInput = useCallback((query: string) => {
     setSearchQuery(query);
     if (searchTimerRef.current) clearTimeout(searchTimerRef.current);
@@ -136,7 +165,7 @@ export function ActionBar({ onReconnect, connected, activeTab, fileShowHidden, s
       const controller = new AbortController();
       searchAbortRef.current = controller;
       try {
-        const results = await searchFiles(query, controller.signal);
+        const results = await searchFiles(query, controller.signal, searchScopeRef.current);
         // Only commit results if this fetch is still the latest one — a
         // later call may have aborted us between await and here.
         if (searchAbortRef.current === controller) {
@@ -150,6 +179,20 @@ export function ActionBar({ onReconnect, connected, activeTab, fileShowHidden, s
       }
     }, 300);
   }, []);
+  handleSearchInputRef.current = handleSearchInput;
+
+  // When the user flips the "current folder only" toggle (or the current
+  // folder itself changes while the sheet is open), re-run the debounced
+  // search so the visible results reflect the new scope. We intentionally
+  // don't depend on `searchQuery` — typing it already schedules its own
+  // search via onChange, so including it here would double-fire.
+  useEffect(() => {
+    if (modal !== "file-search") return;
+    if (searchQuery.length < 2) return;
+    handleSearchInputRef.current?.(searchQuery);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchCurrentFolderOnly, currentFolder, modal]);
+
   const handleCheckAudio = async (filePath: string) => { setAudioStatus(null); setAudioLoading(true); try { setAudioStatus(await checkAudio(filePath)); } catch { setAudioStatus(null); } setAudioLoading(false); };
   const handleGenerateAudio = async (filePath: string) => {
     setAudioLoading(true);
@@ -224,7 +267,7 @@ export function ActionBar({ onReconnect, connected, activeTab, fileShowHidden, s
     case "compact-focus": modalNode = <CompactFocusModal value={compactFocus} onChange={setCompactFocus} onBack={() => setModal("compact-confirm")} onSubmit={() => void handleCompact(compactFocus.trim() ? `/compact ${compactFocus.trim()}` : "/compact")} />; break;
     case "continuity-notes": modalNode = <ContinuityNotesModal value={continuityNotes} onChange={setContinuityNotes} onBack={() => setModal("compact-confirm")} onSubmit={() => void handleCompact(`Before compacting, please ensure: 1) README.md is up to date with recent changes. 2) Anything important from this session is saved to the knowledge base or memory. 3) Open work and next steps are captured in NEXT-SESSION.md and TODO.md.${continuityNotes.trim() ? ` Additional context from user: "${continuityNotes.trim()}".` : ""}`)} />; break;
     case "file-options": modalNode = <FileOptionsSheet fileShowHidden={fileShowHidden} fileSortMode={fileSortMode} setFileShowHidden={setFileShowHidden} setFileSortMode={setFileSortMode} onClose={() => setModal(null)} />; break;
-    case "file-search": modalNode = <FileSearchSheet searchQuery={searchQuery} searchResults={searchResults} onClose={() => setModal(null)} onChange={handleSearchInput} onSelect={(result) => { setModal(null); window.location.hash = `files&file=${encodeURIComponent(result.path)}`; window.location.reload(); }} />; break;
+    case "file-search": modalNode = <FileSearchSheet searchQuery={searchQuery} searchResults={searchResults} currentFolder={currentFolder ?? null} currentFolderOnly={searchCurrentFolderOnly} onToggleCurrentFolderOnly={setSearchCurrentFolderOnly} onClose={() => setModal(null)} onChange={handleSearchInput} onSelect={(result) => { setModal(null); window.location.hash = `files&file=${encodeURIComponent(result.path)}`; window.location.reload(); }} />; break;
     case "tldr": modalNode = viewingFile ? <TldrModal viewingFile={viewingFile} onClose={() => setModal(null)} /> : null; break;
     case "audio-gen": modalNode = viewingFile ? <AudioGenModal viewingFile={viewingFile} audioLoading={audioLoading} audioStatus={audioStatus} onClose={() => setModal(null)} onGenerate={() => void handleGenerateAudio(viewingFile.path)} onSend={() => { if (audioStatus?.path) void handleSendAudio(audioStatus.path); }} /> : null; break;
   }

--- a/apps/web/src/components/action-bar/FileSearchSheet.tsx
+++ b/apps/web/src/components/action-bar/FileSearchSheet.tsx
@@ -5,14 +5,59 @@ import { btnStyle, type SearchResult } from "./types";
 interface FileSearchSheetProps {
   searchQuery: string;
   searchResults: SearchResult[];
+  currentFolder: string | null;
+  currentFolderOnly: boolean;
+  onToggleCurrentFolderOnly: (value: boolean) => void;
   onClose: () => void;
   onChange: (value: string) => void;
   onSelect: (result: SearchResult) => void;
 }
 
-export function FileSearchSheet({ searchQuery, searchResults, onClose, onChange, onSelect }: FileSearchSheetProps) {
+export function FileSearchSheet({
+  searchQuery,
+  searchResults,
+  currentFolder,
+  currentFolderOnly,
+  onToggleCurrentFolderOnly,
+  onClose,
+  onChange,
+  onSelect,
+}: FileSearchSheetProps) {
+  const shortFolder = currentFolder ? currentFolder.replace("/home/claude/", "~/") : null;
+  // When the toggle is on but no folder is available (edge case — file viewer
+  // hasn't reported a path yet), fall back to global so the user isn't stuck
+  // with a scope that resolves to nothing. The label flags this state.
+  const scopeActive = currentFolderOnly && !!currentFolder;
   return (
     <BottomSheet onClose={onClose} title="Search Files">
+      <label
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 8,
+          padding: "6px 2px 10px",
+          fontSize: 12,
+          color: "#a9b1d6",
+          cursor: "pointer",
+          userSelect: "none",
+        }}
+      >
+        <input
+          type="checkbox"
+          checked={currentFolderOnly}
+          onChange={(e) => onToggleCurrentFolderOnly(e.target.checked)}
+          style={{ accentColor: "#7aa2f7", width: 14, height: 14, cursor: "pointer" }}
+        />
+        <span>Current folder only</span>
+        {scopeActive && shortFolder && (
+          <span style={{ color: "#565f89", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+            {shortFolder}
+          </span>
+        )}
+        {currentFolderOnly && !currentFolder && (
+          <span style={{ color: "#e0af68" }}>no folder — searching globally</span>
+        )}
+      </label>
       <input
         value={searchQuery}
         onChange={(e) => onChange(e.target.value)}

--- a/apps/web/src/components/action-bar/api.ts
+++ b/apps/web/src/components/action-bar/api.ts
@@ -116,9 +116,10 @@ export async function runGitCommand(command: string) {
   return data.output || "No output";
 }
 
-export async function searchFiles(query: string, signal?: AbortSignal) {
+export async function searchFiles(query: string, signal?: AbortSignal, scope?: string | null) {
+  const scopeParam = scope ? `&scope=${encodeURIComponent(scope)}` : "";
   const data = await jsonFetch<{ results?: SearchResult[] }>(
-    `/api/files/search?q=${encodeURIComponent(query)}`,
+    `/api/files/search?q=${encodeURIComponent(query)}${scopeParam}`,
     { headers: getAuthHeaders(), signal },
   );
   return data.results || [];

--- a/apps/web/src/components/action-bar/types.ts
+++ b/apps/web/src/components/action-bar/types.ts
@@ -10,6 +10,7 @@ export interface ActionBarProps {
   fileSortMode?: SortMode;
   setFileSortMode?: (v: SortMode) => void;
   viewingFile?: { path: string; name: string } | null;
+  currentFolder?: string | null;
 }
 
 export type Modal =


### PR DESCRIPTION
## Summary
- New toggle at top of file search sheet, default ON
- Persisted per-user via localStorage (`cpc:search:currentFolderOnly`)
- When ON: search scoped to the current folder (the folder browsed when search was opened)
- When OFF: existing global search across all accessible roots
- Backend extends the search endpoint with an optional `scope` query param + `isPathAllowed` validation
- Defence-in-depth: even though BFS is seeded from the scope root, every hit's path is re-checked against a trailing-separator prefix
- Bonus fix: `FileViewer` now seeds `currentPath` from `initialFile`'s parent so scope isn't stale after a hash-nav open from a search result

## Test plan
- [ ] Open file search in CPC, toggle is ON by default
- [ ] Search returns only files in the current folder
- [ ] Toggle OFF, search returns global results
- [ ] Toggle state persists across sheet reopens (localStorage)
- [ ] Toggle state persists across browser reloads
- [ ] Path traversal in scope is rejected by `isPathAllowed` (security)
- [ ] After opening a file from a global search hit, backing out, then re-opening search with scope ON shows results from the file's actual parent folder

## Related
Search UX bundle complete: C1 (#105 backdrop opacity) + C2 (#107 file-type icons) + this (C3).

Local 2-tier swarm review: Codex + Gemini flash — both CLEAN on round 2 after fixing the stale-scope initialFile case Codex flagged in round 1.

Generated with [Claude Code](https://claude.com/claude-code)