### PR TITLE
fix(file-viewer): isolate header touches from tab-swipe gesture

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -623,7 +623,11 @@ export function FileViewer({ onClose, initialFile, showHidden = false, sortMode 
           `4px 8px` so the 44px button heights don't grow the header
           visibly — with box-sizing: border-box the 44px floor already
           absorbs the padding, and the buttons themselves still read as
-          inline icons. */}
+          inline icons. The header also stops touch propagation because
+          the FileViewer lives inside the app-wide swipeable tab viewport;
+          otherwise small tap drift on these buttons can be interpreted as
+          a tab swipe and make the controls feel hard to press even when
+          their DOM boxes are 44x44. */}
       <div
         style={{
           padding: "4px 8px",
@@ -636,6 +640,9 @@ export function FileViewer({ onClose, initialFile, showHidden = false, sortMode 
           maxWidth: "100%",
           overflow: "hidden",
         }}
+        onTouchStart={(e) => e.stopPropagation()}
+        onTouchMove={(e) => e.stopPropagation()}
+        onTouchEnd={(e) => e.stopPropagation()}
       >
         {/* Back/Up button. When viewing a file it goes back to the
             directory listing; when in a directory with a parent it goes


### PR DESCRIPTION
Fixes 'back/download buttons too hard to press' UAT report. Root cause is NOT button size (PR #99 already enforced 44x44) but gesture competition with the swipeable tab viewport in App.tsx. See plan: `tmp/20260410-v1.9.1-tap-targets-fix-plan.md`. Three onTouch handlers added to the header div, same pattern as AppHeader/ActionBar. Reported by Liam during v1.9.0 UAT.