### PR TITLE
feat(perf): 103 Early Hints + telegram.org preconnect (Tier 2a)

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -1,6 +1,9 @@
 import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
 import { Hono } from "hono";
 import { cors } from "hono/cors";
+import type { HttpBindings } from "@hono/node-server";
 import { serveStatic } from "@hono/node-server/serve-static";
 import { serve } from "@hono/node-server";
 import { createNodeWebSocket } from "@hono/node-ws";
@@ -38,7 +41,7 @@ function loadEnv(path: string) {
 
 loadEnv(`${process.env.HOME}/.secrets/cpc.env`);
 
-const app = new Hono();
+const app = new Hono<{ Bindings: HttpBindings }>();
 const { injectWebSocket, upgradeWebSocket } = createNodeWebSocket({ app });
 
 app.use("*", cors());
@@ -83,10 +86,36 @@ app.route("/api/markdown", markdownRoute);
 app.get("/ws/terminal", upgradeWebSocket(terminalWsRoute));
 
 // Serve static frontend in production
-import { join, dirname } from "node:path";
-import { fileURLToPath } from "node:url";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const webDistRoot = join(__dirname, "../../web/dist");
+
+const earlyHintsLinks: string[] = [];
+try {
+  const indexHtml = readFileSync(join(webDistRoot, "index.html"), "utf-8");
+  const js = indexHtml.match(/<script[^>]+src="(\/assets\/index-[^"]+\.js)"/);
+  const css = indexHtml.match(/<link[^>]+href="(\/assets\/index-[^"]+\.css)"/);
+
+  if (js) earlyHintsLinks.push(`<${js[1]}>; rel=preload; as=script; crossorigin`);
+  if (css) earlyHintsLinks.push(`<${css[1]}>; rel=preload; as=style`);
+  earlyHintsLinks.push("<https://telegram.org>; rel=preconnect");
+} catch (e: any) {
+  console.warn(`[earlyHints] Unable to read ${join(webDistRoot, "index.html")}: ${e.message}`);
+}
+
+app.use("/*", async (c, next) => {
+  if (
+    process.env.EARLY_HINTS !== "0" &&
+    c.req.method === "GET" &&
+    (c.req.header("accept") ?? "").includes("text/html") &&
+    earlyHintsLinks.length > 0
+  ) {
+    try {
+      c.env.outgoing.writeEarlyHints({ link: earlyHintsLinks });
+    } catch {}
+  }
+  await next();
+});
+
 app.use("/*", serveStatic({ root: webDistRoot }));
 
 const port = parseInt(process.env.PORT || "38830");

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -5,6 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
     <meta name="color-scheme" content="dark" />
     <title>Claude Pocket Console</title>
+    <link rel="preconnect" href="https://telegram.org" crossorigin>
+    <link rel="dns-prefetch" href="https://telegram.org">
     <script src="https://telegram.org/js/telegram-web-app.js"></script>
     <style>
       * { margin: 0; padding: 0; box-sizing: border-box; }

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
     <meta name="color-scheme" content="dark" />
     <title>Claude Pocket Console</title>
-    <link rel="preconnect" href="https://telegram.org" crossorigin>
+    <link rel="preconnect" href="https://telegram.org">
     <link rel="dns-prefetch" href="https://telegram.org">
     <script src="https://telegram.org/js/telegram-web-app.js"></script>
     <style>


### PR DESCRIPTION
## Summary

Implements Steps 1 + 3 from the 103 Early Hints implementation playbook at `/home/claude/claudes-world/tmp/20260409-103-early-hints-implementation-playbook.md`. Step 2, the Caddy upgrade to 2.11.2, was already completed earlier today.

## Shipped

- Adds `telegram.org` preconnect and dns-prefetch immediately before the Telegram Mini App script in `apps/web/index.html`.
- Re-types the Hono app with `HttpBindings` so the raw Node response is available.
- Reads `apps/web/dist/index.html` once at server boot, extracts the entry `index-*.js` and `index-*.css` paths, and builds the conservative Early Hints Link set.
- Adds a GET HTML navigation pre-handler before the static mount that calls `writeEarlyHints` when `EARLY_HINTS !== "0"`.

## Deferred / follow-ups

- No Cloudflare edge Early Hints toggle. Origin-emitted 103 remains the path under test.
- No automated tests for `writeEarlyHints`; the playbook calls out that Vitest does not mock this path reliably.
- Manual iOS Telegram WebView UAT is still required because WKWebView handling is undocumented.

## Verification

- `pnpm install --silent`
- `pnpm --filter @cpc/server exec tsc -b`
- `pnpm --filter @cpc/server test`
- `pnpm --filter @cpc/server build`
- `pnpm --filter @cpc/web exec tsc -b`
- `pnpm --filter @cpc/web test`
- `pnpm --filter @cpc/web build`

## Manual post-deploy curl check

```bash
curl --http2 -v https://cpc.claude.do/ 2>&1 | grep -E "^< HTTP/|^< [Ll]ink:"
```

Expected: `< HTTP/2 103` appears before the final `< HTTP/2 200`. If only 200 appears, cloudflared may be swallowing the origin informational response, per open question 1 in the playbook.