### PR TITLE
chore(docs): integrate Cursor Cloud doc into Progressive Discovery Index

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,9 @@ Read what you need for your current task. Start with the closest AGENTS.md.
 - [Telegram WebView Rules](docs/reference/telegram-webview-rules.md) -- platform constraints
 - [Modal System](docs/reference/modal-system.md) -- ActionBar modals and BottomSheet
 
+### Environment setup (CI / cloud agents)
+- [Cursor Cloud Agent Instructions](docs/reference/cursor-cloud-agent-instructions.md) -- CI/cloud-agent VM setup, secrets, gotchas
+
 ### Guides (how to do things)
 - [Adding a Modal](docs/guides/adding-a-modal.md) -- step-by-step checklist
 - [Deploying](docs/guides/deploying.md) -- build, restart, verify
@@ -124,9 +127,3 @@ Read what you need for your current task. Start with the closest AGENTS.md.
 | `~/bin/session-history` | Forensic CLI for JSONL session history (list, search, extract, diff) |
 | `~/bin/transcribe`   | Whisper-based audio transcription via OpenAI API        |
 | `/deploy` skill      | Build web, kill server, restart, verify health           |
-
----
-
-## Cursor Cloud specific instructions
-
-For Cursor Cloud agent setup, commands, and gotchas, read [docs/reference/cursor-cloud-agent-instructions.md](docs/reference/cursor-cloud-agent-instructions.md).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,7 +81,7 @@ Read what you need for your current task. Start with the closest AGENTS.md.
 - [Telegram WebView Rules](docs/reference/telegram-webview-rules.md) -- platform constraints
 - [Modal System](docs/reference/modal-system.md) -- ActionBar modals and BottomSheet
 
-### Environment setup (CI / cloud agents)
+### Environment Setup (CI / cloud agents)
 - [Cursor Cloud Agent Instructions](docs/reference/cursor-cloud-agent-instructions.md) -- CI/cloud-agent VM setup, secrets, gotchas
 
 ### Guides (how to do things)

--- a/docs/reference/cursor-cloud-agent-instructions.md
+++ b/docs/reference/cursor-cloud-agent-instructions.md
@@ -1,4 +1,4 @@
-# Cursor Cloud agent instructions
+# Cursor Cloud Agent Instructions
 
 These instructions apply specifically to Cursor Cloud Agent environments.
 


### PR DESCRIPTION
Polish follow-up to merged PR #116 (Cursor Cloud instructions). Docs only, no code changes.

## Fixes

1. **Integrated into Progressive Discovery Index.** Added a new "Environment setup (CI / cloud agents)" sub-list under section 4 with a bullet linking to `docs/reference/cursor-cloud-agent-instructions.md`. This makes the doc discoverable from the canonical index instead of being an unnumbered append.

2. **Removed the ad-hoc bottom section.** The `## Cursor Cloud specific instructions` block at the end of `AGENTS.md` broke the numbered section convention (1-6) and was redundant once the link moved into the Progressive Discovery Index. Deleted it rather than renumbering, since it only contained a single sentence that now lives in fix #1.

3. **Title case on the doc's H1.** Changed `# Cursor Cloud agent instructions` to `# Cursor Cloud Agent Instructions` to match the Title Case convention used by other reference docs ("Architecture", "Telegram WebView Rules", "Modal System").

## Scope

- Only `AGENTS.md` and `docs/reference/cursor-cloud-agent-instructions.md` touched.
- No code changes, no content rewrites in the cursor-cloud doc beyond the H1.