### PR TITLE
feat(tabs): restore tab underline swipe animation (closes #102)

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -12,6 +12,78 @@ type Tab = "terminal" | "files" | "links" | "voice";
 const TABS: Tab[] = ["terminal", "files", "links", "voice"];
 const SWIPE_THRESHOLD = 120;
 
+// Moving blue underline indicator that tracks the active tab and follows
+// swipe progress in real time. Replaces the per-button static borderBottom.
+// See plan: ~/claudes-world/tmp/20260408-issue-102-tab-underline-plan.md
+function TabUnderline({
+  tabRefs,
+  activeIdx,
+  dragOffset,
+  isAnimating,
+}: {
+  tabRefs: React.RefObject<(HTMLButtonElement | null)[]>;
+  activeIdx: number;
+  dragOffset: number;
+  isAnimating: boolean;
+}) {
+  const [geom, setGeom] = useState<{ left: number; width: number }[]>([]);
+
+  // Measure tab button positions after mount and on window resize.
+  // Refs are populated during commit, so the first measure() runs with
+  // valid DOM nodes.
+  useEffect(() => {
+    const measure = () => {
+      const buttons = tabRefs.current ?? [];
+      const rects = buttons.map((b) => {
+        if (!b) return { left: 0, width: 0 };
+        return { left: b.offsetLeft, width: b.offsetWidth };
+      });
+      setGeom(rects);
+    };
+    measure();
+    window.addEventListener("resize", measure);
+    return () => window.removeEventListener("resize", measure);
+  }, [tabRefs]);
+
+  if (geom.length === 0 || !geom[activeIdx]) return null;
+
+  // dragOffset is raw finger-delta pixels: negative dx = finger moved left
+  // = content strip advances to the NEXT tab = indicator should move right.
+  // One full-viewport swipe == one tab of progress, so normalize by viewport.
+  const viewportWidth = window.innerWidth || 375;
+  const dragFraction = -dragOffset / viewportWidth;
+  // Clamp to neighbor range so rubber-banded over-swipe at edges doesn't
+  // slingshot the indicator off the tab bar.
+  const clampedFraction = Math.max(-1, Math.min(1, dragFraction));
+
+  const targetFloat = activeIdx + clampedFraction;
+  const leftIdx = Math.max(0, Math.min(TABS.length - 1, Math.floor(targetFloat)));
+  const rightIdx = Math.max(0, Math.min(TABS.length - 1, Math.ceil(targetFloat)));
+  const t = targetFloat - leftIdx; // 0..1 interpolation weight
+
+  const leftGeom = geom[leftIdx] ?? geom[activeIdx];
+  const rightGeom = geom[rightIdx] ?? geom[activeIdx];
+
+  const interpLeft = leftGeom.left + (rightGeom.left - leftGeom.left) * t;
+  const interpWidth = leftGeom.width + (rightGeom.width - leftGeom.width) * t;
+
+  return (
+    <div
+      style={{
+        position: "absolute",
+        bottom: 0,
+        left: 0,
+        width: interpWidth,
+        height: 2,
+        background: "#7aa2f7",
+        transform: `translateX(${interpLeft}px)`,
+        transition: isAnimating ? "transform 300ms ease-out, width 300ms ease-out" : "none",
+        pointerEvents: "none",
+      }}
+    />
+  );
+}
+
 const SORT_KEY = "cpc-file-sort-mode";
 const HIDDEN_KEY = "cpc-file-show-hidden";
 const VALID_SORTS: SortMode[] = ["name-asc", "name-desc", "date-asc", "date-desc"];
@@ -60,6 +132,10 @@ export function App() {
   const isDragging = useRef(false);
   const [dragOffset, setDragOffset] = useState(0);
   const [isAnimating, setIsAnimating] = useState(false);
+
+  // Refs to each tab button so the moving underline can measure
+  // variable-width tab labels.
+  const tabRefs = useRef<(HTMLButtonElement | null)[]>([]);
 
   const activeIdx = TABS.indexOf(activeTab);
 
@@ -220,11 +296,12 @@ export function App() {
         }}
         onTouchStart={(e) => e.stopPropagation()}
       >
-        <div style={{ display: "flex", gap: 0 }}>
-          {TABS.map((tab) => (
+        <div style={{ display: "flex", gap: 0, position: "relative" }}>
+          {TABS.map((tab, i) => (
             <button
+              ref={(el) => { tabRefs.current[i] = el; }}
               key={tab}
-              onClick={() => setActiveTab(tab)}
+              onClick={() => { setIsAnimating(true); setActiveTab(tab); }}
               style={{
                 padding: "8px 14px",
                 fontSize: 13,
@@ -232,7 +309,7 @@ export function App() {
                 background: "none",
                 color: activeTab === tab ? "#c0caf5" : "#565f89",
                 border: "none",
-                borderBottom: activeTab === tab ? "2px solid #7aa2f7" : "2px solid transparent",
+                // borderBottom removed — moving indicator below replaces it
                 cursor: "pointer",
                 textTransform: "capitalize",
               }}
@@ -240,6 +317,12 @@ export function App() {
               {tab}
             </button>
           ))}
+          <TabUnderline
+            tabRefs={tabRefs}
+            activeIdx={activeIdx}
+            dragOffset={dragOffset}
+            isAnimating={isAnimating}
+          />
         </div>
         <span
           style={{


### PR DESCRIPTION
## Summary
Closes #102. Restores the blue tab underline that tracks the swipe between tabs in real time — a feature Liam confirmed existed before a pre-gitflow recovery period and was lost along the way.

## Implementation
- New `TabUnderline` component rendered as an absolutely-positioned div inside the tab-bar wrapper (wrapper gets `position: relative`)
- Refs array captures each tab button's DOM node so the indicator can measure variable label widths via `offsetLeft` + `offsetWidth`
- `translateX` and `width` are linearly interpolated from `(activeIdx + (-dragOffset / window.innerWidth))`, clamped to `[-1, +1]` so rubber-banded over-swipe at edges doesn't slingshot the indicator
- CSS `transition: transform 300ms ease-out, width 300ms ease-out` (only while `isAnimating`) for smooth snap on swipe release and tab-tap
- Removes the static per-button `borderBottom` on active (replaced by the indicator)
- Tab `onClick` now also sets `isAnimating(true)` so a direct tab tap glides the indicator instead of hard-jumping

## Files touched
- `apps/web/src/App.tsx` only (+87 / -4)

## Based on
- Planner doc: `~/claudes-world/tmp/20260408-issue-102-tab-underline-plan.md`

## Local swarm
- Codex: no verdict — timed out reading on-disk files instead of the piped diff
- Gemini flash: flagged a false positive re: `isAnimating` lifecycle (missed that `handleTouchStart` already calls `setIsAnimating(false)`, and the existing `onTransitionEnd` on the content strip clears it after click-driven animations). Manually traced the state machine and confirmed correct
- Build: `pnpm run build` green

## Test plan
- [ ] Open CPC mini app on iPhone at cpc.claude.do/dev
- [ ] Swipe slowly from terminal -> files -> links -> voice -> (back) — confirm the blue underline follows the finger smoothly in both directions and interpolates width between narrow/wide tabs (terminal vs voice)
- [ ] Release mid-swipe below the 120px threshold — confirm underline snaps back to origin tab
- [ ] Tap a tab directly — confirm underline glides to it with the 300ms ease-out transition (not a hard jump)
- [ ] Attempt to swipe past terminal (first) and voice (last) — confirm underline rubber-bands and does not slingshot off the bar
- [ ] UAT pixel math: does the width match the actual tab width at rest? Does the position land exactly under each tab? Does the speed feel coupled to the content strip underneath? (If it feels too slow/fast, the `dragFraction` divisor can be tuned)

## Confidence
HIGH on implementation, MEDIUM on exact pixel math — needs phone-feel testing during UAT to tune the normalization against the content-strip behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)