### PR TITLE
fix: address PR #106 Copilot findings (polish sweep)

### DIFF
--- a/apps/server/src/routes/terminal-ws.ts
+++ b/apps/server/src/routes/terminal-ws.ts
@@ -2,7 +2,7 @@ import { spawn, execSync } from "node:child_process";
 import type { WSContext } from "hono/ws";
 import { checkAuth, validateSession, validateJwtToken, getAllowedUsers } from "../auth.js";
 // Import the validated TMUX_SESSION from routes/utils so we inherit the
-// `/^[A-Za-z0-9_-]+$/` character-set check that runs once at module load.
+// `/^[A-Za-z0-9_.-]+$/` character-set check that runs once at module load.
 // Keeping a local unvalidated copy would bypass that fence and leave the
 // execSync call below vulnerable to env-var shell injection. Flagged
 // security-high by cloud Gemini Code Assist on round-2 review of PR #85.

--- a/apps/server/src/routes/utils.ts
+++ b/apps/server/src/routes/utils.ts
@@ -9,7 +9,11 @@ const execFileAsync = promisify(execFile);
 // TMUX_SESSION is consumed by execAsync (shell) in several helpers, so a
 // malicious `process.env.TMUX_SESSION` would break the fence. Validate
 // once at module load against the canonical tmux session-name charset
-// (alphanumerics, hyphens, underscores) and refuse to start otherwise.
+// (alphanumerics, hyphens, underscores, dots) and refuse to start
+// otherwise. Dots are allowed because real tmux session names in use
+// here include them (e.g. "claudes-world" plus dotted variants from
+// knowledge/ADR work); tmux itself accepts them. See PR #100 round 5
+// for the regex expansion.
 // Every TMUX_SESSION consumer in the codebase must import THIS constant
 // rather than reading process.env directly so the validation is
 // unbypassable.
@@ -17,7 +21,7 @@ const _rawTmuxSession = process.env.TMUX_SESSION || "claudes-world";
 if (!/^[A-Za-z0-9_.-]+$/.test(_rawTmuxSession)) {
   throw new Error(
     `Invalid TMUX_SESSION name: ${JSON.stringify(_rawTmuxSession)}. ` +
-      `Only alphanumerics, hyphens, and underscores are allowed.`,
+      `Only alphanumerics, hyphens, underscores, and dots are allowed.`,
   );
 }
 export const TMUX_SESSION = _rawTmuxSession;

--- a/apps/web/src/components/action-bar/api.ts
+++ b/apps/web/src/components/action-bar/api.ts
@@ -57,11 +57,28 @@ export async function fetchSessionNames() {
 }
 
 export async function deleteSessionName(ts: number) {
-  await fetch("/api/session/names", {
+  // fetch() only rejects on network errors, so a 4xx/5xx would otherwise
+  // resolve successfully and the UI would optimistically filter the row
+  // out — only for it to reappear on the next page load because the
+  // server never actually deleted it. Check res.ok and throw with any
+  // structured server error body so callers' catch blocks surface the
+  // real failure. (Copilot PR #106 review; mirrors the jsonFetch pattern
+  // from PR #98 round 4 split B1 above.)
+  const res = await fetch("/api/session/names", {
     method: "DELETE",
     headers: { ...getAuthHeaders(), "Content-Type": "application/json" },
     body: JSON.stringify({ ts }),
   });
+  if (!res.ok) {
+    let serverError: string | undefined;
+    try {
+      const body = (await res.json()) as { error?: string };
+      if (body && typeof body.error === "string") serverError = body.error;
+    } catch {
+      // Body wasn't JSON — fall through to generic status-text error.
+    }
+    throw new Error(serverError ?? `Request failed: ${res.status} ${res.statusText}`);
+  }
 }
 
 export async function fetchGitBranch() {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,10 +1,39 @@
 import { defineConfig } from "@playwright/test";
 
+// Playwright resolves test URLs via `new URL(path, baseURL)`. When tests
+// call `page.goto("/")`, a leading slash is treated as root-relative and
+// the URL constructor STRIPS any path prefix from baseURL — so a
+// PLAYWRIGHT_BASE_URL like `https://cpc.claude.do/dev/` would silently
+// send tests to `https://cpc.claude.do/` and hit a 404 or the wrong app.
+// Refuse to start with a path-prefixed baseURL rather than running a
+// whole suite against the wrong origin. For path-prefixed deployments,
+// either hit the bare origin of a port-forward to 127.0.0.1:38831 (what
+// Caddy proxies /dev/* onto), or change the tests to use relative paths
+// like `page.goto(".")` which preserve the prefix.
+// (Copilot PR #106 review.)
+const rawBaseUrl = process.env.PLAYWRIGHT_BASE_URL || "http://localhost:38830";
+try {
+  const parsed = new URL(rawBaseUrl);
+  if (parsed.pathname !== "/" && parsed.pathname !== "") {
+    throw new Error(
+      `PLAYWRIGHT_BASE_URL has a path prefix (${parsed.pathname}), which is ` +
+        `incompatible with the tests' page.goto("/") calls — the leading ` +
+        `slash strips the prefix via URL resolution. Use the bare origin ` +
+        `(e.g. http://127.0.0.1:38831) or update tests to relative paths.`,
+    );
+  }
+} catch (err) {
+  if (err instanceof TypeError) {
+    throw new Error(`PLAYWRIGHT_BASE_URL is not a valid URL: ${rawBaseUrl}`);
+  }
+  throw err;
+}
+
 export default defineConfig({
   testDir: "./tests",
   timeout: 30000,
   use: {
-    baseURL: process.env.PLAYWRIGHT_BASE_URL || "http://localhost:38830",
+    baseURL: rawBaseUrl,
     screenshot: "on",
     trace: "retain-on-failure",
   },


### PR DESCRIPTION
## Summary
Cleanup PR addressing all 4 Copilot findings from the v1.9.0 RC (#106) initial review. Not new bugs — mostly stale docs + one real-but-minor fetch hygiene fix + one preventive playwright config guard.

## Changes
1. **\`apps/server/src/routes/utils.ts\`** — TMUX_SESSION regex comment + thrown error message updated to reflect that dots are allowed (was stale after PR #100 round 5 expanded the regex from \`[A-Za-z0-9_-]\` to \`[A-Za-z0-9_.-]\`).
2. **\`apps/server/src/routes/terminal-ws.ts\`** — comment at line 5 updated to match the current regex.
3. **\`apps/web/src/components/action-bar/api.ts\`** — \`deleteSessionName\` now checks \`res.ok\` and throws the server error message on non-2xx, same pattern as \`jsonFetch\` from PR #98 round 4 B1. Side effect: this also fixes the caller's optimistic-filter bug in \`ActionBar.tsx\` without touching that file, because the row-removal happens on the line *after* the \`await\` — a thrown error now skips it and the caller's \`catch {}\` swallows cleanly.
4. **\`playwright.config.ts\`** — validates \`PLAYWRIGHT_BASE_URL\` at config load and refuses to start with a path-prefixed baseURL. Playwright resolves \`page.goto("/")\` via \`new URL(path, baseURL)\`, and the leading slash strips any path prefix because it's root-relative — so \`PLAYWRIGHT_BASE_URL=https://cpc.claude.do/dev/\` would silently send the whole suite to \`https://cpc.claude.do/\`. Now errors with a clear message pointing to the bare origin (e.g. \`http://127.0.0.1:38831\` for local Caddy bypass). Verified locally: default \`http://localhost:38830\` still loads cleanly; a path-prefixed URL errors out at config load with a helpful message.

## Why now
Liam is napping through his flight. The RC #106 has these findings parked but unaddressed, and they're all low-risk. Cleaning them up before \`@codex please review\` fires means codex sees a cleaner state and we don't consume cloud quota re-verifying known-fixable items.

## Verification
- Build: clean (\`pnpm run build\` turbo, both \`@cpc/server\` and \`@cpc/web\`)
- Server tests: 21/21 pass (\`vitest run\` in \`apps/server\`)
- Playwright config: \`--list\` succeeds on default baseURL, errors clearly on \`https://cpc.claude.do/dev/\`
- Local swarm (codex-5.4 + gemini-2.5-flash): CLEAN on the 118-line diff

## Test plan
- [ ] \`pnpm run build\` at monorepo root — should pass
- [ ] \`cd apps/server && pnpm run test\` — should pass (21 tests)
- [ ] Rename a tmux session with a dot in the name (e.g. \`test.1\`) — should still work; no behavior change, the regex was already updated in PR #100 round 5
- [ ] Delete a saved session name via the UI while the server is down or returning 500 — UI should now leave the row in place instead of silently removing it (optimistic filter bug fixed as a side effect)
- [ ] \`PLAYWRIGHT_BASE_URL=https://cpc.claude.do/dev/ npx playwright test\` — should error at config load with a helpful message (regression prevention)

## Scope discipline
Touched only the 4 files flagged by Copilot. No scope creep. The \`ActionBar.tsx\` caller still has an empty \`catch {}\` which silently swallows the delete error — that's a UX polish opportunity but not a new bug introduced here, and is explicitly out of scope for this sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)