### PR TITLE
fix(file-viewer): move horizontal scroll axis from MarkdownViewer shell

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -753,7 +753,15 @@ export function FileViewer({ onClose, initialFile, showHidden = false, sortMode 
 
       {/* File content view */}
       {fileContent !== null && !loading && fileName.endsWith(".md") && (
-        <div style={{ flex: 1, overflow: "auto", overflowX: "hidden" }}>
+        <div
+          style={{
+            flex: 1,
+            overflow: "auto",
+            overflowX: "hidden",
+            minWidth: 0,
+            boxSizing: "border-box",
+          }}
+        >
           <MarkdownViewer content={fileContent} fileName={fileName} />
         </div>
       )}

--- a/apps/web/src/components/MarkdownViewer.tsx
+++ b/apps/web/src/components/MarkdownViewer.tsx
@@ -29,7 +29,7 @@ export function MarkdownViewer({ content, fileName: _fileName }: MarkdownViewerP
     if (!container) return;
 
     container.querySelectorAll<HTMLTableElement>("table").forEach((table) => {
-      if (table.parentElement?.classList.contains("md-table-scroll")) return;
+      if (table.closest(".md-table-scroll")) return;
 
       const wrapper = document.createElement("div");
       wrapper.className = "md-table-scroll";

--- a/apps/web/src/components/MarkdownViewer.tsx
+++ b/apps/web/src/components/MarkdownViewer.tsx
@@ -21,12 +21,22 @@ export function MarkdownViewer({ content, fileName: _fileName }: MarkdownViewerP
 
   const contentRef = useRef<HTMLDivElement | null>(null);
 
-  // After marked renders the HTML, find any ```mermaid code blocks and
-  // replace them with a React-rendered MermaidDiagram component. We track
-  // each root we create so we can unmount them on cleanup to avoid leaks.
+  // After marked renders the HTML, add local scroll wrappers for tables, then
+  // replace ```mermaid code blocks with React-rendered MermaidDiagram nodes.
+  // We track each root we create so cleanup can unmount it without leaks.
   useEffect(() => {
     const container = contentRef.current;
     if (!container) return;
+
+    container.querySelectorAll<HTMLTableElement>("table").forEach((table) => {
+      if (table.parentElement?.classList.contains("md-table-scroll")) return;
+
+      const wrapper = document.createElement("div");
+      wrapper.className = "md-table-scroll";
+      wrapper.dataset.wrapped = "true";
+      table.parentNode?.insertBefore(wrapper, table);
+      wrapper.appendChild(table);
+    });
 
     const codeBlocks = container.querySelectorAll<HTMLElement>(
       "code.language-mermaid"
@@ -65,13 +75,17 @@ export function MarkdownViewer({ content, fileName: _fileName }: MarkdownViewerP
 
   return (
     <div
+      className="md-viewer-scroll"
       style={{
         padding: "16px 16px",
         overflowY: "auto",
-        overflowX: "auto",
+        // X-axis scroll lives in semantic child scrollers (<pre>, .md-table-scroll, .mermaid-container), not on the shell itself.
+        overflowX: "hidden",
         height: "100%",
         width: "100%",
         maxWidth: "100%",
+        minWidth: 0,
+        boxSizing: "border-box",
       }}
     >
       <style>{`
@@ -82,7 +96,9 @@ export function MarkdownViewer({ content, fileName: _fileName }: MarkdownViewerP
           color: #c0caf5;
           overflow-wrap: break-word;
           word-break: break-word;
+          width: 100%;
           max-width: 100%;
+          box-sizing: border-box;
         }
         .md-content * {
           max-width: 100%;
@@ -136,6 +152,9 @@ export function MarkdownViewer({ content, fileName: _fileName }: MarkdownViewerP
           overflow-x: auto;
           -webkit-overflow-scrolling: touch;
           margin: 12px 0;
+          width: 100%;
+          max-width: 100%;
+          box-sizing: border-box;
         }
         .md-content pre code {
           background: none;
@@ -149,12 +168,20 @@ export function MarkdownViewer({ content, fileName: _fileName }: MarkdownViewerP
           white-space: pre;
           max-width: none;
         }
-        .md-content table {
-          display: block;
-          overflow-x: auto;
+        .md-content .md-table-scroll {
           width: 100%;
-          border-collapse: collapse;
+          max-width: 100%;
+          overflow-x: auto;
+          -webkit-overflow-scrolling: touch;
+          box-sizing: border-box;
           margin: 12px 0;
+        }
+        .md-content table {
+          width: max-content;
+          min-width: 100%;
+          max-width: none;
+          border-collapse: collapse;
+          margin: 0;
           font-size: 13px;
         }
         .md-content th {


### PR DESCRIPTION
## Summary

v1.9.1 fix for the file viewer horizontal scroll bug Liam reported during the v1.9.0 UAT. PR #104 attempted a band-aid by setting `overflowX: hidden` on the FileViewer markdown branch wrapper. Liam (correctly) called that a footgun: it masks the symptom at the wrong layer instead of fixing the structural issue.

This PR moves the X-axis scroll responsibility from the `MarkdownViewer` outer shell down into semantic children that *intentionally* need horizontal overflow:

- Code blocks inside `<pre>` (preserves PR #20 behavior — wide code lines scroll inside their own pre)
- Wide tables wrapped in `<div class="md-table-scroll">` (new — idempotent useEffect post-processes the rendered markdown to wrap raw `<table>` elements)
- Mermaid diagrams (already self-contained scrollers, untouched)

The MarkdownViewer outer shell becomes a strict Y-only scroller. The FileViewer markdown branch wrapper keeps `overflowX: hidden` as a defense-in-depth containment assertion (not the primary fix).

## Plan + DA

- Plan: `tmp/20260410-v1.9.1-hscroll-fix-plan.md`
- DA: `tmp/codex-da-hscroll-raw.txt` — verdict was BUILD-WITH-AMENDMENTS, all amendments applied (deliberate `overflowX:hidden` on shell with comment, `md-viewer-scroll` testability hook, structural table CSS, `pre` containment treated as assertion not main fix)

## Files changed

- `apps/web/src/components/MarkdownViewer.tsx` (+34 -8) — shell scroll axis, table wrapping useEffect, table CSS
- `apps/web/src/components/FileViewer.tsx` (+9 -1) — minWidth/boxSizing additions, kept hidden as defense-in-depth

## Verification

- `pnpm install`: ✅
- `pnpm --filter @cpc/web exec tsc -b`: ✅ (note: there's no `typecheck` script defined in `apps/web/package.json` — `tsc -b` is the underlying check)
- `pnpm --filter @cpc/web test`: ✅ 41/41 pass
- `pnpm --filter @cpc/web build`: ✅

## Manual UAT required (cannot automate)

**Confidence: MEDIUM-HIGH on the shell-scroll-layer hypothesis.** Liam should retest on actual iPhone inside Telegram WebView before we tag v1.9.1. Specifically:

1. Open a markdown file with code blocks and at least one wide table
2. Try to drag horizontally on the file viewer body — should NOT scroll
3. Try to drag horizontally inside a code block — SHOULD scroll inside the `<pre>`
4. Try to drag horizontally inside a wide table — SHOULD scroll inside the `.md-table-scroll` wrapper
5. Confirm vertical scroll still works

## Test plan

- [ ] iPhone manual UAT in Telegram WebView (Liam)
- [ ] Verify code block hscroll still works (PR #20 regression check)
- [ ] Verify wide table hscroll works inside the new wrapper
- [ ] Verify mermaid diagrams unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code) using Codex CLI for the implementation, orchestrator handled the git plumbing.