### PR TITLE
fix(links): use BASE_URL prefix for app tile icons (dev mode)

### DIFF
--- a/apps/web/src/components/Links.tsx
+++ b/apps/web/src/components/Links.tsx
@@ -42,14 +42,14 @@ const APPS: AppItem[] = [
     id: "companion",
     name: "Companion",
     url: "https://companion.claude.do",
-    iconSrc: "/apps/companion-512.png",
+    iconSrc: `${import.meta.env.BASE_URL}apps/companion-512.png`,
     fallbackEmoji: "🦆",
   },
   {
     id: "t3",
     name: "T3",
     url: "https://t3.claude.do",
-    iconSrc: "/apps/t3-blueprint-256.png",
+    iconSrc: `${import.meta.env.BASE_URL}apps/t3-blueprint-256.png`,
     fallbackEmoji: "🌀",
   },
 ];

--- a/apps/web/src/vite-env.d.ts
+++ b/apps/web/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />


### PR DESCRIPTION
## Summary

Fixes the T3 blueprint icon falling back to the 🌀 emoji in the dev app (`cpc.claude.do/dev/`). Root cause: absolute string-literal paths in JSX `src` attributes are not rewritten by Vite's `base` config — only explicit `import` statements are. So `iconSrc: "/apps/t3-blueprint-256.png"` resolved to the host root at runtime, hit the prod Caddy handler (older v1.8.0 dist that doesn't have the new blueprint asset) and returned 404, triggering the `onError` fallback emoji.

## The fix

- `apps/web/src/components/Links.tsx`: two iconSrc values now use `` `${import.meta.env.BASE_URL}apps/...` `` template literals so Vite substitutes the base at build time. Prod rendering is byte-identical to current behavior; only dev mode is fixed.
- `apps/web/src/vite-env.d.ts`: new file with the standard Vite client type reference. This was missing from the scaffolding, so without it, tsc didn't know `import.meta.env.BASE_URL` existed. Single line, no runtime impact.

## Verification

```sh
# Before fix — hit the prod handler:
curl https://cpc.claude.do/apps/t3-blueprint-256.png  # 404

# After fix in dev mode — hits the dev handler:
curl https://cpc.claude.do/dev/apps/t3-blueprint-256.png  # 200, 120859 bytes
```

TypeScript clean: `pnpm -C apps/web exec tsc --noEmit` exits 0.

## Why the 5-tier swarm on PR #103 missed this

All reviewers tested prod mode (base `/`), where the absolute path was correct. The bug is dev-only and disappears once v1.9.0 deploys to prod (because the new file will exist at `/apps/...` in the built dist). But it's blocking UAT on the dev URL right now.

## Unblocks

- v1.9.0 RC UAT (PR #106) — T3 blueprint icon now renders correctly in dev

## Test plan

- [x] Verified diff matches the intended 2-line change
- [x] TypeScript check passes (`pnpm -C apps/web exec tsc --noEmit`)
- [ ] Manual UAT on `https://cpc.claude.do/dev/` — Liam to confirm T3 tile shows blueprint icon, not 🌀 fallback
- [ ] Companion tile icon still renders (using the same pattern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)