### PR TITLE
Add Cursor Cloud specific instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,43 +129,4 @@ Read what you need for your current task. Start with the closest AGENTS.md.
 
 ## Cursor Cloud specific instructions
 
-### Quick reference
-
-| Task | Command |
-|---|---|
-| Install deps | `pnpm install` (from repo root) |
-| Build frontend | `pnpm --filter @cpc/web build` |
-| Build server | `pnpm --filter @cpc/server build` |
-| Run web tests | `pnpm --filter @cpc/web test` |
-| Run server tests | `pnpm --filter @cpc/server test` |
-| Dev server (backend) | `pnpm --filter @cpc/server dev` (port 38830) |
-| Dev server (frontend) | `pnpm --filter @cpc/web dev` (port 58830) |
-| TypeScript check | `tsc -b` in each app directory |
-
-### Secrets setup
-
-The server reads `~/.secrets/cpc.env` at startup via a custom `loadEnv()`.
-If the file is missing, the server still starts but auth-protected routes
-return 500 ("Not configured"). Public health endpoints work without secrets.
-
-For Cloud Agent VMs, create `~/.secrets/cpc.env` with at least a placeholder:
-```
-TELEGRAM_BOT_TOKEN=dev-placeholder-token
-ALLOWED_TELEGRAM_USERS=
-```
-
-The SQLite database auto-creates at `~/data/cpc-voice.db`; just ensure
-`~/data/` exists (`mkdir -p ~/data`).
-
-### Gotchas
-
-- No ESLint is configured; TypeScript compilation (`tsc -b`) is the
-  primary static check. `pnpm lint` (via turbo) is a no-op.
-- The Vite dev server uses `base: "/dev/"` so the local URL is
-  `http://127.0.0.1:58830/dev/` (not just `/`).
-- The Vite dev server proxies `/api` and `/ws` to the backend at port 38830,
-  so the backend must be running for API calls to succeed during frontend dev.
-- Outside Telegram WebView, the frontend shows an auth screen
-  ("Telegram auth unavailable"). This is expected behavior.
-- `better-sqlite3` requires a native build step (handled by `pnpm install`
-  via `onlyBuiltDependencies` in `pnpm-workspace.yaml`).
+For Cursor Cloud agent setup, commands, and gotchas, read [docs/reference/cursor-cloud-agent-instructions.md](docs/reference/cursor-cloud-agent-instructions.md).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,3 +124,48 @@ Read what you need for your current task. Start with the closest AGENTS.md.
 | `~/bin/session-history` | Forensic CLI for JSONL session history (list, search, extract, diff) |
 | `~/bin/transcribe`   | Whisper-based audio transcription via OpenAI API        |
 | `/deploy` skill      | Build web, kill server, restart, verify health           |
+
+---
+
+## Cursor Cloud specific instructions
+
+### Quick reference
+
+| Task | Command |
+|---|---|
+| Install deps | `pnpm install` (from repo root) |
+| Build frontend | `pnpm --filter @cpc/web build` |
+| Build server | `pnpm --filter @cpc/server build` |
+| Run web tests | `pnpm --filter @cpc/web test` |
+| Run server tests | `pnpm --filter @cpc/server test` |
+| Dev server (backend) | `pnpm --filter @cpc/server dev` (port 38830) |
+| Dev server (frontend) | `pnpm --filter @cpc/web dev` (port 58830) |
+| TypeScript check | `tsc -b` in each app directory |
+
+### Secrets setup
+
+The server reads `~/.secrets/cpc.env` at startup via a custom `loadEnv()`.
+If the file is missing, the server still starts but auth-protected routes
+return 500 ("Not configured"). Public health endpoints work without secrets.
+
+For Cloud Agent VMs, create `~/.secrets/cpc.env` with at least a placeholder:
+```
+TELEGRAM_BOT_TOKEN=dev-placeholder-token
+ALLOWED_TELEGRAM_USERS=
+```
+
+The SQLite database auto-creates at `~/data/cpc-voice.db`; just ensure
+`~/data/` exists (`mkdir -p ~/data`).
+
+### Gotchas
+
+- No ESLint is configured; TypeScript compilation (`tsc -b`) is the
+  primary static check. `pnpm lint` (via turbo) is a no-op.
+- The Vite dev server uses `base: "/dev/"` so the local URL is
+  `http://127.0.0.1:58830/dev/` (not just `/`).
+- The Vite dev server proxies `/api` and `/ws` to the backend at port 38830,
+  so the backend must be running for API calls to succeed during frontend dev.
+- Outside Telegram WebView, the frontend shows an auth screen
+  ("Telegram auth unavailable"). This is expected behavior.
+- `better-sqlite3` requires a native build step (handled by `pnpm install`
+  via `onlyBuiltDependencies` in `pnpm-workspace.yaml`).

--- a/docs/reference/cursor-cloud-agent-instructions.md
+++ b/docs/reference/cursor-cloud-agent-instructions.md
@@ -1,0 +1,44 @@
+# Cursor Cloud agent instructions
+
+These instructions apply specifically to Cursor Cloud Agent environments.
+
+## Quick reference
+
+| Task | Command |
+|---|---|
+| Install deps | `pnpm install` (from repo root) |
+| Build frontend | `pnpm --filter @cpc/web build` |
+| Build server | `pnpm --filter @cpc/server build` |
+| Run web tests | `pnpm --filter @cpc/web test` |
+| Run server tests | `pnpm --filter @cpc/server test` |
+| Dev server (backend) | `pnpm --filter @cpc/server dev` (port 38830) |
+| Dev server (frontend) | `pnpm --filter @cpc/web dev` (port 58830) |
+| TypeScript check | `tsc -b` in each app directory |
+
+## Secrets setup
+
+The server reads `~/.secrets/cpc.env` at startup via a custom `loadEnv()`.
+If the file is missing, the server still starts but auth-protected routes
+return 500 ("Not configured"). Public health endpoints work without secrets.
+
+For Cloud Agent VMs, create `~/.secrets/cpc.env` with at least a placeholder:
+```
+TELEGRAM_BOT_TOKEN=dev-placeholder-token
+ALLOWED_TELEGRAM_USERS=
+```
+
+The SQLite database auto-creates at `~/data/cpc-voice.db`; just ensure
+`~/data/` exists (`mkdir -p ~/data`).
+
+## Gotchas
+
+- No ESLint is configured; TypeScript compilation (`tsc -b`) is the
+  primary static check. `pnpm lint` (via turbo) is a no-op.
+- The Vite dev server uses `base: "/dev/"` so the local URL is
+  `http://127.0.0.1:58830/dev/` (not just `/`).
+- The Vite dev server proxies `/api` and `/ws` to the backend at port 38830,
+  so the backend must be running for API calls to succeed during frontend dev.
+- Outside Telegram WebView, the frontend shows an auth screen
+  ("Telegram auth unavailable"). This is expected behavior.
+- `better-sqlite3` requires a native build step (handled by `pnpm install`
+  via `onlyBuiltDependencies` in `pnpm-workspace.yaml`).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` with:

- Quick-reference table for common dev commands (install, build, test, dev servers)
- Secrets setup guidance for Cloud Agent VMs (`~/.secrets/cpc.env` placeholder)
- Documented gotchas: no ESLint (tsc-only), Vite `/dev/` base path, proxy requirements, Telegram auth screen outside WebView, native `better-sqlite3` build

**Environment verification:**

[CPC frontend loaded in browser showing auth screen](https://cursor.com/agents/bc-baf5b01a-47cf-4d2b-96cb-0641053c8907/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcpc_frontend_loaded.webp)
[Health endpoint returning status ok](https://cursor.com/agents/bc-baf5b01a-47cf-4d2b-96cb-0641053c8907/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhealth_endpoint_ok.webp)

**Testing**
- `pnpm install` -- all 339 packages installed
- `pnpm --filter @cpc/web test` -- 41 tests passed (2 files)
- `pnpm --filter @cpc/server test` -- 21 tests passed (2 files)
- `pnpm --filter @cpc/web build` -- frontend built successfully
- `pnpm --filter @cpc/server build` -- server TypeScript compiled clean
- Server dev mode: health endpoint returns `{"status":"ok"}` on port 38830
- Vite dev server: frontend renders on port 58830 at `/dev/`

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-baf5b01a-47cf-4d2b-96cb-0641053c8907"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-baf5b01a-47cf-4d2b-96cb-0641053c8907"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

