### PR TITLE
fix(tldr): in-flight guard for duplicate generation requests

### DIFF
--- a/apps/web/src/components/action-bar/ActionBar.tsx
+++ b/apps/web/src/components/action-bar/ActionBar.tsx
@@ -54,6 +54,7 @@ export function ActionBar({ onReconnect, connected, activeTab, fileShowHidden, s
   searchScopeRef.current = searchCurrentFolderOnly && currentFolder ? currentFolder : null;
   const [audioStatus, setAudioStatus] = useState<AudioStatus | null>(null);
   const [audioLoading, setAudioLoading] = useState(false);
+  const [audioOp, setAudioOp] = useState<"idle" | "checking" | "generating" | "sending">("idle");
   // Synchronous in-flight guard for audio generation/send. Mirrors the
   // TldrModal pattern (PR #121): React hasn't necessarily committed
   // setAudioLoading(true) by the time a fast double-tap fires the second
@@ -199,11 +200,12 @@ export function ActionBar({ onReconnect, connected, activeTab, fileShowHidden, s
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [searchCurrentFolderOnly, currentFolder, modal]);
 
-  const handleCheckAudio = async (filePath: string) => { setAudioStatus(null); setAudioLoading(true); try { setAudioStatus(await checkAudio(filePath)); } catch { setAudioStatus(null); } setAudioLoading(false); };
+  const handleCheckAudio = async (filePath: string) => { setAudioStatus(null); setAudioLoading(true); setAudioOp("checking"); try { setAudioStatus(await checkAudio(filePath)); } catch { setAudioStatus(null); } finally { setAudioOp("idle"); setAudioLoading(false); } };
   const handleGenerateAudio = async (filePath: string) => {
     if (audioInFlightRef.current) return;
     audioInFlightRef.current = true;
     setAudioLoading(true);
+    setAudioOp("generating");
     setStatus("Generating audio...");
     try {
       const controller = new AbortController();
@@ -221,6 +223,7 @@ export function ActionBar({ onReconnect, connected, activeTab, fileShowHidden, s
       setStatus(err instanceof DOMException && err.name === "AbortError" ? "Timed out" : `Error: ${err instanceof Error ? err.message : String(err)}`);
     } finally {
       audioInFlightRef.current = false;
+      setAudioOp("idle");
       setAudioLoading(false);
     }
   };
@@ -228,6 +231,7 @@ export function ActionBar({ onReconnect, connected, activeTab, fileShowHidden, s
     if (audioInFlightRef.current) return;
     audioInFlightRef.current = true;
     setAudioLoading(true);
+    setAudioOp("sending");
     setStatus("Sending to Telegram...");
     try {
       const controller = new AbortController();
@@ -244,6 +248,7 @@ export function ActionBar({ onReconnect, connected, activeTab, fileShowHidden, s
       setStatus(err instanceof DOMException && err.name === "AbortError" ? "Timed out" : `Error: ${err instanceof Error ? err.message : String(err)}`);
     } finally {
       audioInFlightRef.current = false;
+      setAudioOp("idle");
       setAudioLoading(false);
     }
   };
@@ -281,7 +286,7 @@ export function ActionBar({ onReconnect, connected, activeTab, fileShowHidden, s
     case "file-options": modalNode = <FileOptionsSheet fileShowHidden={fileShowHidden} fileSortMode={fileSortMode} setFileShowHidden={setFileShowHidden} setFileSortMode={setFileSortMode} onClose={() => setModal(null)} />; break;
     case "file-search": modalNode = <FileSearchSheet searchQuery={searchQuery} searchResults={searchResults} currentFolder={currentFolder ?? null} currentFolderOnly={searchCurrentFolderOnly} onToggleCurrentFolderOnly={setSearchCurrentFolderOnly} onClose={() => setModal(null)} onChange={handleSearchInput} onSelect={(result) => { setModal(null); window.location.hash = `files&file=${encodeURIComponent(result.path)}`; window.location.reload(); }} />; break;
     case "tldr": modalNode = viewingFile ? <TldrModal viewingFile={viewingFile} onClose={() => setModal(null)} /> : null; break;
-    case "audio-gen": modalNode = viewingFile ? <AudioGenModal viewingFile={viewingFile} audioLoading={audioLoading} audioStatus={audioStatus} onClose={() => setModal(null)} onGenerate={() => void handleGenerateAudio(viewingFile.path)} onSend={() => { if (audioStatus?.path) void handleSendAudio(audioStatus.path); }} /> : null; break;
+    case "audio-gen": modalNode = viewingFile ? <AudioGenModal viewingFile={viewingFile} audioLoading={audioLoading} audioOp={audioOp} audioStatus={audioStatus} onClose={() => setModal(null)} onGenerate={() => void handleGenerateAudio(viewingFile.path)} onSend={() => { if (audioStatus?.path) void handleSendAudio(audioStatus.path); }} /> : null; break;
   }
 
   return (

--- a/apps/web/src/components/action-bar/ActionBar.tsx
+++ b/apps/web/src/components/action-bar/ActionBar.tsx
@@ -54,6 +54,12 @@ export function ActionBar({ onReconnect, connected, activeTab, fileShowHidden, s
   searchScopeRef.current = searchCurrentFolderOnly && currentFolder ? currentFolder : null;
   const [audioStatus, setAudioStatus] = useState<AudioStatus | null>(null);
   const [audioLoading, setAudioLoading] = useState(false);
+  // Synchronous in-flight guard for audio generation/send. Mirrors the
+  // TldrModal pattern (PR #121): React hasn't necessarily committed
+  // setAudioLoading(true) by the time a fast double-tap fires the second
+  // click handler, so a ref-based lock is the only way to prevent two
+  // concurrent backend audio jobs racing each other.
+  const audioInFlightRef = useRef(false);
   const [gitBranch, setGitBranch] = useState<GitBranch | null>(null);
   const searchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const searchAbortRef = useRef<AbortController | null>(null);
@@ -195,6 +201,8 @@ export function ActionBar({ onReconnect, connected, activeTab, fileShowHidden, s
 
   const handleCheckAudio = async (filePath: string) => { setAudioStatus(null); setAudioLoading(true); try { setAudioStatus(await checkAudio(filePath)); } catch { setAudioStatus(null); } setAudioLoading(false); };
   const handleGenerateAudio = async (filePath: string) => {
+    if (audioInFlightRef.current) return;
+    audioInFlightRef.current = true;
     setAudioLoading(true);
     setStatus("Generating audio...");
     try {
@@ -212,10 +220,13 @@ export function ActionBar({ onReconnect, connected, activeTab, fileShowHidden, s
     } catch (err) {
       setStatus(err instanceof DOMException && err.name === "AbortError" ? "Timed out" : `Error: ${err instanceof Error ? err.message : String(err)}`);
     } finally {
+      audioInFlightRef.current = false;
       setAudioLoading(false);
     }
   };
   const handleSendAudio = async (audioPath: string) => {
+    if (audioInFlightRef.current) return;
+    audioInFlightRef.current = true;
     setAudioLoading(true);
     setStatus("Sending to Telegram...");
     try {
@@ -232,6 +243,7 @@ export function ActionBar({ onReconnect, connected, activeTab, fileShowHidden, s
     } catch (err) {
       setStatus(err instanceof DOMException && err.name === "AbortError" ? "Timed out" : `Error: ${err instanceof Error ? err.message : String(err)}`);
     } finally {
+      audioInFlightRef.current = false;
       setAudioLoading(false);
     }
   };

--- a/apps/web/src/components/action-bar/AudioGenModal.tsx
+++ b/apps/web/src/components/action-bar/AudioGenModal.tsx
@@ -19,13 +19,13 @@ export function AudioGenModal({ viewingFile, audioLoading, audioStatus, onClose,
       ) : audioStatus?.exists ? (
         <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
           <div style={{ fontSize: 12, color: "#9ece6a", marginBottom: 4 }}>Audio file exists</div>
-          <button onClick={onSend} style={{ ...btnStyle, padding: "10px 14px", background: "#2d2a3a", color: "#bb9af7", border: "1px solid #4a3d6a" }}>Send to Telegram</button>
-          <button onClick={onGenerate} style={{ ...btnStyle, padding: "10px 14px" }}>Regenerate</button>
+          <button disabled={audioLoading} onClick={onSend} style={{ ...btnStyle, padding: "10px 14px", background: "#2d2a3a", color: "#bb9af7", border: "1px solid #4a3d6a" }}>Send to Telegram</button>
+          <button disabled={audioLoading} onClick={onGenerate} style={{ ...btnStyle, padding: "10px 14px" }}>Regenerate</button>
         </div>
       ) : (
         <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
           <div style={{ fontSize: 12, color: "#565f89", marginBottom: 4 }}>No audio file found</div>
-          <button onClick={onGenerate} style={{ ...btnStyle, padding: "10px 14px", background: "#2d2a3a", color: "#bb9af7", border: "1px solid #4a3d6a" }}>Generate Audio</button>
+          <button disabled={audioLoading} onClick={onGenerate} style={{ ...btnStyle, padding: "10px 14px", background: "#2d2a3a", color: "#bb9af7", border: "1px solid #4a3d6a" }}>Generate Audio</button>
         </div>
       )}
     </BottomSheet>

--- a/apps/web/src/components/action-bar/AudioGenModal.tsx
+++ b/apps/web/src/components/action-bar/AudioGenModal.tsx
@@ -2,35 +2,44 @@ import { BottomSheet } from "../BottomSheet";
 import { InProgressAnimation } from "./InProgressAnimation";
 import { btnStyle, type AudioStatus } from "./types";
 
+type AudioOp = "idle" | "checking" | "generating" | "sending";
+
+const AUDIO_OP_LABELS: Record<AudioOp, { label: string; hint?: string }> = {
+  idle: { label: "Loading…" },
+  checking: { label: "Checking for audio file…" },
+  generating: { label: "Generating audio…", hint: "typically 15-20 seconds" },
+  sending: { label: "Sending to Telegram…" },
+};
+
 interface AudioGenModalProps {
   viewingFile: { path: string; name: string };
   audioLoading: boolean;
+  audioOp: AudioOp;
   audioStatus: AudioStatus | null;
   onClose: () => void;
   onGenerate: () => void;
   onSend: () => void;
 }
 
-export function AudioGenModal({ viewingFile, audioLoading, audioStatus, onClose, onGenerate, onSend }: AudioGenModalProps) {
+export function AudioGenModal({ viewingFile, audioLoading, audioOp, audioStatus, onClose, onGenerate, onSend }: AudioGenModalProps) {
   return (
     <BottomSheet onClose={onClose} title="Audio">
       <div style={{ fontSize: 12, color: "#a9b1d6", marginBottom: 12 }}>{viewingFile.name}</div>
       {audioLoading ? (
         <InProgressAnimation
-          label="Generating audio…"
-          hint="typically 15-20 seconds"
-          ariaLabel="Generating audio"
+          {...AUDIO_OP_LABELS[audioOp]}
+          ariaLabel="Audio operation in progress"
         />
       ) : audioStatus?.exists ? (
         <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
           <div style={{ fontSize: 12, color: "#9ece6a", marginBottom: 4 }}>Audio file exists</div>
-          <button disabled={audioLoading} onClick={onSend} style={{ ...btnStyle, padding: "10px 14px", background: "#2d2a3a", color: "#bb9af7", border: "1px solid #4a3d6a" }}>Send to Telegram</button>
-          <button disabled={audioLoading} onClick={onGenerate} style={{ ...btnStyle, padding: "10px 14px" }}>Regenerate</button>
+          <button onClick={onSend} style={{ ...btnStyle, padding: "10px 14px", background: "#2d2a3a", color: "#bb9af7", border: "1px solid #4a3d6a" }}>Send to Telegram</button>
+          <button onClick={onGenerate} style={{ ...btnStyle, padding: "10px 14px" }}>Regenerate</button>
         </div>
       ) : (
         <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
           <div style={{ fontSize: 12, color: "#565f89", marginBottom: 4 }}>No audio file found</div>
-          <button disabled={audioLoading} onClick={onGenerate} style={{ ...btnStyle, padding: "10px 14px", background: "#2d2a3a", color: "#bb9af7", border: "1px solid #4a3d6a" }}>Generate Audio</button>
+          <button onClick={onGenerate} style={{ ...btnStyle, padding: "10px 14px", background: "#2d2a3a", color: "#bb9af7", border: "1px solid #4a3d6a" }}>Generate Audio</button>
         </div>
       )}
     </BottomSheet>

--- a/apps/web/src/components/action-bar/AudioGenModal.tsx
+++ b/apps/web/src/components/action-bar/AudioGenModal.tsx
@@ -1,4 +1,5 @@
 import { BottomSheet } from "../BottomSheet";
+import { InProgressAnimation } from "./InProgressAnimation";
 import { btnStyle, type AudioStatus } from "./types";
 
 interface AudioGenModalProps {
@@ -15,7 +16,11 @@ export function AudioGenModal({ viewingFile, audioLoading, audioStatus, onClose,
     <BottomSheet onClose={onClose} title="Audio">
       <div style={{ fontSize: 12, color: "#a9b1d6", marginBottom: 12 }}>{viewingFile.name}</div>
       {audioLoading ? (
-        <div style={{ fontSize: 13, color: "#565f89", padding: 16, textAlign: "center" }}>Loading...</div>
+        <InProgressAnimation
+          label="Generating audio…"
+          hint="typically 15-20 seconds"
+          ariaLabel="Generating audio"
+        />
       ) : audioStatus?.exists ? (
         <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
           <div style={{ fontSize: 12, color: "#9ece6a", marginBottom: 4 }}>Audio file exists</div>

--- a/apps/web/src/components/action-bar/InProgressAnimation.tsx
+++ b/apps/web/src/components/action-bar/InProgressAnimation.tsx
@@ -1,0 +1,94 @@
+interface InProgressAnimationProps {
+  /** Main label shown under the spinner (e.g. "Generating summary…"). */
+  label: string;
+  /** Optional smaller hint underneath (e.g. "typically 15-20 seconds"). */
+  hint?: string;
+  /** Accessible name for the role=status region. Defaults to `label`. */
+  ariaLabel?: string;
+}
+
+/**
+ * Loading animation shared across modals that wait on a slow LLM/backend
+ * call (TL;DR generation, audio generation). Pure CSS keyframes — no new
+ * deps. Three signals so the UI never looks frozen: (1) a rotating teal
+ * spinner, (2) a pulsing label, and (3) three bouncing dots. Tokyo Night
+ * palette: bg #1a1b26, text #c0caf5, accent #7dcfff. Honors
+ * `prefers-reduced-motion`.
+ */
+export function InProgressAnimation({ label, hint, ariaLabel }: InProgressAnimationProps) {
+  return (
+    <>
+      <style>{`
+        @keyframes inprogress-spin { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
+        @keyframes inprogress-pulse { 0%, 100% { opacity: 0.55; } 50% { opacity: 1; } }
+        @keyframes inprogress-bounce {
+          0%, 80%, 100% { transform: translateY(0); opacity: 0.35; }
+          40%           { transform: translateY(-4px); opacity: 1; }
+        }
+        @media (prefers-reduced-motion: reduce) {
+          [data-inprogress-spinner], [data-inprogress-label], [data-inprogress-dot] {
+            animation: none !important;
+          }
+          [data-inprogress-spinner] { border-top-color: #7dcfff; }
+          [data-inprogress-label]   { opacity: 1; }
+          [data-inprogress-dot]     { opacity: 0.9; }
+        }
+      `}</style>
+      <div
+        role="status"
+        aria-live="polite"
+        aria-label={ariaLabel ?? label}
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          justifyContent: "center",
+          gap: 12,
+          padding: "28px 16px",
+          minHeight: 140,
+        }}
+      >
+        <div
+          data-inprogress-spinner=""
+          aria-hidden="true"
+          style={{
+            width: 32,
+            height: 32,
+            borderRadius: "50%",
+            border: "3px solid #2a2b3d",
+            borderTopColor: "#7dcfff",
+            animation: "inprogress-spin 0.9s linear infinite",
+          }}
+        />
+        <div
+          data-inprogress-label=""
+          style={{
+            fontSize: 13,
+            color: "#c0caf5",
+            animation: "inprogress-pulse 1.6s ease-in-out infinite",
+          }}
+        >
+          {label}
+        </div>
+        <div aria-hidden="true" style={{ display: "flex", gap: 5 }}>
+          {[0, 0.15, 0.3].map((delay) => (
+            <span
+              key={delay}
+              data-inprogress-dot=""
+              style={{
+                width: 6,
+                height: 6,
+                borderRadius: "50%",
+                background: "#7dcfff",
+                animation: `inprogress-bounce 1.2s ease-in-out ${delay}s infinite`,
+              }}
+            />
+          ))}
+        </div>
+        {hint && (
+          <div style={{ fontSize: 11, color: "#a9b1d6" }}>{hint}</div>
+        )}
+      </div>
+    </>
+  );
+}

--- a/apps/web/src/components/action-bar/TldrModal.tsx
+++ b/apps/web/src/components/action-bar/TldrModal.tsx
@@ -49,7 +49,7 @@ export function TldrModal({ viewingFile, onClose }: TldrModalProps) {
     } finally {
       clearTimeout(timeout);
       if (abortRef.current === controller) abortRef.current = null;
-      if (abortRef.current === null) inFlightRef.current = false;
+      inFlightRef.current = false;
       if (requestIdRef.current === requestId) setLoading(false);
     }
   };

--- a/apps/web/src/components/action-bar/TldrModal.tsx
+++ b/apps/web/src/components/action-bar/TldrModal.tsx
@@ -18,9 +18,12 @@ export function TldrModal({ viewingFile, onClose }: TldrModalProps) {
   const [copyError, setCopyError] = useState<string | null>(null);
   const requestIdRef = useRef(0);
   const abortRef = useRef<AbortController | null>(null);
+  const inFlightRef = useRef(false);
   const copyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const generateTldr = async (filePath: string, force = false) => {
+    if (inFlightRef.current) return;
+    inFlightRef.current = true;
     const requestId = ++requestIdRef.current;
     abortRef.current?.abort();
     setLoading(true);
@@ -46,6 +49,7 @@ export function TldrModal({ viewingFile, onClose }: TldrModalProps) {
     } finally {
       clearTimeout(timeout);
       if (abortRef.current === controller) abortRef.current = null;
+      if (abortRef.current === null) inFlightRef.current = false;
       if (requestIdRef.current === requestId) setLoading(false);
     }
   };
@@ -68,6 +72,7 @@ export function TldrModal({ viewingFile, onClose }: TldrModalProps) {
         abortRef.current.abort();
         abortRef.current = null;
       }
+      inFlightRef.current = false;
     };
   }, [viewingFile.path]);
 
@@ -92,6 +97,7 @@ export function TldrModal({ viewingFile, onClose }: TldrModalProps) {
       abortRef.current.abort();
       abortRef.current = null;
     }
+    inFlightRef.current = false;
     requestIdRef.current++;
     setLoading(false);
     onClose();
@@ -184,7 +190,7 @@ export function TldrModal({ viewingFile, onClose }: TldrModalProps) {
       {!loading && error && (
         <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
           <div style={{ fontSize: 12, color: "#f7768e", padding: "8px 10px", background: "#2a1a22", border: "1px solid #4a2d3a", borderRadius: 6 }}>{error}</div>
-          <button onClick={() => void generateTldr(viewingFile.path)} style={{ ...btnStyle, padding: "10px 14px", background: "#1a3a3a", color: "#7dcfff", border: "1px solid #2d5a5a" }}>Retry</button>
+          <button disabled={loading} onClick={() => void generateTldr(viewingFile.path)} style={{ ...btnStyle, padding: "10px 14px", background: "#1a3a3a", color: "#7dcfff", border: "1px solid #2d5a5a" }}>Retry</button>
         </div>
       )}
       {!loading && !error && summary && (
@@ -208,7 +214,7 @@ export function TldrModal({ viewingFile, onClose }: TldrModalProps) {
           </div>
           <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
             <button onClick={copyTldr} style={{ ...btnStyle, padding: "10px 14px", background: "#1a3a3a", color: "#7dcfff", border: "1px solid #2d5a5a" }}>{copied ? "Copied" : "Copy"}</button>
-            <button onClick={() => void generateTldr(viewingFile.path, true)} style={{ ...btnStyle, padding: "10px 14px" }}>Regenerate</button>
+            <button disabled={loading} onClick={() => void generateTldr(viewingFile.path, true)} style={{ ...btnStyle, padding: "10px 14px" }}>Regenerate</button>
           </div>
           {copyError && <div style={{ fontSize: 11, color: "#f7768e", marginTop: 4 }}>{copyError}</div>}
         </div>

--- a/apps/web/src/components/action-bar/TldrModal.tsx
+++ b/apps/web/src/components/action-bar/TldrModal.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { BottomSheet } from "../BottomSheet";
 import { summarizeMarkdown } from "./api";
+import { InProgressAnimation } from "./InProgressAnimation";
 import { btnStyle } from "./types";
 
 interface TldrModalProps {
@@ -107,85 +108,11 @@ export function TldrModal({ viewingFile, onClose }: TldrModalProps) {
     <BottomSheet onClose={handleClose} title="TL;DR">
       <div style={{ fontSize: 12, color: "#a9b1d6", marginBottom: 12 }}>{viewingFile.name}</div>
       {loading && (
-        <>
-          {/* Loading animation for the 15-20s LLM generation window.
-              Pure CSS keyframes (no new deps). Three signals so the UI
-              never looks frozen: (1) a rotating teal spinner, (2) a
-              pulsing "Generating summary…" label, and (3) three
-              bouncing dots. Tokyo Night palette: bg #1a1b26, text
-              #c0caf5, accent #7dcfff. */}
-          <style>{`
-            @keyframes tldr-spin { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
-            @keyframes tldr-pulse { 0%, 100% { opacity: 0.55; } 50% { opacity: 1; } }
-            @keyframes tldr-bounce {
-              0%, 80%, 100% { transform: translateY(0); opacity: 0.35; }
-              40%           { transform: translateY(-4px); opacity: 1; }
-            }
-            @media (prefers-reduced-motion: reduce) {
-              [data-tldr-spinner], [data-tldr-label], [data-tldr-dot] {
-                animation: none !important;
-              }
-              [data-tldr-spinner] { border-top-color: #7dcfff; }
-              [data-tldr-label]   { opacity: 1; }
-              [data-tldr-dot]     { opacity: 0.9; }
-            }
-          `}</style>
-          <div
-            role="status"
-            aria-live="polite"
-            aria-label="Generating summary"
-            style={{
-              display: "flex",
-              flexDirection: "column",
-              alignItems: "center",
-              justifyContent: "center",
-              gap: 12,
-              padding: "28px 16px",
-              minHeight: 140,
-            }}
-          >
-            <div
-              data-tldr-spinner=""
-              aria-hidden="true"
-              style={{
-                width: 32,
-                height: 32,
-                borderRadius: "50%",
-                border: "3px solid #2a2b3d",
-                borderTopColor: "#7dcfff",
-                animation: "tldr-spin 0.9s linear infinite",
-              }}
-            />
-            <div
-              data-tldr-label=""
-              style={{
-                fontSize: 13,
-                color: "#c0caf5",
-                animation: "tldr-pulse 1.6s ease-in-out infinite",
-              }}
-            >
-              Generating summary…
-            </div>
-            <div aria-hidden="true" style={{ display: "flex", gap: 5 }}>
-              {[0, 0.15, 0.3].map((delay) => (
-                <span
-                  key={delay}
-                  data-tldr-dot=""
-                  style={{
-                    width: 6,
-                    height: 6,
-                    borderRadius: "50%",
-                    background: "#7dcfff",
-                    animation: `tldr-bounce 1.2s ease-in-out ${delay}s infinite`,
-                  }}
-                />
-              ))}
-            </div>
-            <div style={{ fontSize: 11, color: "#a9b1d6" }}>
-              typically 15-20 seconds
-            </div>
-          </div>
-        </>
+        <InProgressAnimation
+          label="Generating summary…"
+          hint="typically 15-20 seconds"
+          ariaLabel="Generating summary"
+        />
       )}
       {!loading && error && (
         <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>

--- a/apps/web/src/components/action-bar/TldrModal.tsx
+++ b/apps/web/src/components/action-bar/TldrModal.tsx
@@ -117,7 +117,7 @@ export function TldrModal({ viewingFile, onClose }: TldrModalProps) {
       {!loading && error && (
         <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
           <div style={{ fontSize: 12, color: "#f7768e", padding: "8px 10px", background: "#2a1a22", border: "1px solid #4a2d3a", borderRadius: 6 }}>{error}</div>
-          <button disabled={loading} onClick={() => void generateTldr(viewingFile.path)} style={{ ...btnStyle, padding: "10px 14px", background: "#1a3a3a", color: "#7dcfff", border: "1px solid #2d5a5a" }}>Retry</button>
+          <button onClick={() => void generateTldr(viewingFile.path)} style={{ ...btnStyle, padding: "10px 14px", background: "#1a3a3a", color: "#7dcfff", border: "1px solid #2d5a5a" }}>Retry</button>
         </div>
       )}
       {!loading && !error && summary && (
@@ -141,7 +141,7 @@ export function TldrModal({ viewingFile, onClose }: TldrModalProps) {
           </div>
           <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
             <button onClick={copyTldr} style={{ ...btnStyle, padding: "10px 14px", background: "#1a3a3a", color: "#7dcfff", border: "1px solid #2d5a5a" }}>{copied ? "Copied" : "Copy"}</button>
-            <button disabled={loading} onClick={() => void generateTldr(viewingFile.path, true)} style={{ ...btnStyle, padding: "10px 14px" }}>Regenerate</button>
+            <button onClick={() => void generateTldr(viewingFile.path, true)} style={{ ...btnStyle, padding: "10px 14px" }}>Regenerate</button>
           </div>
           {copyError && <div style={{ fontSize: 11, color: "#f7768e", marginTop: 4 }}>{copyError}</div>}
         </div>


### PR DESCRIPTION
Fixes duplicate TL;DR generation requests when the user double-taps Retry or Regenerate. See plan: `tmp/20260410-v1.9.1-tldr-debounce-fix-plan.md`. Implements the exact diff from the Recommended fix section: add inFlightRef synchronous lock + disabled={loading} on generation buttons. Reported by Liam during v1.9.0 UAT. Test plan: see plan doc verification section. Unblocks v1.9.1.