### PR TITLE
Follow-up: move Cursor Cloud agent details out of AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,43 +129,4 @@ Read what you need for your current task. Start with the closest AGENTS.md.
 
 ## Cursor Cloud specific instructions
 
-### Quick reference
-
-| Task | Command |
-|---|---|
-| Install deps | `pnpm install` (from repo root) |
-| Build frontend | `pnpm --filter @cpc/web build` |
-| Build server | `pnpm --filter @cpc/server build` |
-| Run web tests | `pnpm --filter @cpc/web test` |
-| Run server tests | `pnpm --filter @cpc/server test` |
-| Dev server (backend) | `pnpm --filter @cpc/server dev` (port 38830) |
-| Dev server (frontend) | `pnpm --filter @cpc/web dev` (port 58830) |
-| TypeScript check | `tsc -b` in each app directory |
-
-### Secrets setup
-
-The server reads `~/.secrets/cpc.env` at startup via a custom `loadEnv()`.
-If the file is missing, the server still starts but auth-protected routes
-return 500 ("Not configured"). Public health endpoints work without secrets.
-
-For Cloud Agent VMs, create `~/.secrets/cpc.env` with at least a placeholder:
-```
-TELEGRAM_BOT_TOKEN=dev-placeholder-token
-ALLOWED_TELEGRAM_USERS=
-```
-
-The SQLite database auto-creates at `~/data/cpc-voice.db`; just ensure
-`~/data/` exists (`mkdir -p ~/data`).
-
-### Gotchas
-
-- No ESLint is configured; TypeScript compilation (`tsc -b`) is the
-  primary static check. `pnpm lint` (via turbo) is a no-op.
-- The Vite dev server uses `base: "/dev/"` so the local URL is
-  `http://127.0.0.1:58830/dev/` (not just `/`).
-- The Vite dev server proxies `/api` and `/ws` to the backend at port 38830,
-  so the backend must be running for API calls to succeed during frontend dev.
-- Outside Telegram WebView, the frontend shows an auth screen
-  ("Telegram auth unavailable"). This is expected behavior.
-- `better-sqlite3` requires a native build step (handled by `pnpm install`
-  via `onlyBuiltDependencies` in `pnpm-workspace.yaml`).
+For Cursor Cloud agent setup, commands, and gotchas, read [docs/reference/cursor-cloud-agent-instructions.md](docs/reference/cursor-cloud-agent-instructions.md).

--- a/docs/reference/cursor-cloud-agent-instructions.md
+++ b/docs/reference/cursor-cloud-agent-instructions.md
@@ -1,0 +1,44 @@
+# Cursor Cloud agent instructions
+
+These instructions apply specifically to Cursor Cloud Agent environments.
+
+## Quick reference
+
+| Task | Command |
+|---|---|
+| Install deps | `pnpm install` (from repo root) |
+| Build frontend | `pnpm --filter @cpc/web build` |
+| Build server | `pnpm --filter @cpc/server build` |
+| Run web tests | `pnpm --filter @cpc/web test` |
+| Run server tests | `pnpm --filter @cpc/server test` |
+| Dev server (backend) | `pnpm --filter @cpc/server dev` (port 38830) |
+| Dev server (frontend) | `pnpm --filter @cpc/web dev` (port 58830) |
+| TypeScript check | `tsc -b` in each app directory |
+
+## Secrets setup
+
+The server reads `~/.secrets/cpc.env` at startup via a custom `loadEnv()`.
+If the file is missing, the server still starts but auth-protected routes
+return 500 ("Not configured"). Public health endpoints work without secrets.
+
+For Cloud Agent VMs, create `~/.secrets/cpc.env` with at least a placeholder:
+```
+TELEGRAM_BOT_TOKEN=dev-placeholder-token
+ALLOWED_TELEGRAM_USERS=
+```
+
+The SQLite database auto-creates at `~/data/cpc-voice.db`; just ensure
+`~/data/` exists (`mkdir -p ~/data`).
+
+## Gotchas
+
+- No ESLint is configured; TypeScript compilation (`tsc -b`) is the
+  primary static check. `pnpm lint` (via turbo) is a no-op.
+- The Vite dev server uses `base: "/dev/"` so the local URL is
+  `http://127.0.0.1:58830/dev/` (not just `/`).
+- The Vite dev server proxies `/api` and `/ws` to the backend at port 38830,
+  so the backend must be running for API calls to succeed during frontend dev.
+- Outside Telegram WebView, the frontend shows an auth screen
+  ("Telegram auth unavailable"). This is expected behavior.
+- `better-sqlite3` requires a native build step (handled by `pnpm install`
+  via `onlyBuiltDependencies` in `pnpm-workspace.yaml`).


### PR DESCRIPTION
### Motivation
- Reduce clutter in `AGENTS.md` for non-Cursor agents by moving Cursor Cloud environment-specific instructions into a dedicated reference document so Cursor Cloud agents still have a clear place to find their setup notes.

### Description
- Add `docs/reference/cursor-cloud-agent-instructions.md` containing the quick-reference commands, secrets setup guidance, and Cursor Cloud gotchas.
- Replace the detailed Cursor Cloud section in `AGENTS.md` with the header `## Cursor Cloud specific instructions` and a one-line pointer to the new document.

### Testing
- This is a documentation-only refactor; no automated unit or integration tests were required or run.
- Verified the updated files and contents using `sed -n '1,260p' AGENTS.md` and `nl`/`sed` on `docs/reference/cursor-cloud-agent-instructions.md`, and the outputs matched the intended changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d844918db0832785f0260e6a223b12)