### PR TITLE
fix(search): FileSearchSheet folder type check ('directory' -> 'dir')

### DIFF
--- a/apps/web/src/components/action-bar/FileSearchSheet.tsx
+++ b/apps/web/src/components/action-bar/FileSearchSheet.tsx
@@ -76,7 +76,7 @@ export function FileSearchSheet({
             style={{ ...btnStyle, display: "block", width: "100%", padding: "8px 12px", textAlign: "left", marginBottom: 4, overflow: "hidden", textOverflow: "ellipsis" }}
           >
             <span style={{ display: "inline-flex", alignItems: "center", gap: 6 }}>
-              {getFileIcon(result.name, result.type === "directory")}
+              {getFileIcon(result.name, result.type === "dir")}
               <span>{result.name}</span>
             </span>
             <div style={{ fontSize: 10, color: "#565f89", marginTop: 2, overflow: "hidden", textOverflow: "ellipsis" }}>{result.relPath}</div>


### PR DESCRIPTION
## Summary
Tiny bug shipped in PR #107 (Search UX C2): the search result row checks `result.type === "directory"` to decide whether to render the folder icon, but the server returns `"dir"` for directories. Result: folders always got the default DocIcon.

## The fix
```diff
- {getFileIcon(result.name, result.type === "directory")}
+ {getFileIcon(result.name, result.type === "dir")}
```

## Why tests didn't catch it
The unit tests in #110 cover `getFileIcon()` directly with all its branches, which are correct. The bug was in the consumer call site passing the wrong comparison string. Surfaced during review of the test PR.

## Test plan
- [ ] Open file search in CPC mini app
- [ ] Search for something that matches both folders and files (e.g. "src")
- [ ] Confirm folders now render with the FolderIcon (blue folder SVG), files with their type-specific icon

Local swarm review (Codex): CLEAN. Gemini was rate-limited (429 capacity exhausted) so this shipped with a single local tier plus the existing 41-test suite passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)