### PR TITLE
fix(downloads): download-ticket flow for iOS-safe popup downloads

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "tsx watch src/index.ts",
+    "typecheck": "tsc --noEmit",
     "build": "tsc",
     "start": "node dist/index.js",
     "test": "vitest run",

--- a/apps/server/src/middleware.ts
+++ b/apps/server/src/middleware.ts
@@ -6,6 +6,15 @@ import { validateTelegramInitData, getAllowedUsers, validateSession, validateJwt
  * Expects initData in the Authorization header as: tma <initData>
  */
 export async function telegramAuth(c: Context, next: Next) {
+  if (
+    c.req.method === "GET" &&
+    new URL(c.req.url).pathname === "/api/files/download" &&
+    c.req.query("ticket")
+  ) {
+    await next();
+    return;
+  }
+
   const botToken = process.env.TELEGRAM_BOT_TOKEN;
   if (!botToken) {
     return c.json({ error: "Server not configured: missing bot token" }, 500);

--- a/apps/server/src/middleware.ts
+++ b/apps/server/src/middleware.ts
@@ -8,7 +8,7 @@ import { validateTelegramInitData, getAllowedUsers, validateSession, validateJwt
 export async function telegramAuth(c: Context, next: Next) {
   if (
     c.req.method === "GET" &&
-    new URL(c.req.url).pathname === "/api/files/download" &&
+    c.req.path === "/api/files/download" &&
     c.req.query("ticket")
   ) {
     await next();

--- a/apps/server/src/routes/__tests__/download-ticket.test.ts
+++ b/apps/server/src/routes/__tests__/download-ticket.test.ts
@@ -1,0 +1,62 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { __resetRealRootCacheForTests } from "../../lib/path-allowed.js";
+
+let sandbox: string;
+let testAllowedRoots: string[] = [];
+
+vi.mock("../../lib/path-allowed.js", async () => {
+  const real = await vi.importActual<typeof import("../../lib/path-allowed.js")>(
+    "../../lib/path-allowed.js",
+  );
+  return {
+    ...real,
+    isPathAllowed: async (candidate: string, _ignoredAllowedRoots: string[]) => {
+      return real.isPathAllowed(candidate, testAllowedRoots);
+    },
+  };
+});
+
+const { filesRoute } = await import("../files.js");
+
+beforeAll(() => {
+  process.env.NODE_ENV = "test";
+  sandbox = mkdtempSync(join(tmpdir(), "cpc-download-ticket-"));
+  testAllowedRoots = [sandbox];
+  __resetRealRootCacheForTests();
+  writeFileSync(join(sandbox, "sample.html"), "<h1>download me</h1>");
+});
+
+afterAll(() => {
+  rmSync(sandbox, { recursive: true, force: true });
+  __resetRealRootCacheForTests();
+});
+
+describe("download tickets", () => {
+  it("downloads once with hardened attachment headers", async () => {
+    const ticketRes = await filesRoute.request("/download-ticket", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ path: join(sandbox, "sample.html") }),
+    });
+    expect(ticketRes.status).toBe(200);
+
+    const { ticket } = await ticketRes.json() as { ticket: string };
+    expect(ticket).toMatch(/^[0-9a-f]{32}$/);
+
+    const downloadRes = await filesRoute.request(`/download?ticket=${ticket}`);
+    expect(downloadRes.status).toBe(200);
+    expect(downloadRes.headers.get("Content-Type")).toBe("application/octet-stream");
+    expect(downloadRes.headers.get("X-Content-Type-Options")).toBe("nosniff");
+    expect(downloadRes.headers.get("Cache-Control")).toBe("no-store");
+    expect(downloadRes.headers.get("Content-Length")).toBe("20");
+    expect(downloadRes.headers.get("Content-Disposition")).toContain("attachment; filename=\"sample.html\"");
+    expect(await downloadRes.text()).toBe("<h1>download me</h1>");
+
+    const reuseRes = await filesRoute.request(`/download?ticket=${ticket}`);
+    expect(reuseRes.status).toBe(403);
+    expect(await reuseRes.json()).toEqual({ error: "invalid or expired ticket" });
+  });
+});

--- a/apps/server/src/routes/files.ts
+++ b/apps/server/src/routes/files.ts
@@ -52,7 +52,7 @@ function pruneExpiredDownloadTickets(now = Date.now()) {
 
 async function getDownloadableFile(filePath: string): Promise<
   | { ok: true; path: string; size: number; name: string }
-  | { ok: false; status: 400 | 403 | 413 | 500; error: string }
+  | { ok: false; status: 400 | 403 | 404 | 413 | 500; error: string }
 > {
   const resolved = resolve(filePath);
   if (!await isPathAllowed(resolved)) {
@@ -66,7 +66,7 @@ async function getDownloadableFile(filePath: string): Promise<
     }
 
     if (st.size > DOWNLOAD_MAX_BYTES) {
-      return { ok: false, status: 413, error: "File too large (max 50MB)" };
+      return { ok: false, status: 413, error: `File too large (max ${DOWNLOAD_MAX_BYTES / (1024 * 1024)}MB)` };
     }
 
     return {
@@ -75,7 +75,10 @@ async function getDownloadableFile(filePath: string): Promise<
       size: st.size,
       name: basename(resolved) || "file",
     };
-  } catch (err) {
+  } catch (err: any) {
+    if (err?.code === "ENOENT") {
+      return { ok: false, status: 404, error: "File not found" };
+    }
     console.error("[files/download] stat error:", err);
     return { ok: false, status: 500, error: "Failed to read file" };
   }
@@ -293,8 +296,8 @@ app.post("/download-ticket", async (c) => {
 app.get("/download", async (c) => {
   const ticket = c.req.query("ticket");
   if (ticket) {
-    pruneExpiredDownloadTickets();
-
+    // Pruning happens in the POST handler so the map doesn't grow unbounded;
+    // the per-request expiry check below handles correctness on GET.
     const record = downloadTickets.get(ticket);
     if (!record || record.used || record.expiresAt <= Date.now()) {
       return c.json({ error: "invalid or expired ticket" }, 403);

--- a/apps/server/src/routes/files.ts
+++ b/apps/server/src/routes/files.ts
@@ -1,5 +1,6 @@
 import { Hono } from "hono";
 import { bodyLimit } from "hono/body-limit";
+import { randomBytes } from "node:crypto";
 import {
   open,
   readdir,
@@ -8,13 +9,25 @@ import {
   unlink,
   writeFile,
 } from "node:fs/promises";
+import { createReadStream } from "node:fs";
 import { basename, join, resolve, sep } from "node:path";
 import { constants as fsConstants } from "node:fs";
+import { Readable } from "node:stream";
 import { isPathAllowed as isPathAllowedShared } from "../lib/path-allowed.js";
 
 const app = new Hono();
 
 const BASE_DIR = process.env.FILES_BASE_DIR || "/home/claude/claudes-world";
+const DOWNLOAD_MAX_BYTES = 50 * 1024 * 1024;
+const DOWNLOAD_TICKET_TTL_MS = 60 * 1000;
+
+type DownloadTicket = {
+  path: string;
+  expiresAt: number;
+  used: boolean;
+};
+
+const downloadTickets = new Map<string, DownloadTicket>();
 
 // Allowed root directories the file viewer can access
 const ALLOWED_ROOTS = [
@@ -27,6 +40,62 @@ const ALLOWED_ROOTS = [
 
 function isPathAllowed(absPath: string): Promise<boolean> {
   return isPathAllowedShared(absPath, ALLOWED_ROOTS);
+}
+
+function pruneExpiredDownloadTickets(now = Date.now()) {
+  for (const [ticket, record] of downloadTickets) {
+    if (record.expiresAt <= now) {
+      downloadTickets.delete(ticket);
+    }
+  }
+}
+
+async function getDownloadableFile(filePath: string): Promise<
+  | { ok: true; path: string; size: number; name: string }
+  | { ok: false; status: 400 | 403 | 413 | 500; error: string }
+> {
+  const resolved = resolve(filePath);
+  if (!await isPathAllowed(resolved)) {
+    return { ok: false, status: 403, error: "Access denied" };
+  }
+
+  try {
+    const st = await stat(resolved);
+    if (!st.isFile()) {
+      return { ok: false, status: 400, error: "Not a file" };
+    }
+
+    if (st.size > DOWNLOAD_MAX_BYTES) {
+      return { ok: false, status: 413, error: "File too large (max 50MB)" };
+    }
+
+    return {
+      ok: true,
+      path: resolved,
+      size: st.size,
+      name: basename(resolved) || "file",
+    };
+  } catch (err) {
+    console.error("[files/download] stat error:", err);
+    return { ok: false, status: 500, error: "Failed to read file" };
+  }
+}
+
+function createDownloadResponse(file: { path: string; size: number; name: string }) {
+  const encodedName = encodeURIComponent(file.name);
+  const safeName = file.name.replace(/["\r\n]/g, "") || "file";
+  const body = Readable.toWeb(createReadStream(file.path)) as unknown as BodyInit;
+
+  return new Response(body, {
+    status: 200,
+    headers: {
+      "Content-Type": "application/octet-stream",
+      "Content-Length": String(file.size),
+      "Content-Disposition": `attachment; filename="${safeName}"; filename*=UTF-8''${encodedName}`,
+      "X-Content-Type-Options": "nosniff",
+      "Cache-Control": "no-store",
+    },
+  });
 }
 
 /**
@@ -192,61 +261,65 @@ app.get("/read", async (c) => {
 });
 
 // Download file (raw bytes, preserves binary content)
+app.post("/download-ticket", async (c) => {
+  pruneExpiredDownloadTickets();
+
+  let body: unknown;
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ error: "Invalid JSON body" }, 400);
+  }
+
+  if (!body || typeof body !== "object" || typeof (body as { path?: unknown }).path !== "string") {
+    return c.json({ error: "path required" }, 400);
+  }
+
+  const file = await getDownloadableFile((body as { path: string }).path);
+  if (!file.ok) {
+    return c.json({ error: file.error }, file.status);
+  }
+
+  const ticket = randomBytes(16).toString("hex");
+  downloadTickets.set(ticket, {
+    path: file.path,
+    expiresAt: Date.now() + DOWNLOAD_TICKET_TTL_MS,
+    used: false,
+  });
+
+  return c.json({ ticket });
+});
+
 app.get("/download", async (c) => {
+  const ticket = c.req.query("ticket");
+  if (ticket) {
+    pruneExpiredDownloadTickets();
+
+    const record = downloadTickets.get(ticket);
+    if (!record || record.used || record.expiresAt <= Date.now()) {
+      return c.json({ error: "invalid or expired ticket" }, 403);
+    }
+
+    record.used = true;
+    const file = await getDownloadableFile(record.path);
+    if (!file.ok) {
+      return c.json({ error: file.error }, file.status);
+    }
+
+    return createDownloadResponse(file);
+  }
+
   const filePath = c.req.query("path");
   if (!filePath) {
     return c.json({ error: "path parameter required" }, 400);
   }
 
-  const resolved = resolve(filePath);
-  if (!await isPathAllowed(resolved)) {
-    return c.json({ error: "Access denied" }, 403);
+  const file = await getDownloadableFile(filePath);
+  if (!file.ok) {
+    return c.json({ error: file.error }, file.status);
   }
 
-  try {
-    const st = await stat(resolved);
-    if (!st.isFile()) {
-      return c.json({ error: "Not a file" }, 400);
-    }
-
-    // Cap download size at 50MB for safety
-    if (st.size > 50 * 1024 * 1024) {
-      return c.json({ error: "File too large (max 50MB)" }, 413);
-    }
-
-    const content = await readFile(resolved);
-    const baseName = resolved.split("/").pop() || "file";
-
-    // Basic content-type guess by extension (keeps browsers from mis-sniffing)
-    const ext = baseName.split(".").pop()?.toLowerCase() || "";
-    const typeMap: Record<string, string> = {
-      md: "text/markdown", txt: "text/plain", json: "application/json",
-      js: "application/javascript", ts: "application/typescript",
-      html: "text/html", css: "text/css", csv: "text/csv",
-      png: "image/png", jpg: "image/jpeg", jpeg: "image/jpeg",
-      gif: "image/gif", webp: "image/webp", svg: "image/svg+xml",
-      pdf: "application/pdf", mp3: "audio/mpeg", mp4: "video/mp4",
-      webm: "video/webm", wav: "audio/wav", ogg: "audio/ogg",
-      zip: "application/zip", gz: "application/gzip",
-    };
-    const contentType = typeMap[ext] || "application/octet-stream";
-
-    // RFC 5987 encoding for Content-Disposition filename to handle unicode safely
-    const encodedName = encodeURIComponent(baseName);
-
-    return new Response(new Uint8Array(content), {
-      status: 200,
-      headers: {
-        "Content-Type": contentType,
-        "Content-Length": String(content.length),
-        "Content-Disposition": `attachment; filename="${baseName.replace(/"/g, "")}"; filename*=UTF-8''${encodedName}`,
-        "Cache-Control": "no-store",
-      },
-    });
-  } catch (err) {
-    console.error("[files/download] error:", err);
-    return c.json({ error: "Failed to read file" }, 500);
-  }
+  return createDownloadResponse(file);
 });
 
 // Fuzzy file/path search — BFS across all allowed roots.

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite --port 58830",
+    "typecheck": "tsc --noEmit",
     "build": "tsc -b && vite build",
     "preview": "vite preview",
     "test": "vitest run",

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -155,54 +155,49 @@ export function FileViewer({ onClose, initialFile, showHidden = false, sortMode 
 
   const handleDownload = async () => {
     if (!filePath || !fileName || downloading) return;
-    setDownloading(true);
     setError(null);
+
+    const downloadWindow = window.open("about:blank", "_blank");
+    if (!downloadWindow) {
+      setError("Download blocked by browser. Allow popups for this site.");
+      return;
+    }
+
     try {
-      const res = await fetch(`/api/files/download?path=${encodeURIComponent(filePath)}`, {
-        headers: getAuthHeaders(),
+      downloadWindow.opener = null;
+    } catch {
+      // Some WebViews make opener read-only. The ticket is still single-use.
+    }
+
+    setDownloading(true);
+    try {
+      const res = await fetch("/api/files/download-ticket", {
+        method: "POST",
+        headers: {
+          ...getAuthHeaders(),
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ path: filePath }),
       });
       if (!res.ok) {
-        // Try to surface server error message if JSON
+        downloadWindow.close();
         let msg = `Download failed (${res.status})`;
         try {
           const data = await res.json();
           if (data?.error) msg = data.error;
         } catch { /* not JSON */ }
-        setError(msg);
-        return;
+        throw new Error(msg);
       }
-      // Re-type the response bytes as octet-stream. iOS Safari / Telegram
-      // in-app webview ignore the `download` attribute on anchors pointing
-      // at blob URLs whose MIME type is something the browser can render
-      // inline (text/markdown, text/plain, text/html, etc.). The result is
-      // that instead of triggering a save, the webview navigates to the
-      // blob URL in-place and shows the raw content, which Liam reported as
-      // "raw markdown in the viewer" for v1.8.0 .md files. Forcing
-      // application/octet-stream keeps the browser from sniffing a
-      // renderable type and reliably routes the click through the normal
-      // file-save path on iOS, Android, and desktop.
-      //
-      // Use Blob.slice() instead of `new Blob([rawBlob], {...})` because
-      // slice returns a view over the existing bytes (zero-copy) whereas
-      // the Blob constructor clones the whole payload. The server caps
-      // downloads at 50MB, and doubling that in WebView RAM has been known
-      // to get the renderer killed mid-download on low-memory iOS devices.
-      const rawBlob = await res.blob();
-      const blob = rawBlob.slice(0, rawBlob.size, "application/octet-stream");
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement("a");
-      a.href = url;
-      a.download = fileName;
-      // rel=noopener is a safety belt: if a browser ever opens the link in
-      // a new context instead of downloading, we don't want it to inherit
-      // window.opener access back into the CPC app.
-      a.rel = "noopener";
-      document.body.appendChild(a);
-      a.click();
-      document.body.removeChild(a);
-      // Give the browser a tick before revoking the object URL
-      setTimeout(() => URL.revokeObjectURL(url), 1000);
+
+      const data = await res.json() as { ticket?: string };
+      if (!data.ticket) {
+        downloadWindow.close();
+        throw new Error("Download failed: missing ticket");
+      }
+
+      downloadWindow.location.href = `/api/files/download?ticket=${encodeURIComponent(data.ticket)}`;
     } catch (err) {
+      downloadWindow.close();
       setError(err instanceof Error ? err.message : "Download failed");
     } finally {
       setDownloading(false);


### PR DESCRIPTION
## Summary
- Add a narrow download-ticket flow: header-authenticated POST issues a 60s single-use ticket, anonymous GET validates it and streams the file.
- Harden download responses with octet-stream, nosniff, no-store, content length, and attachment disposition.
- Replace the FileViewer blob/synthetic-click path with a synchronous blank popup followed by ticket navigation.
- Add package typecheck scripts so the requested verification commands exist.

## Verification
- pnpm install --silent
- pnpm --filter @cpc/server typecheck
- pnpm --filter @cpc/server test
- pnpm --filter @cpc/web typecheck
- pnpm --filter @cpc/web test
- pnpm --filter @cpc/web build
- pnpm --filter @cpc/server build

## Manual UAT
Manual UAT on iPhone in the actual Telegram client is required before merge.