### PR TITLE
fix(links): remove squircle tile shape + border

### DIFF
--- a/apps/web/src/components/Links.tsx
+++ b/apps/web/src/components/Links.tsx
@@ -54,57 +54,12 @@ const APPS: AppItem[] = [
   },
 ];
 
-// True iOS squircle (superellipse) as inline SVG mask.
-// Used as the @supports-not fallback below the CSS `corner-shape: squircle` primary path.
-// The SVG is URL-encoded via encodeURIComponent for cross-browser safety (spaces, <, >,
-// quotes parse inconsistently in some WebViews). The non-standard `;utf8` parameter is
-// intentionally dropped — it's not in the data URI spec and the encoded form works
-// without it.
-const SQUIRCLE_SVG =
-  `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><path d="M 50,0 C 10,0 0,10 0,50 0,90 10,100 50,100 90,100 100,90 100,50 100,10 90,0 50,0 Z"/></svg>`;
-const SQUIRCLE_MASK = `url("data:image/svg+xml,${encodeURIComponent(SQUIRCLE_SVG)}")`;
-
-// Squircle technique: tiered fallback chain driven by @supports.
-// Layer 1 (primary): CSS `corner-shape: squircle` + `border-radius: 22%` — native true
-//   squircle available in Safari 26+ (2025) and Chrome 130+ (late 2025). Telegram iOS
-//   WebView wraps WKWebView and inherits Safari's support.
-// Layer 2 (fallback): mask-image with an inline SVG superellipse path for browsers that
-//   do not yet implement `corner-shape` but do support CSS masks. Indistinguishable from
-//   Layer 1 at 64px. Gated with a nested @supports (mask-image) check so browsers that
-//   lack BOTH corner-shape AND mask-image still keep the base border-radius fallback.
-// Layer 3 (graceful): bare `border-radius: 22%` rounded rect — the base rule, inherited
-//   by everything that doesn't get upgraded by Layer 1 or Layer 2. When Layer 2 kicks in
-//   (mask-supported branch) the nested @supports zeros out the base border-radius so the
-//   masked superellipse isn't visually layered on a rounded rect — the mask defines the
-//   entire shape for those browsers.
-// See https://developer.mozilla.org/en-US/docs/Web/CSS/corner-shape
 const TILE_STYLE = `
   .cpc-app-tile {
     transition: transform 120ms ease-out;
   }
   .cpc-app-tile:active {
     transform: scale(0.92);
-  }
-  .cpc-app-squircle {
-    border-radius: 22%;
-    corner-shape: squircle;
-  }
-  @supports not (corner-shape: squircle) {
-    @supports (mask-image: url(#x)) or (-webkit-mask-image: url(#x)) {
-      .cpc-app-squircle {
-        /* Zero out border-radius inside the mask branch so the masked
-           superellipse is not visually layered on a standard rounded rect.
-           The base rule above (border-radius: 22%) still applies to Layer 3
-           browsers that lack both corner-shape AND mask-image. */
-        border-radius: 0;
-        -webkit-mask-image: ${SQUIRCLE_MASK};
-        mask-image: ${SQUIRCLE_MASK};
-        -webkit-mask-size: 100% 100%;
-        mask-size: 100% 100%;
-        -webkit-mask-repeat: no-repeat;
-        mask-repeat: no-repeat;
-      }
-    }
   }
 `;
 
@@ -231,7 +186,6 @@ function AppTile({ app }: { app: AppItem }) {
       }}
     >
       <div
-        className="cpc-app-squircle"
         style={{
           width: 64,
           height: 64,

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -110,29 +110,3 @@ button:active:not(:disabled) {
     transition-duration: 0ms;
   }
 }
-
-/* ============================================================
-   App tile squircle edge definition (Links page)
-   ============================================================
-   The Companion app's green duck icon blends into the dark
-   #1a1b26 background because the squircle tile's own #1e1f2e
-   fill is barely one shade lighter. A subtle inset shadow
-   gives the tile a visible edge without drawing a hard border.
-
-   Why inset box-shadow (not border/outline): the .cpc-app-squircle
-   class uses corner-shape: squircle on modern browsers and
-   mask-image fallback on older ones. A CSS `border` on the
-   masked branch would render as the element's rectangular
-   bounding box, breaking the shape. `box-shadow: inset` paints
-   INSIDE the element's painted area and therefore follows the
-   clip/mask geometry on both primary and fallback paths.
-
-   rgba(192,202,245,0.14) is the Tokyo Night fg color at low
-   alpha — neutral-cool so it doesn't compete with icon colors.
-   Rule lives here (not in the injected <style> in Links.tsx)
-   so it's part of the global sheet alongside the other tokens.
-   ============================================================ */
-
-.cpc-app-squircle {
-  box-shadow: inset 0 0 0 1px rgba(192, 202, 245, 0.14);
-}


### PR DESCRIPTION
## Summary

Liam decided during UAT (after the icons started rendering correctly post-#118) that the squircle CSS on the Links page app tiles doesn't look good. The PNG icons already have their own rounded corners baked in — they don't need an outer mask shape layered over them. This PR removes the squircle treatment so app tiles are plain 64x64 containers and each icon's own baked-in corners show through.

Removing `.cpc-app-squircle` also removes the recently-added inset box-shadow border (#117) since that rule was scoped to the same class.

## Changes

- `apps/web/src/components/Links.tsx`
  - Delete the `.cpc-app-squircle` CSS block + `@supports not (corner-shape: squircle)` mask-image fallback from the injected `TILE_STYLE` template literal
  - Delete the now-unused `SQUIRCLE_SVG` + `SQUIRCLE_MASK` constants and the explanatory comment blocks above them
  - Remove `className="cpc-app-squircle"` from the `AppTile` wrapper `<div>`
- `apps/web/src/index.css`
  - Delete the `.cpc-app-squircle { box-shadow: inset ... }` rule and its explanatory comment block

Net: 72 deletions, 0 additions. `.cpc-app-tile` transition/active rules are untouched.

## Why

Unblocks the visual look Liam wants for the Links page. The squircle was added speculatively assuming the PNGs were raw squares — now that the real icons are in place, the double-rounding (PNG corners + CSS mask) looked off.

## Verification

- `grep -rn "cpc-app-squircle" apps/web/src/` → 0 matches
- `pnpm exec tsc --noEmit` → exit 0
- `git diff` reviewed — pure deletions, no orphan braces or fragments

## Test plan

- [ ] Visual UAT on dev branch after merge + deploy: Links page app tiles render as plain 64x64 containers, icons keep their baked-in rounded corners, no double-rounding, no outer border