### PR TITLE
perf(web): kill mermaid modulepreload + vendor chunk split

### DIFF
--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -23,10 +23,33 @@ export default defineConfig(({ command }) => ({
     __APP_VERSION__: JSON.stringify(gitVersion),
   },
   build: {
+    // Kill the eager `<link rel="modulepreload">` hint Vite emits for the
+    // mermaid chunk. Mermaid is dynamically imported inside MermaidDiagram.tsx
+    // and only needed when a markdown file actually contains a diagram, but
+    // Vite auto-hoists dynamic-import targets into modulepreload hints, so
+    // every cold start was downloading the 637 KB mermaid bundle for nothing.
+    // `resolveDependencies` lets us filter that specific chunk out of the
+    // preload list while leaving all other dynamic-import preloads alone.
+    modulePreload: {
+      resolveDependencies: (_filename, deps) =>
+        deps.filter((d) => !d.includes("mermaid")),
+    },
     rollupOptions: {
       output: {
+        // Split heavy, rarely-changing vendor libraries into their own
+        // content-hashed chunks so browsers can cache them across app-code
+        // redeploys. These chunks only change when the corresponding package
+        // version bumps, unlike the main app chunk which changes on every
+        // deploy.
         manualChunks: {
           mermaid: ["mermaid"],
+          "vendor-react": ["react", "react-dom", "react-dom/client"],
+          "vendor-xterm": [
+            "@xterm/xterm",
+            "@xterm/addon-fit",
+            "@xterm/addon-web-links",
+          ],
+          "vendor-marked": ["marked"],
         },
       },
     },


### PR DESCRIPTION
## Summary

Cheap perf win from the load-speed research doc at `tmp/20260408-cpc-load-speed-options.md` (steps 2 of 3 — the matching Caddy immutable-headers change is being handled by orchestrator as system admin, logged separately in `VPS_CHANGELOG.md`).

1. **Kill mermaid modulepreload hint** — Vite was auto-hoisting the dynamic `import("mermaid")` in `MermaidDiagram.tsx` into an eager `<link rel="modulepreload">`, shipping 637 KB on every cold start even when no diagram was rendered. Fix: use `build.modulePreload.resolveDependencies` to filter the mermaid chunk out of the computed preload list. Mermaid still loads **lazily** on first diagram render via the existing dynamic import — only the preload hint is removed.
2. **Vendor chunk split** — React, xterm, and marked are now separately-hashed long-cached chunks via `build.rollupOptions.output.manualChunks`. These chunks only change when the corresponding package version bumps, so browsers can cache them across app-code redeploys.

## Before / after (raw bundle sizes)

| Asset | Before | After | Delta |
|---|---|---|---|
| main `index.js` | **614 KB** | **93 KB** | **-521 KB (-85%)** |
| mermaid preload on cold start | YES (637 KB) | **NO (lazy)** | **-637 KB** |
| `vendor-react.js` | — | 189 KB (new) | cacheable |
| `vendor-xterm.js` | — | 289 KB (new) | cacheable |
| `vendor-marked.js` | — | 41 KB (new) | cacheable |
| `mermaid-*.js` (on disk) | 637 KB | 637 KB | unchanged, lazy |
| Total `dist/` | 4.0 MB | 4.0 MB | unchanged |

**Cold-start wire cost (non-diagram session):**
- Before: `index.js` (614) + `mermaid` preload (637) = **1251 KB**
- After: `index.js` (93) + `vendor-react` (189) + `vendor-xterm` (289) + `vendor-marked` (41) = **612 KB**
- **Savings: ~639 KB (-51%) on every cold start** for sessions that don't open a markdown file with a diagram

**Return-visit cost (after a small app-code deploy):**
- Before: browser re-downloads the full 614 KB main bundle because React/xterm/marked are baked in
- After: browser re-downloads only the ~93 KB app chunk; vendor chunks are content-hashed and served from HTTP cache (requires the Caddyfile `immutable` header change orchestrator is handling)

## `index.html` diff (conceptual)

Before:
```html
<script type="module" src="/assets/index-*.js"></script>
<link rel="modulepreload" href="/assets/mermaid-*.js">  <!-- 637 KB wasted -->
<link rel="stylesheet" href="/assets/index-*.css">
```

After:
```html
<script type="module" src="/assets/index-*.js"></script>
<link rel="modulepreload" href="/assets/vendor-react-*.js">
<link rel="modulepreload" href="/assets/vendor-xterm-*.js">
<link rel="modulepreload" href="/assets/vendor-marked-*.js">
<!-- no mermaid preload; loaded lazily on first diagram render -->
<link rel="stylesheet" href="/assets/index-*.css">
```

## Implementation notes

- `build.modulePreload.resolveDependencies` is the Vite-supported hook for filtering the preload list. Signature: `(filename, deps, context) => string[]`. We pass through everything except chunks whose filename contains `mermaid`. This is safer than `modulePreload: false`, which would drop preload hints for all dynamic imports — we still want preload for the vendor chunks (Rollup correctly emits those because they're static deps of the entry chunk).
- The `manualChunks` object form assigns Rollup chunks by package id, which is the deterministic/stable form (no hashing instability).
- `MermaidDiagram.tsx` is untouched — its `import("mermaid")` already loaded lazily; the only problem was the preload hint Vite was auto-inserting.

## Related

- Research doc: `tmp/20260408-cpc-load-speed-options.md` (options 1, 3 from the "cheap triple")
- Matching Caddyfile change (`Cache-Control: public, max-age=31536000, immutable` for `/assets/*`) — being handled by orchestrator as system-admin edit, logged in `VPS_CHANGELOG.md`.

## Test plan

- [ ] Dev URL loads normally after deploy
- [ ] Mermaid diagrams still render (lazy-loaded on first view of a markdown file with a diagram)
- [ ] Initial paint is visibly faster on mobile (UAT)
- [ ] Chrome DevTools Network tab: verify `vendor-react`/`vendor-xterm`/`vendor-marked` are separate 200 responses on first load; verify they're 304s (or served from disk cache) on second load
- [ ] Chrome DevTools Network tab: verify `mermaid-*.js` does NOT appear in the initial request waterfall — should only appear after rendering a markdown file with a mermaid fence

## Local swarm review

- Codex CLI (gpt-5.4): **CLEAN** — verified Vite `build.modulePreload.resolveDependencies` docs and Rollup `output.manualChunks` object form docs, confirmed no runtime/build risk
- Gemini 2.5 flash: **CLEAN**