### PR TITLE
feat(markdown): migrate MarkdownViewer from marked to react-markdown

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -19,7 +19,11 @@
     "mermaid": "^11.14.0",
     "react": "^19",
     "react-dom": "^19",
-    "react-icons": "^5.6.0"
+    "react-icons": "^5.6.0",
+    "react-markdown": "^10.1.0",
+    "rehype-slug": "^6.0.0",
+    "remark-breaks": "^4.0.0",
+    "remark-gfm": "^4.0.1"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.2.2",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,7 +15,6 @@
     "@xterm/addon-fit": "^0.10",
     "@xterm/addon-web-links": "^0.11",
     "@xterm/xterm": "^5",
-    "marked": "^17.0.5",
     "mermaid": "^11.14.0",
     "react": "^19",
     "react-dom": "^19",

--- a/apps/web/src/__tests__/__snapshots__/markdown-snapshots.test.ts.snap
+++ b/apps/web/src/__tests__/__snapshots__/markdown-snapshots.test.ts.snap
@@ -1,49 +1,51 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`MarkdownViewer (marked baseline) > renders 01-headings.md consistently 1`] = `
-"<h1>Heading Level 1</h1>
+exports[`MarkdownViewer (react-markdown baseline) > renders 01-headings.md consistently 1`] = `
+"<div class="md-content"><h1 id="heading-level-1">Heading Level 1</h1>
 <p>Some content under an h1 with <strong>bold</strong> text.</p>
-<h2>Heading Level 2</h2>
+<h2 id="heading-level-2">Heading Level 2</h2>
 <p>A paragraph under h2 with <code>inline code</code> and a <a href="https://example.com">link</a>.</p>
-<h3>Heading Level 3</h3>
+<h3 id="heading-level-3">Heading Level 3</h3>
 <ul>
 <li>A bullet under h3</li>
 <li>Another bullet</li>
 </ul>
-<h4>Heading Level 4</h4>
+<h4 id="heading-level-4">Heading Level 4</h4>
 <p>Paragraph under h4.</p>
-<h5>Heading Level 5</h5>
+<h5 id="heading-level-5">Heading Level 5</h5>
 <blockquote>
 <p>A blockquote under h5.</p>
 </blockquote>
-<h6>Heading Level 6</h6>
+<h6 id="heading-level-6">Heading Level 6</h6>
 <p>Final paragraph under the smallest heading.</p>
-<h2>Another H2 After H6</h2>
+<h2 id="another-h2-after-h6">Another H2 After H6</h2>
 <p>Content to test heading-reset behavior.</p>
-<h3>Nested h3</h3>
-<p>And some trailing content.</p>
-"
+<h3 id="nested-h3">Nested h3</h3>
+<p>And some trailing content.</p></div>"
 `;
 
-exports[`MarkdownViewer (marked baseline) > renders 02-lists.md consistently 1`] = `
-"<h1>Lists</h1>
-<h2>Unordered</h2>
+exports[`MarkdownViewer (react-markdown baseline) > renders 02-lists.md consistently 1`] = `
+"<div class="md-content"><h1 id="lists">Lists</h1>
+<h2 id="unordered">Unordered</h2>
 <ul>
 <li>Apple</li>
 <li>Banana</li>
 <li>Cherry</li>
 </ul>
-<h2>Ordered</h2>
+<h2 id="ordered">Ordered</h2>
 <ol>
 <li>First</li>
 <li>Second</li>
 <li>Third</li>
 </ol>
-<h2>Nested (3+ deep)</h2>
+<h2 id="nested-3-deep">Nested (3+ deep)</h2>
 <ul>
-<li>Level 1 item A<ul>
-<li>Level 2 item A.1<ul>
-<li>Level 3 item A.1.a<ul>
+<li>Level 1 item A
+<ul>
+<li>Level 2 item A.1
+<ul>
+<li>Level 3 item A.1.a
+<ul>
 <li>Level 4 item A.1.a.i</li>
 </ul>
 </li>
@@ -55,41 +57,46 @@ exports[`MarkdownViewer (marked baseline) > renders 02-lists.md consistently 1`]
 </li>
 <li>Level 1 item B</li>
 </ul>
-<h2>Task list</h2>
-<ul>
-<li><input disabled="" type="checkbox"> Open task</li>
-<li><input checked="" disabled="" type="checkbox"> Completed task</li>
-<li><input disabled="" type="checkbox"> Another open task<ul>
-<li><input checked="" disabled="" type="checkbox"> Nested completed subtask</li>
-<li><input disabled="" type="checkbox"> Nested open subtask</li>
+<h2 id="task-list">Task list</h2>
+<ul class="contains-task-list">
+<li class="task-list-item"><input type="checkbox" disabled=""/> Open task</li>
+<li class="task-list-item"><input type="checkbox" disabled="" checked=""/> Completed task</li>
+<li class="task-list-item"><input type="checkbox" disabled=""/> Another open task
+<ul class="contains-task-list">
+<li class="task-list-item"><input type="checkbox" disabled="" checked=""/> Nested completed subtask</li>
+<li class="task-list-item"><input type="checkbox" disabled=""/> Nested open subtask</li>
 </ul>
 </li>
 </ul>
-<h2>Mixed ordered + unordered</h2>
+<h2 id="mixed-ordered--unordered">Mixed ordered + unordered</h2>
 <ol>
-<li><p>First ordered</p>
+<li>
+<p>First ordered</p>
 <ul>
 <li>Unordered sub A</li>
-<li>Unordered sub B<ol>
+<li>Unordered sub B
+<ol>
 <li>Re-ordered sub-sub</li>
 <li>Another re-ordered sub-sub</li>
 </ol>
 </li>
 </ul>
 </li>
-<li><p>Second ordered</p>
+<li>
+<p>Second ordered</p>
 </li>
-<li><p>Third ordered with a paragraph.</p>
+<li>
+<p>Third ordered with a paragraph.</p>
 <p>Continuation paragraph inside list item.</p>
 </li>
-<li><p>Fourth ordered</p>
+<li>
+<p>Fourth ordered</p>
 </li>
-</ol>
-"
+</ol></div>"
 `;
 
-exports[`MarkdownViewer (marked baseline) > renders 03-code-block-short.md consistently 1`] = `
-"<h1>Short code block</h1>
+exports[`MarkdownViewer (react-markdown baseline) > renders 03-code-block-short.md consistently 1`] = `
+"<div class="md-content"><h1 id="short-code-block">Short code block</h1>
 <p>Here is a small TypeScript snippet:</p>
 <pre><code class="language-ts">function greet(name: string): string {
   return \`Hello, \${name}!\`;
@@ -100,12 +107,11 @@ greet(&quot;world&quot;);
 <p>And a short bash example:</p>
 <pre><code class="language-bash">pnpm install
 pnpm test
-</code></pre>
-"
+</code></pre></div>"
 `;
 
-exports[`MarkdownViewer (marked baseline) > renders 04-code-block-wide.md consistently 1`] = `
-"<h1>Wide code block (horizontal scroll target)</h1>
+exports[`MarkdownViewer (react-markdown baseline) > renders 04-code-block-wide.md consistently 1`] = `
+"<div class="md-content"><h1 id="wide-code-block-horizontal-scroll-target">Wide code block (horizontal scroll target)</h1>
 <p>This fixture exists to pin down the PR #20 regression around wide code blocks and horizontal scrolling.</p>
 <pre><code class="language-ts">// This single line is intentionally very long to force horizontal scrolling inside the rendered &lt;pre&gt;&lt;code&gt; container so we can diff how marked and react-markdown lay out the overflow behavior under the same CSS.
 const veryLongIdentifier = { alpha: 1, beta: 2, gamma: 3, delta: 4, epsilon: 5, zeta: 6, eta: 7, theta: 8, iota: 9, kappa: 10, lambda: 11, mu: 12, nu: 13, xi: 14, omicron: 15, pi: 16, rho: 17, sigma: 18, tau: 19, upsilon: 20, phi: 21, chi: 22, psi: 23, omega: 24 };
@@ -116,99 +122,27 @@ function doSomethingThatTakesAbsurdlyManyArgumentsAndReturnsAnAbsurdlyLongInline
 <p>And a short line afterwards to verify the following paragraph wraps normally after a wide code block:</p>
 <pre><code>$ curl -sSL https://example.com/some/very/long/path/that/should/not/wrap/inside/the/pre/block/because/pre/preserves/whitespace/and/horizontal/scroll/should/kick/in?query=param1&amp;query=param2&amp;query=param3
 </code></pre>
-<p>End of wide fixture.</p>
-"
+<p>End of wide fixture.</p></div>"
 `;
 
-exports[`MarkdownViewer (marked baseline) > renders 05-table-narrow.md consistently 1`] = `
-"<h1>Narrow table</h1>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th align="right">Count</th>
-</tr>
-</thead>
-<tbody><tr>
-<td>Apples</td>
-<td align="right">3</td>
-</tr>
-<tr>
-<td>Bananas</td>
-<td align="right">12</td>
-</tr>
-<tr>
-<td>Cherries</td>
-<td align="right">47</td>
-</tr>
-</tbody></table>
-<p>A short paragraph after the table.</p>
-"
+exports[`MarkdownViewer (react-markdown baseline) > renders 05-table-narrow.md consistently 1`] = `
+"<div class="md-content"><h1 id="narrow-table">Narrow table</h1>
+<div class="md-table-scroll"><table><thead><tr><th>Name</th><th style="text-align:right">Count</th></tr></thead><tbody><tr><td>Apples</td><td style="text-align:right">3</td></tr><tr><td>Bananas</td><td style="text-align:right">12</td></tr><tr><td>Cherries</td><td style="text-align:right">47</td></tr></tbody></table></div>
+<p>A short paragraph after the table.</p></div>"
 `;
 
-exports[`MarkdownViewer (marked baseline) > renders 06-table-wide.md consistently 1`] = `
-"<h1>Wide table</h1>
-<table>
-<thead>
-<tr>
-<th align="left">Column A</th>
-<th align="center">Column B</th>
-<th align="left">Column C (with a long header)</th>
-<th align="right">Column D</th>
-<th>Column E</th>
-<th>Column F</th>
-</tr>
-</thead>
-<tbody><tr>
-<td align="left">alpha</td>
-<td align="center">beta</td>
-<td align="left">this is a fairly long cell value that should push the column width out</td>
-<td align="right">1</td>
-<td>true</td>
-<td><code>code</code></td>
-</tr>
-<tr>
-<td align="left">gamma</td>
-<td align="center">delta</td>
-<td align="left">another long cell with <strong>bold</strong> and <em>italic</em> inline styles interleaved</td>
-<td align="right">22</td>
-<td>false</td>
-<td><a href="https://example.com">link</a></td>
-</tr>
-<tr>
-<td align="left">epsilon</td>
-<td align="center">zeta</td>
-<td align="left">short</td>
-<td align="right">333</td>
-<td>true</td>
-<td>plain</td>
-</tr>
-<tr>
-<td align="left">eta</td>
-<td align="center">theta</td>
-<td align="left">cell with a pipe escape | inside it</td>
-<td align="right">4444</td>
-<td>false</td>
-<td><code>x</code></td>
-</tr>
-<tr>
-<td align="left">iota</td>
-<td align="center">kappa</td>
-<td align="left">final row with a <a href="https://example.com/path?a=1&b=2">link</a> embedded</td>
-<td align="right">55555</td>
-<td>true</td>
-<td>done</td>
-</tr>
-</tbody></table>
-<p>Trailing paragraph to verify flow after a wide table.</p>
-"
+exports[`MarkdownViewer (react-markdown baseline) > renders 06-table-wide.md consistently 1`] = `
+"<div class="md-content"><h1 id="wide-table">Wide table</h1>
+<div class="md-table-scroll"><table><thead><tr><th style="text-align:left">Column A</th><th style="text-align:center">Column B</th><th style="text-align:left">Column C (with a long header)</th><th style="text-align:right">Column D</th><th>Column E</th><th>Column F</th></tr></thead><tbody><tr><td style="text-align:left">alpha</td><td style="text-align:center">beta</td><td style="text-align:left">this is a fairly long cell value that should push the column width out</td><td style="text-align:right">1</td><td>true</td><td><code>code</code></td></tr><tr><td style="text-align:left">gamma</td><td style="text-align:center">delta</td><td style="text-align:left">another long cell with <strong>bold</strong> and <em>italic</em> inline styles interleaved</td><td style="text-align:right">22</td><td>false</td><td><a href="https://example.com">link</a></td></tr><tr><td style="text-align:left">epsilon</td><td style="text-align:center">zeta</td><td style="text-align:left">short</td><td style="text-align:right">333</td><td>true</td><td>plain</td></tr><tr><td style="text-align:left">eta</td><td style="text-align:center">theta</td><td style="text-align:left">cell with a pipe escape | inside it</td><td style="text-align:right">4444</td><td>false</td><td><code>x</code></td></tr><tr><td style="text-align:left">iota</td><td style="text-align:center">kappa</td><td style="text-align:left">final row with a <a href="https://example.com/path?a=1&amp;b=2">link</a> embedded</td><td style="text-align:right">55555</td><td>true</td><td>done</td></tr></tbody></table></div>
+<p>Trailing paragraph to verify flow after a wide table.</p></div>"
 `;
 
-exports[`MarkdownViewer (marked baseline) > renders 07-blockquote.md consistently 1`] = `
-"<h1>Blockquotes</h1>
+exports[`MarkdownViewer (react-markdown baseline) > renders 07-blockquote.md consistently 1`] = `
+"<div class="md-content"><h1 id="blockquotes">Blockquotes</h1>
 <p>Single-level blockquote:</p>
 <blockquote>
-<p>This is a simple single-level blockquote.<br>It spans two lines of markdown source.</p>
+<p>This is a simple single-level blockquote.<br/>
+It spans two lines of markdown source.</p>
 </blockquote>
 <p>With inline formatting:</p>
 <blockquote>
@@ -230,7 +164,8 @@ exports[`MarkdownViewer (marked baseline) > renders 07-blockquote.md consistentl
 <blockquote>
 <ul>
 <li>Item one inside quote</li>
-<li>Item two inside quote<ul>
+<li>Item two inside quote
+<ul>
 <li>Nested item</li>
 </ul>
 </li>
@@ -241,26 +176,26 @@ exports[`MarkdownViewer (marked baseline) > renders 07-blockquote.md consistentl
 <blockquote>
 <pre><code class="language-ts">const quoted = &quot;code inside blockquote&quot;;
 </code></pre>
-</blockquote>
-"
+</blockquote></div>"
 `;
 
-exports[`MarkdownViewer (marked baseline) > renders 08-mixed-inline.md consistently 1`] = `
-"<h1>Mixed inline formatting</h1>
+exports[`MarkdownViewer (react-markdown baseline) > renders 08-mixed-inline.md consistently 1`] = `
+"<div class="md-content"><h1 id="mixed-inline-formatting">Mixed inline formatting</h1>
 <p>A single dense paragraph with <strong>bold</strong>, <em>italic</em>, <em><strong>bold-italic</strong></em>, <code>inline code</code>, <del>strikethrough</del>, and a <a href="https://example.com">link</a> all interleaved into one flowing sentence so the renderer has to deal with many inline transitions in a row without any breaks between them at all.</p>
 <p>Another paragraph that <strong>combines <code>code inside bold</code></strong> and <em><a href="https://example.com">links inside italics</a></em> and <code>**not bold inside code**</code> to verify escape semantics.</p>
 <p>A line with emphasis edges: <strong>bold at start</strong> of a sentence, and another sentence ending with <strong>bold at end</strong>. Also <em>italic at start</em> and <em>italic at end</em>.</p>
 <p>Adjacent inline tokens: <strong>bold</strong><code>code</code> and <em>italic</em><strong>bold</strong> and <code>code</code><a href="https://example.com">link</a>.</p>
 <p>Strikethrough combos: <del>plain strike</del>, <del><strong>bold strike</strong></del>, <del><em>italic strike</em></del>, <del><code>code strike</code></del>.</p>
-<p>Line 1 with trailing spaces to force a soft break<br>Line 2 after the soft break.</p>
-<p>Line A<br>Line B (single newline between — with <code>breaks: true</code>, marked renders this as <code>&lt;br&gt;</code>).</p>
-"
+<p>Line 1 with trailing spaces to force a soft break<br/>
+Line 2 after the soft break.</p>
+<p>Line A<br/>
+Line B (single newline between — with <code>breaks: true</code>, marked renders this as <code>&lt;br&gt;</code>).</p></div>"
 `;
 
-exports[`MarkdownViewer (marked baseline) > renders 09-link-edge-cases.md consistently 1`] = `
-"<h1>Link edge cases</h1>
+exports[`MarkdownViewer (react-markdown baseline) > renders 09-link-edge-cases.md consistently 1`] = `
+"<link rel="preload" as="image" href="https://shared.claude.do/public/placeholder.png"/><div class="md-content"><h1 id="link-edge-cases">Link edge cases</h1>
 <p>Inline link with parens in URL: <a href="https://en.wikipedia.org/wiki/Markdown_(software)">wiki article</a>.</p>
-<p>Inline link with query + fragment: <a href="https://example.com/path?query=foo&bar=baz#section-2">search</a>.</p>
+<p>Inline link with query + fragment: <a href="https://example.com/path?query=foo&amp;bar=baz#section-2">search</a>.</p>
 <p>Inline link with title: <a href="https://example.com" title="Example title">hover me</a>.</p>
 <p>Autolink: <a href="https://example.com/autolink">https://example.com/autolink</a>.</p>
 <p>Autolink email: <a href="mailto:someone@example.com">someone@example.com</a>.</p>
@@ -269,18 +204,20 @@ exports[`MarkdownViewer (marked baseline) > renders 09-link-edge-cases.md consis
 <p>Collapsed reference: <a href="https://example.com/collapsed">collapsed</a>.</p>
 <p>Shortcut reference: <a href="https://example.com/shortcut">shortcut</a>.</p>
 <p>Link with special chars in text: <a href="https://example.com"><code>code</code> in <strong>bold</strong> link text</a>.</p>
-<p>Image: <img src="https://shared.claude.do/public/placeholder.png" alt="alt text" title="image title">.</p>
+<p>Image: <img src="https://shared.claude.do/public/placeholder.png" alt="alt text" title="image title"/>.</p>
 <p>Link followed immediately by punctuation: see <a href="https://example.com">example</a>, then continue.</p>
-<p>Bare URL (not autolinked without angle brackets): <a href="https://example.com/bare">https://example.com/bare</a></p>
-"
+<p>Bare URL (not autolinked without angle brackets): <a href="https://example.com/bare">https://example.com/bare</a></p></div>"
 `;
 
-exports[`MarkdownViewer (marked baseline) > renders 10-real-doc-adr.md consistently 1`] = `
-"<h1>ADR 0001: Package CPC as the Shareable Hub with Toolbox as a Git Submodule</h1>
-<p><strong>Status:</strong> Proposed<br><strong>Date:</strong> 2026-04-06<br><strong>Deciders:</strong> Liam (Chaintail), Claude<br><strong>Context:</strong> Hackathon friends asked for GitHub links to &quot;what we built.&quot; This forced the question of what artifact best represents Claude&#39;s World as a sharable, runnable system.</p>
-<hr>
-<h2>Context</h2>
-<p>Claude&#39;s World is currently spread across multiple repositories and directories with no single artifact a new user could clone to &quot;get the system&quot;:</p>
+exports[`MarkdownViewer (react-markdown baseline) > renders 10-real-doc-adr.md consistently 1`] = `
+"<div class="md-content"><h1 id="adr-0001-package-cpc-as-the-shareable-hub-with-toolbox-as-a-git-submodule">ADR 0001: Package CPC as the Shareable Hub with Toolbox as a Git Submodule</h1>
+<p><strong>Status:</strong> Proposed<br/>
+<strong>Date:</strong> 2026-04-06<br/>
+<strong>Deciders:</strong> Liam (Chaintail), Claude<br/>
+<strong>Context:</strong> Hackathon friends asked for GitHub links to &quot;what we built.&quot; This forced the question of what artifact best represents Claude&#x27;s World as a sharable, runnable system.</p>
+<hr/>
+<h2 id="context">Context</h2>
+<p>Claude&#x27;s World is currently spread across multiple repositories and directories with no single artifact a new user could clone to &quot;get the system&quot;:</p>
 <ul>
 <li><strong>CPC</strong> (<code>~/code/claude-pocket-console</code>) — the Telegram mini app, the most polished and visually impressive piece</li>
 <li><strong>Toolbox</strong> (<code>~/code/toolbox</code>) — reusable scripts (md-speak, share-doc, transcribe, hooks). About 20 of the 40 entries in <code>~/bin</code> are now symlinks into this repo. Migration is in progress.</li>
@@ -288,14 +225,14 @@ exports[`MarkdownViewer (marked baseline) > renders 10-real-doc-adr.md consisten
 <li><strong>Host config</strong> (<code>~/do-box</code>) — VPS-specific systemd, Caddy, cloudflared (brittle whitelist-driven snapshot)</li>
 <li><strong>Live state</strong> (<code>~/claudes-world/</code>) — working directory, knowledge base, memory, ephemeral files</li>
 </ul>
-<p>When the user&#39;s hackathon friends asked for GitHub links, there was no clean answer. Pointing them to CPC alone misses the supporting infrastructure. Pointing them to multiple repos requires explaining the relationships. A monolithic &quot;everything in one repo&quot; approach was considered but rejected (see Alternatives).</p>
+<p>When the user&#x27;s hackathon friends asked for GitHub links, there was no clean answer. Pointing them to CPC alone misses the supporting infrastructure. Pointing them to multiple repos requires explaining the relationships. A monolithic &quot;everything in one repo&quot; approach was considered but rejected (see Alternatives).</p>
 <p>The user proposed: <strong>what if CPC stays as the primary shareable artifact and toolbox is included as a dependency inside it?</strong> This ADR captures that decision.</p>
-<hr>
-<h2>Decision</h2>
-<p><strong>CPC will be the primary shareable artifact for Claude&#39;s World. Toolbox will be embedded as a git submodule.</strong></p>
+<hr/>
+<h2 id="decision">Decision</h2>
+<p><strong>CPC will be the primary shareable artifact for Claude&#x27;s World. Toolbox will be embedded as a git submodule.</strong></p>
 <p>The structure will be:</p>
 <pre><code>claude-pocket-console/             ← what new users clone
-├── README.md                      ← &quot;This is Claude&#39;s World&quot;
+├── README.md                      ← &quot;This is Claude&#x27;s World&quot;
 ├── apps/web/                      ← React/Vite mini app
 ├── apps/server/                   ← Hono API
 ├── tools/                         ← git submodule → toolbox repo
@@ -318,53 +255,53 @@ exports[`MarkdownViewer (marked baseline) > renders 10-real-doc-adr.md consisten
 <li>Optionally install the toolbox scripts to their own <code>~/bin</code> for full Claude Code integration</li>
 </ol>
 <p>Toolbox keeps its own repository, its own commit history, and its own lifecycle. CPC pins to a specific toolbox commit via the submodule reference, and bumps that pin intentionally when toolbox ships changes.</p>
-<hr>
-<h2>Consequences</h2>
-<h3>Positive</h3>
+<hr/>
+<h2 id="consequences">Consequences</h2>
+<h3 id="positive">Positive</h3>
 <ul>
 <li><strong>One link to share.</strong> &quot;Check out github.com/{user}/claude-pocket-console&quot; gives someone the whole system. The first impression is the polished mini app, not a wall of bash scripts.</li>
 <li><strong>Toolbox stays portable.</strong> Someone who wants only the scripts can clone toolbox alone without pulling CPC. The two repos serve different audiences (CPC for &quot;show me the system,&quot; toolbox for &quot;give me the tools&quot;).</li>
 <li><strong>Independent lifecycles.</strong> Toolbox can ship breaking changes, ship rapid iterations, or be totally rewritten without forcing a CPC release. CPC pins to a known-good commit and bumps deliberately.</li>
-<li><strong>Smaller blast radius.</strong> A bug in toolbox doesn&#39;t break CPC unless CPC explicitly bumps the submodule. Reverting is one commit away.</li>
-<li><strong>Existing structure preserved.</strong> The toolbox repo doesn&#39;t need restructuring. It just becomes a sub-tree inside CPC at <code>tools/</code>.</li>
+<li><strong>Smaller blast radius.</strong> A bug in toolbox doesn&#x27;t break CPC unless CPC explicitly bumps the submodule. Reverting is one commit away.</li>
+<li><strong>Existing structure preserved.</strong> The toolbox repo doesn&#x27;t need restructuring. It just becomes a sub-tree inside CPC at <code>tools/</code>.</li>
 <li><strong>Matches how people discover the project.</strong> &quot;Claude Pocket Console&quot; is the recognizable name. Toolbox is invisible infrastructure. The submodule pattern reflects this asymmetry honestly.</li>
 </ul>
-<h3>Negative</h3>
+<h3 id="negative">Negative</h3>
 <ul>
-<li><strong>Submodule UX is clunky.</strong> New contributors will forget <code>--recursive</code> on clone. They&#39;ll see an empty <code>tools/</code> directory and be confused. Mitigation: README has a &quot;first steps&quot; section that explicitly addresses this, and <code>pnpm install</code> could check for the submodule and warn if missing.</li>
+<li><strong>Submodule UX is clunky.</strong> New contributors will forget <code>--recursive</code> on clone. They&#x27;ll see an empty <code>tools/</code> directory and be confused. Mitigation: README has a &quot;first steps&quot; section that explicitly addresses this, and <code>pnpm install</code> could check for the submodule and warn if missing.</li>
 <li><strong>Submodule pin updates require explicit commits.</strong> When toolbox ships a fix, CPC needs a commit to pull it in. Not bad in practice (usually you want this control) but adds a step.</li>
 <li><strong>Two-repo cognitive load.</strong> Anyone contributing to both CPC and toolbox has to manage two repos, two commit histories, two PR workflows. Mitigation: most contributors will only touch one or the other.</li>
-<li><strong>The &quot;host&quot; pieces still don&#39;t have a home.</strong> This ADR doesn&#39;t address where systemd/Caddy/cloudflared configs live. They&#39;re VPS-specific and don&#39;t belong in CPC. A separate decision is needed for the do-box replacement.</li>
+<li><strong>The &quot;host&quot; pieces still don&#x27;t have a home.</strong> This ADR doesn&#x27;t address where systemd/Caddy/cloudflared configs live. They&#x27;re VPS-specific and don&#x27;t belong in CPC. A separate decision is needed for the do-box replacement.</li>
 <li><strong>Skills location split.</strong> Skills currently live in <code>~/.claude/skills/</code> AND <code>~/claudes-world/.claude/skills/</code>. Deciding which is canonical and migrating to <code>claude-pocket-console/skills/</code> is a follow-up task.</li>
 </ul>
-<h3>Neutral</h3>
+<h3 id="neutral">Neutral</h3>
 <ul>
-<li>The user&#39;s <code>~/code/claude-pocket-console</code> working directory and the GitHub repo will share a name (already the case). Nothing changes locally.</li>
+<li>The user&#x27;s <code>~/code/claude-pocket-console</code> working directory and the GitHub repo will share a name (already the case). Nothing changes locally.</li>
 <li>The <code>~/.world/</code> directory concept (per-project overrides) is orthogonal to this decision and can still be added.</li>
 </ul>
-<hr>
-<h2>Alternatives Considered</h2>
-<h3>Alternative 1: Single monorepo containing everything</h3>
+<hr/>
+<h2 id="alternatives-considered">Alternatives Considered</h2>
+<h3 id="alternative-1-single-monorepo-containing-everything">Alternative 1: Single monorepo containing everything</h3>
 <p>Move CPC, toolbox, skills, host config, and apps into one new repo at <code>github.com/{user}/claudes-world</code>. Each becomes a top-level package.</p>
 <p><strong>Why rejected:</strong></p>
 <ul>
 <li>Breaks the existing CPC and toolbox repo histories (or requires complex git filter-repo work)</li>
 <li>Forces all packages to share a release cadence</li>
-<li>The &quot;host&quot; pieces (systemd, Caddy) don&#39;t belong in a portable repo at all — they&#39;re VPS-specific</li>
+<li>The &quot;host&quot; pieces (systemd, Caddy) don&#x27;t belong in a portable repo at all — they&#x27;re VPS-specific</li>
 <li>A new monorepo means a new repo name that nobody recognizes</li>
-<li>Doesn&#39;t match how the user actually thinks about the system (CPC is the recognizable thing, everything else supports it)</li>
+<li>Doesn&#x27;t match how the user actually thinks about the system (CPC is the recognizable thing, everything else supports it)</li>
 </ul>
 <p>The original portability design doc proposed this approach. After discussing it with the user, the CPC-as-hub model is a better fit for the actual goal (a shareable artifact for hackathon friends) without the migration cost.</p>
-<h3>Alternative 2: Git subtree instead of submodule</h3>
-<p>Same end state but using <code>git subtree</code> to merge toolbox&#39;s history into CPC at <code>tools/</code>. Consumers don&#39;t need <code>--recursive</code>.</p>
+<h3 id="alternative-2-git-subtree-instead-of-submodule">Alternative 2: Git subtree instead of submodule</h3>
+<p>Same end state but using <code>git subtree</code> to merge toolbox&#x27;s history into CPC at <code>tools/</code>. Consumers don&#x27;t need <code>--recursive</code>.</p>
 <p><strong>Why rejected:</strong></p>
 <ul>
-<li>Subtrees are harder to update bidirectionally. Pushing changes from CPC&#39;s <code>tools/</code> back to the toolbox repo requires <code>git subtree split</code> and manual reconciliation.</li>
+<li>Subtrees are harder to update bidirectionally. Pushing changes from CPC&#x27;s <code>tools/</code> back to the toolbox repo requires <code>git subtree split</code> and manual reconciliation.</li>
 <li>Subtree is less commonly understood than submodule. Most developers know <code>git submodule update --init --recursive</code>; fewer know <code>git subtree pull</code>.</li>
 <li>The &quot;no init step&quot; benefit is real but small — a one-line README note solves it.</li>
 <li>Could revisit if submodule pain proves worse than subtree pain in practice.</li>
 </ul>
-<h3>Alternative 3: pnpm workspace / npm package</h3>
+<h3 id="alternative-3-pnpm-workspace--npm-package">Alternative 3: pnpm workspace / npm package</h3>
 <p>Publish toolbox to npm and have CPC depend on it via <code>package.json</code>. Cleanest from a JS perspective.</p>
 <p><strong>Why rejected:</strong></p>
 <ul>
@@ -373,55 +310,58 @@ exports[`MarkdownViewer (marked baseline) > renders 10-real-doc-adr.md consisten
 <li>Versioning becomes a release-management chore — every toolbox change needs a version bump and publish.</li>
 <li>Adds an external dependency (npm registry) for what should be a self-contained system.</li>
 </ul>
-<h3>Alternative 4: Symlinks (do nothing)</h3>
+<h3 id="alternative-4-symlinks-do-nothing">Alternative 4: Symlinks (do nothing)</h3>
 <p>The current state. <code>~/bin</code> symlinks into <code>~/code/toolbox</code>, CPC is a separate repo. No packaging.</p>
 <p><strong>Why rejected:</strong></p>
 <ul>
-<li>This is exactly what the user is trying to fix. The current state has no shareable artifact and the relationships are invisible to anyone outside the user&#39;s head.</li>
-<li>Doesn&#39;t survive a host migration. Symlinks are filesystem-specific.</li>
-<li>Doesn&#39;t help hackathon friends at all.</li>
+<li>This is exactly what the user is trying to fix. The current state has no shareable artifact and the relationships are invisible to anyone outside the user&#x27;s head.</li>
+<li>Doesn&#x27;t survive a host migration. Symlinks are filesystem-specific.</li>
+<li>Doesn&#x27;t help hackathon friends at all.</li>
 </ul>
-<hr>
-<h2>Follow-Up Actions</h2>
+<hr/>
+<h2 id="follow-up-actions">Follow-Up Actions</h2>
 <p>These are not part of this ADR but are needed to execute the decision:</p>
 <ol>
 <li><strong>Decide on the host config story</strong> — separate ADR. The do-box replacement (manifest-driven, deterministic rebuild) is its own design problem.</li>
 <li><strong>Decide on skills canonical location</strong> — consolidate <code>~/.claude/skills/</code> and <code>~/claudes-world/.claude/skills/</code>, then migrate to <code>claude-pocket-console/skills/</code>.</li>
-<li><strong>Adopt progressive disclosure docs in CPC</strong> — restructure CPC&#39;s existing AGENTS.md and docs into the OmniPass <code>reference/guides/conventions/</code> pattern. (See ADR 0002, forthcoming.)</li>
+<li><strong>Adopt progressive disclosure docs in CPC</strong> — restructure CPC&#x27;s existing AGENTS.md and docs into the OmniPass <code>reference/guides/conventions/</code> pattern. (See ADR 0002, forthcoming.)</li>
 <li><strong>Submodule integration plan</strong> — actually create the submodule, write the README &quot;first steps&quot; section, set up CI to verify the submodule resolves cleanly.</li>
 <li><strong>Port convention v2</strong> — separate ADR. The current 38xxx/48xxx/58xxx convention is too coarse and caused hackathon collisions.</li>
 <li><strong>Plugin packaging (longer term)</strong> — if CPC grows into a Claude Code plugin, the plugin manifest can reference the same submodule structure. No conflict.</li>
 </ol>
-<hr>
-<h2>References</h2>
+<hr/>
+<h2 id="references">References</h2>
 <ul>
 <li><code>~/claudes-world/knowledge/claudes-world-portability-design.md</code> — the broader design doc this ADR resolves</li>
 <li><code>~/code/omnipass-world/AGENTS.md</code> — the progressive disclosure pattern used as the docs model</li>
 <li><code>~/code/claude-pocket-console/</code> — the CPC repo to be restructured</li>
 <li><code>~/code/toolbox/</code> — the toolbox repo to become a submodule</li>
 <li><a href="https://git-scm.com/book/en/v2/Git-Tools-Submodules">Git submodule docs</a></li>
-</ul>
-"
+</ul></div>"
 `;
 
-exports[`MarkdownViewer (marked baseline) > renders 11-real-doc-overnight-summary.md consistently 1`] = `
-"<h1>Overnight Final Report — April 6-7, 2026</h1>
-<p><strong>Session start:</strong> ~7:30pm ET April 6<br><strong>Session end:</strong> ~9:30pm ET April 6 (this report)<br><strong>Format:</strong> Single document for morning review</p>
-<hr>
-<h2>TL;DR</h2>
+exports[`MarkdownViewer (react-markdown baseline) > renders 11-real-doc-overnight-summary.md consistently 1`] = `
+"<div class="md-content"><h1 id="overnight-final-report--april-6-7-2026">Overnight Final Report — April 6-7, 2026</h1>
+<p><strong>Session start:</strong> ~7:30pm ET April 6<br/>
+<strong>Session end:</strong> ~9:30pm ET April 6 (this report)<br/>
+<strong>Format:</strong> Single document for morning review</p>
+<hr/>
+<h2 id="tldr">TL;DR</h2>
 <p><strong>8 PRs open and ready for your review.</strong> None merged. Foundational tools shipped (Scrum button, send-md fix). Three big-picture synthesis docs are ready for morning decisions (reading list, portability, theme). One known issue: the dev tunnel is currently 502 because of agent worktree coordination — fixes itself when you merge PR #21.</p>
-<hr>
-<h2>What&#39;s ready for you to merge (in order)</h2>
-<h3>Toolbox</h3>
+<hr/>
+<h2 id="whats-ready-for-you-to-merge-in-order">What&#x27;s ready for you to merge (in order)</h2>
+<h3 id="toolbox">Toolbox</h3>
 <ol>
-<li><p><strong>toolbox PR #1</strong> — <code>tune: reduce heading pauses, speed up body voice</code></p>
+<li>
+<p><strong>toolbox PR #1</strong> — <code>tune: reduce heading pauses, speed up body voice</code></p>
 <ul>
 <li>6 line edits, body voice 0.95 → 1.05, heading pauses cut ~30%</li>
 <li>Verdict: LGTM SHIP IT</li>
 <li>Branch: <code>tune/md-speak-pacing</code> → <code>main</code></li>
 </ul>
 </li>
-<li><p><strong>toolbox PR #2</strong> — <code>feat(hooks): Scrum button + share-doc backtick fix</code></p>
+<li>
+<p><strong>toolbox PR #2</strong> — <code>feat(hooks): Scrum button + share-doc backtick fix</code></p>
 <ul>
 <li>Scrum button on launcher keyboard + handler</li>
 <li>share-doc dual-mode (file path or inline content) — fixes the backtick truncation bug</li>
@@ -430,49 +370,56 @@ exports[`MarkdownViewer (marked baseline) > renders 11-real-doc-overnight-summar
 </ul>
 </li>
 </ol>
-<h3>CPC (in recommended merge order)</h3>
+<h3 id="cpc-in-recommended-merge-order">CPC (in recommended merge order)</h3>
 <ol>
-<li><p><strong>PR #21</strong> — <code>fix: allow cpc.claude.do host in Vite dev server</code></p>
+<li>
+<p><strong>PR #21</strong> — <code>fix: allow cpc.claude.do host in Vite dev server</code></p>
 <ul>
 <li><strong>MERGE FIRST</strong> — unblocks the dev tunnel which is currently 502</li>
 <li>Adds <code>host: &quot;127.0.0.1&quot;</code> and <code>allowedHosts: [&quot;cpc.claude.do&quot;]</code> to vite.config.ts</li>
 <li>Verdict: APPROVE WITH NITS (Gemini suggested also updating proxy + HMR config — see follow-up items)</li>
 </ul>
 </li>
-<li><p><strong>PR #19</strong> — <code>feat(links): Companion + T3 app icon links</code></p>
+<li>
+<p><strong>PR #19</strong> — <code>feat(links): Companion + T3 app icon links</code></p>
 <ul>
 <li>Trivial (+12/-0), no risk</li>
 <li>Verdict: SHIP IT</li>
 </ul>
 </li>
-<li><p><strong>PR #18</strong> — <code>feat: download button in file viewer</code></p>
+<li>
+<p><strong>PR #18</strong> — <code>feat: download button in file viewer</code></p>
 <ul>
 <li>New <code>/api/files/download</code> endpoint + FiDownload button in FileViewer</li>
 <li>Verdict: APPROVE WITH NITS</li>
-<li><strong>Should-fix items Gemini caught (you decide):</strong><ul>
+<li><strong>Should-fix items Gemini caught (you decide):</strong>
+<ul>
 <li>Use <code>buf.length</code> instead of <code>st.size</code> for Content-Length (TOCTOU)</li>
-<li>Sanitize 500 error messages (don&#39;t leak internal paths)</li>
+<li>Sanitize 500 error messages (don&#x27;t leak internal paths)</li>
 <li>Consider streaming instead of <code>readFile</code> for large files (memory pressure)</li>
 </ul>
 </li>
 <li><strong>Pre-existing security issue Gemini flagged:</strong> <code>isPathAllowed</code> uses startsWith — vulnerable to prefix-based path traversal. Affects ALL existing routes (<code>/list</code>, <code>/read</code>, <code>/search</code>, <code>/upload</code>) AND this new <code>/download</code>. Should be its own hardening PR.</li>
 </ul>
 </li>
-<li><p><strong>PR #20</strong> — <code>fix: code block horizontal scroll in markdown viewer</code></p>
+<li>
+<p><strong>PR #20</strong> — <code>fix: code block horizontal scroll in markdown viewer</code></p>
 <ul>
-<li>Two commits: original fix + follow-up addressing Gemini&#39;s &quot;right padding lost on scroll&quot; finding</li>
+<li>Two commits: original fix + follow-up addressing Gemini&#x27;s &quot;right padding lost on scroll&quot; finding</li>
 <li>Now includes <code>width: max-content; min-width: 100%</code> on <code>pre code</code></li>
 <li>Verdict: APPROVE</li>
 </ul>
 </li>
-<li><p><strong>PR #22</strong> — <code>feat: render Mermaid diagrams in markdown viewer</code></p>
+<li>
+<p><strong>PR #22</strong> — <code>feat: render Mermaid diagrams in markdown viewer</code></p>
 <ul>
 <li>Lazy-loaded mermaid (main bundle stays at 595KB, mermaid in own 652KB chunk)</li>
 <li>Two commits: initial component + follow-up wiring (vite.config.ts manualChunks, MarkdownViewer integration, mermaid dependency)</li>
 <li>Verdict: pending agent re-review (running)</li>
 </ul>
 </li>
-<li><p><strong>PR #23</strong> — <code>feat: file viewer sort control with persistence</code></p>
+<li>
+<p><strong>PR #23</strong> — <code>feat: file viewer sort control with persistence</code></p>
 <ul>
 <li>Inline sort control row in FileViewer header</li>
 <li>localStorage persistence + SortMode type promotion + sort logic hardening</li>
@@ -480,14 +427,15 @@ exports[`MarkdownViewer (marked baseline) > renders 11-real-doc-overnight-summar
 </ul>
 </li>
 </ol>
-<hr>
-<h2>Big-picture decisions waiting for your input</h2>
-<p>These are the three synthesis docs from the devil&#39;s advocate sessions. Each has my recommended answers — if you agree with my recs, just say &quot;go&quot; and I&#39;ll execute. If you disagree, tell me which.</p>
-<h3>Reading list feature</h3>
+<hr/>
+<h2 id="big-picture-decisions-waiting-for-your-input">Big-picture decisions waiting for your input</h2>
+<p>These are the three synthesis docs from the devil&#x27;s advocate sessions. Each has my recommended answers — if you agree with my recs, just say &quot;go&quot; and I&#x27;ll execute. If you disagree, tell me which.</p>
+<h3 id="reading-list-feature">Reading list feature</h3>
 <ul>
 <li><strong>Doc:</strong> <code>tmp/20260406-reading-list-synthesis.md</code></li>
 <li><strong>3 reviewers:</strong> Gemini (RETHINK), Codex (NEEDS WORK), Sonnet (NEEDS WORK)</li>
-<li><strong>6 decisions to make:</strong><ol>
+<li><strong>6 decisions to make:</strong>
+<ol>
 <li>Hard delete instead of soft delete (my rec: yes)</li>
 <li>Reject <code>default</code> user for reading list endpoints (my rec: yes — security)</li>
 <li>Save button in ActionBar instead of FileViewer header (my rec: yes — consistency)</li>
@@ -497,148 +445,111 @@ exports[`MarkdownViewer (marked baseline) > renders 11-real-doc-overnight-summar
 </ol>
 </li>
 </ul>
-<h3>Claude&#39;s World portability / .world directory</h3>
+<h3 id="claudes-world-portability--world-directory">Claude&#x27;s World portability / .world directory</h3>
 <ul>
 <li><strong>Doc:</strong> <code>tmp/20260406-portability-synthesis.md</code></li>
 <li><strong>2 reviewers:</strong> Gemini (RETHINK), Codex (NEEDS WORK)</li>
-<li><strong>Key takeaway:</strong> ADR 0001 (CPC + toolbox submodule) already addresses most critiques. The original maximalist monorepo doc has one factual contradiction to fix (don&#39;t version live state in git). 5 follow-up ADRs identified.</li>
+<li><strong>Key takeaway:</strong> ADR 0001 (CPC + toolbox submodule) already addresses most critiques. The original maximalist monorepo doc has one factual contradiction to fix (don&#x27;t version live state in git). 5 follow-up ADRs identified.</li>
 <li><strong>My rec:</strong> Keep ADR 0001 as Proposed and continue. Update the original design doc to remove the monorepo-version-memory contradiction.</li>
 </ul>
-<h3>Light/dark mode</h3>
+<h3 id="lightdark-mode">Light/dark mode</h3>
 <ul>
 <li><strong>Doc:</strong> <code>tmp/20260406-theme-synthesis.md</code></li>
 <li><strong>1 reviewer:</strong> Gemini (RETHINK)</li>
 <li><strong>Critical issue:</strong> No accessibility/contrast analysis for the proposed light palette</li>
 <li><strong>My rec:</strong> Defer entirely until you have time for a proper week-long migration. The current plan is correct but not a sleep-time job.</li>
 </ul>
-<hr>
-<h2>Documents shipped to your Telegram tonight</h2>
-<table>
-<thead>
-<tr>
-<th>Doc</th>
-<th>Type</th>
-</tr>
-</thead>
-<tbody><tr>
-<td>ADR 0001 — CPC + toolbox submodule packaging</td>
-<td>Decision</td>
-</tr>
-<tr>
-<td>ADR 0003 — Port allocation v2 / port-for</td>
-<td>Decision</td>
-</tr>
-<tr>
-<td>Reading list 3-way DA synthesis</td>
-<td>Synthesis</td>
-</tr>
-<tr>
-<td>Portability 2-way DA synthesis</td>
-<td>Synthesis</td>
-</tr>
-<tr>
-<td>Theme DA review</td>
-<td>Synthesis</td>
-</tr>
-<tr>
-<td>PR reviews summary (5 PRs)</td>
-<td>Status</td>
-</tr>
-<tr>
-<td>Overnight status hour 1</td>
-<td>Status</td>
-</tr>
-<tr>
-<td>.world skeleton README</td>
-<td>Proposal</td>
-</tr>
-<tr>
-<td>.world skeleton AGENTS.md</td>
-<td>Proposal</td>
-</tr>
-<tr>
-<td>USDX white paper (downloadable)</td>
-<td>Re-shared</td>
-</tr>
-</tbody></table>
+<hr/>
+<h2 id="documents-shipped-to-your-telegram-tonight">Documents shipped to your Telegram tonight</h2>
+<div class="md-table-scroll"><table><thead><tr><th>Doc</th><th>Type</th></tr></thead><tbody><tr><td>ADR 0001 — CPC + toolbox submodule packaging</td><td>Decision</td></tr><tr><td>ADR 0003 — Port allocation v2 / port-for</td><td>Decision</td></tr><tr><td>Reading list 3-way DA synthesis</td><td>Synthesis</td></tr><tr><td>Portability 2-way DA synthesis</td><td>Synthesis</td></tr><tr><td>Theme DA review</td><td>Synthesis</td></tr><tr><td>PR reviews summary (5 PRs)</td><td>Status</td></tr><tr><td>Overnight status hour 1</td><td>Status</td></tr><tr><td>.world skeleton README</td><td>Proposal</td></tr><tr><td>.world skeleton AGENTS.md</td><td>Proposal</td></tr><tr><td>USDX white paper (downloadable)</td><td>Re-shared</td></tr></tbody></table></div>
 <p>All are saved in <code>~/claudes-world/tmp/</code> or <code>~/claudes-world/knowledge/</code> and can be re-shared via the deep-link system.</p>
-<hr>
-<h2>Outside-the-box ideas (ranked by ROI × feasibility)</h2>
-<h3>For Claude&#39;s World infrastructure</h3>
+<hr/>
+<h2 id="outside-the-box-ideas-ranked-by-roi--feasibility">Outside-the-box ideas (ranked by ROI × feasibility)</h2>
+<h3 id="for-claudes-world-infrastructure">For Claude&#x27;s World infrastructure</h3>
 <ol>
-<li><p><strong>Morning brief cron job</strong> — runs at 7am ET, sends a markdown doc with overnight git changes, open PRs needing review, weather, calendar (when OAuth wired), memory-based reminders.</p>
+<li>
+<p><strong>Morning brief cron job</strong> — runs at 7am ET, sends a markdown doc with overnight git changes, open PRs needing review, weather, calendar (when OAuth wired), memory-based reminders.</p>
 <ul>
-<li>ROI: HIGH — zero ongoing effort, captures all the context you&#39;d assemble manually</li>
+<li>ROI: HIGH — zero ongoing effort, captures all the context you&#x27;d assemble manually</li>
 <li>Feasibility: HIGH — ~1-2 hours of work, all pieces exist</li>
 <li>Recommended next step</li>
 </ul>
 </li>
-<li><p><strong>A &quot;next thing to work on&quot; agent</strong> — ask via Telegram, scans TODO.md / open PRs / recent memories / calendar, suggests highest-leverage next action.</p>
+<li>
+<p><strong>A &quot;next thing to work on&quot; agent</strong> — ask via Telegram, scans TODO.md / open PRs / recent memories / calendar, suggests highest-leverage next action.</p>
 <ul>
 <li>ROI: HIGH — decision fatigue is real</li>
 <li>Feasibility: HIGH — small focused skill, 1 hour to write</li>
 </ul>
 </li>
-<li><p><strong>Sleep-aware agent operation</strong> — agents stop dispatching new high-risk work after midnight ET unless explicitly told. Morning checks are still allowed but mutations are paused.</p>
+<li>
+<p><strong>Sleep-aware agent operation</strong> — agents stop dispatching new high-risk work after midnight ET unless explicitly told. Morning checks are still allowed but mutations are paused.</p>
 <ul>
 <li>ROI: MEDIUM-HIGH — prevents bad-overnight surprises</li>
 <li>Feasibility: HIGH — trivial guard at agent dispatch</li>
 </ul>
 </li>
-<li><p><strong>Auto-archive <code>quarantine/</code> after 30 days</strong> — cron moves untrusted research artifacts older than 30 days into compressed archive.</p>
+<li>
+<p><strong>Auto-archive <code>quarantine/</code> after 30 days</strong> — cron moves untrusted research artifacts older than 30 days into compressed archive.</p>
 <ul>
 <li>ROI: LOW-MEDIUM — keeps active workspace clean</li>
 <li>Feasibility: HIGH — 10-line bash + systemd timer</li>
 </ul>
 </li>
-<li><p><strong>Meta-skill: lints other skills</strong> — periodic agent that scans <code>~/.claude/skills/</code> against the skill-authoring-tips guide. Flags any missing descriptions, vague triggers, etc.</p>
+<li>
+<p><strong>Meta-skill: lints other skills</strong> — periodic agent that scans <code>~/.claude/skills/</code> against the skill-authoring-tips guide. Flags any missing descriptions, vague triggers, etc.</p>
 <ul>
 <li>ROI: MEDIUM — prevents skill bloat over time</li>
 <li>Feasibility: MEDIUM — couple hours</li>
 </ul>
 </li>
 </ol>
-<h3>For your IRL life (Liam)</h3>
+<h3 id="for-your-irl-life-liam">For your IRL life (Liam)</h3>
 <ol>
-<li><p><strong>Conference contact card MVP</strong> (the one we discussed) — single highest-leverage thing you could ship next month for IRL networking. Day or two of work, transforms every conference for you.</p>
+<li>
+<p><strong>Conference contact card MVP</strong> (the one we discussed) — single highest-leverage thing you could ship next month for IRL networking. Day or two of work, transforms every conference for you.</p>
 <ul>
 <li>ROI: VERY HIGH — every conference becomes 10x more connectable</li>
 <li>Feasibility: HIGH — small feature, you already have a Telegram presence</li>
 </ul>
 </li>
-<li><p><strong>Daily &quot;what did I learn today&quot; capture</strong> — voice memo at end of day → transcription → LLM summary → committed to a personal knowledge base in <code>claudes-world/journal/</code>. Compound interest on insights over months.</p>
+<li>
+<p><strong>Daily &quot;what did I learn today&quot; capture</strong> — voice memo at end of day → transcription → LLM summary → committed to a personal knowledge base in <code>claudes-world/journal/</code>. Compound interest on insights over months.</p>
 <ul>
 <li>ROI: HIGH if you actually use it</li>
 <li>Feasibility: HIGH — 2 hours, voice-hook already exists</li>
 </ul>
 </li>
-<li><p><strong>Dev-tunnel uptime monitor</strong> — ntfy hook pings cpc.claude.do/dev every 5 min, notifies if down for 2+ checks. Stops weird issues from going unnoticed.</p>
+<li>
+<p><strong>Dev-tunnel uptime monitor</strong> — ntfy hook pings cpc.claude.do/dev every 5 min, notifies if down for 2+ checks. Stops weird issues from going unnoticed.</p>
 <ul>
 <li>ROI: MEDIUM — prevents debugging-at-3am</li>
 <li>Feasibility: HIGH — 30 minutes</li>
 </ul>
 </li>
-<li><p><strong>Auto-tagging for shared docs</strong> — share-doc generates audio with rich ID3 metadata via topic detection. Turns your shared docs into a personal podcast feed.</p>
+<li>
+<p><strong>Auto-tagging for shared docs</strong> — share-doc generates audio with rich ID3 metadata via topic detection. Turns your shared docs into a personal podcast feed.</p>
 <ul>
 <li>ROI: MEDIUM-HIGH (turns reading queue into listening queue)</li>
 <li>Feasibility: HIGH — tag-mp3 binary already supports it</li>
 </ul>
 </li>
-<li><p><strong>Conference-mode auto-Calendly</strong> — when conference mode is on (the contact card idea), automatically open 15-min &quot;coffee chat&quot; availability.</p>
+<li>
+<p><strong>Conference-mode auto-Calendly</strong> — when conference mode is on (the contact card idea), automatically open 15-min &quot;coffee chat&quot; availability.</p>
 <ul>
 <li>ROI: HIGH during events, low otherwise</li>
 <li>Feasibility: MEDIUM — needs Calendly API</li>
 </ul>
 </li>
 </ol>
-<hr>
-<h2>Issues / things to know</h2>
-<h3>1. Dev tunnel 502 (worktree coordination)</h3>
+<hr/>
+<h2 id="issues--things-to-know">Issues / things to know</h2>
+<h3 id="1-dev-tunnel-502-worktree-coordination">1. Dev tunnel 502 (worktree coordination)</h3>
 <p><strong>Current state:</strong> <code>https://cpc.claude.do/dev/</code> returns 502.</p>
-<p><strong>Why:</strong> Multiple agents share <code>~/code/claude-pocket-console</code> worktree and check out different feature branches. The cpc-dev.service serves whatever branch is currently checked out. Currently it&#39;s on <code>feat/file-viewer-sort-control</code> (PR #23&#39;s branch), which doesn&#39;t have the IPv4 fix. Vite is bound to <code>[::1]:58830</code> (IPv6 only), Caddy can&#39;t proxy to <code>127.0.0.1:58830</code>.</p>
+<p><strong>Why:</strong> Multiple agents share <code>~/code/claude-pocket-console</code> worktree and check out different feature branches. The cpc-dev.service serves whatever branch is currently checked out. Currently it&#x27;s on <code>feat/file-viewer-sort-control</code> (PR #23&#x27;s branch), which doesn&#x27;t have the IPv4 fix. Vite is bound to <code>[::1]:58830</code> (IPv6 only), Caddy can&#x27;t proxy to <code>127.0.0.1:58830</code>.</p>
 <p><strong>Fix:</strong> Merge PR #21 to dev. Once IPv4 fix lands on dev, every feature branch will inherit it.</p>
-<p><strong>Lesson learned:</strong> This proves the worktree-aware port allocation idea (ADR 0003) — agents need their own worktrees. I&#39;ll avoid launching parallel CPC agents going forward until we have proper isolation.</p>
-<h3>2. Toolbox dirty state (pre-existing)</h3>
+<p><strong>Lesson learned:</strong> This proves the worktree-aware port allocation idea (ADR 0003) — agents need their own worktrees. I&#x27;ll avoid launching parallel CPC agents going forward until we have proper isolation.</p>
+<h3 id="2-toolbox-dirty-state-pre-existing">2. Toolbox dirty state (pre-existing)</h3>
 <p>The toolbox repo has uncommitted changes from before I arrived:</p>
 <ul>
 <li><code>hooks/agent-stop-hook</code> (small)</li>
@@ -647,70 +558,71 @@ exports[`MarkdownViewer (marked baseline) > renders 11-real-doc-overnight-summar
 <li><code>tg-sanitize/</code> (untracked directory)</li>
 </ul>
 <p>I left these alone. They look intentional but are not on any branch. Worth checking what they are and either committing or stashing properly.</p>
-<h3>3. send-md fix branch is currently checked out</h3>
-<p>Toolbox is currently on <code>feat/scrum-button-and-share-doc-fix</code> (toolbox PR #2&#39;s branch). This is intentional — that branch has the share-doc Mode 2 fix, which is what&#39;s powering the send-md skill right now via the symlink at <code>~/bin/share-doc</code>. If you switch toolbox branches, send-md will revert to the old broken behavior until you switch back or merge.</p>
+<h3 id="3-send-md-fix-branch-is-currently-checked-out">3. send-md fix branch is currently checked out</h3>
+<p>Toolbox is currently on <code>feat/scrum-button-and-share-doc-fix</code> (toolbox PR #2&#x27;s branch). This is intentional — that branch has the share-doc Mode 2 fix, which is what&#x27;s powering the send-md skill right now via the symlink at <code>~/bin/share-doc</code>. If you switch toolbox branches, send-md will revert to the old broken behavior until you switch back or merge.</p>
 <p><strong>Recommended:</strong> Merge toolbox PR #2 first thing in the morning to permanently land the share-doc fix.</p>
-<h3>4. Pre-existing isPathAllowed security issue</h3>
-<p>Gemini flagged this on PR #18 but it&#39;s NOT introduced by PR #18 — it&#39;s pre-existing in <code>apps/server/src/routes/files.ts</code>. The <code>isPathAllowed</code> function uses <code>startsWith</code> which is vulnerable to prefix-based path traversal. Affects <code>/list</code>, <code>/read</code>, <code>/search</code>, <code>/upload</code>, AND the new <code>/download</code>.</p>
+<h3 id="4-pre-existing-ispathallowed-security-issue">4. Pre-existing isPathAllowed security issue</h3>
+<p>Gemini flagged this on PR #18 but it&#x27;s NOT introduced by PR #18 — it&#x27;s pre-existing in <code>apps/server/src/routes/files.ts</code>. The <code>isPathAllowed</code> function uses <code>startsWith</code> which is vulnerable to prefix-based path traversal. Affects <code>/list</code>, <code>/read</code>, <code>/search</code>, <code>/upload</code>, AND the new <code>/download</code>.</p>
 <p><strong>My recommendation:</strong> File a separate hardening PR. Should not block PR #18 from merging (the vulnerability exists with or without #18).</p>
-<hr>
-<h2>Stats</h2>
+<hr/>
+<h2 id="stats">Stats</h2>
 <ul>
 <li><strong>PRs opened:</strong> 8 (5 CPC + 3 toolbox*) — *toolbox #1 was opened before this session</li>
 <li><strong>PRs reviewed by me:</strong> 7 (all CPC + toolbox #1)</li>
 <li><strong>Background agents launched:</strong> ~13</li>
-<li><strong>Devil&#39;s advocate reviews run:</strong> 6 (3 reading list, 2 portability, 1 theme)</li>
+<li><strong>Devil&#x27;s advocate reviews run:</strong> 6 (3 reading list, 2 portability, 1 theme)</li>
 <li><strong>ADRs written:</strong> 2 (0001, 0003)</li>
 <li><strong>Synthesis docs:</strong> 3 (reading list, portability, theme)</li>
 <li><strong>Skeleton stub files:</strong> 9 in <code>tmp/world-skeleton/</code></li>
 <li><strong>TODO items closed:</strong> 6 (the in-flight CPC features)</li>
 <li><strong>TODO items added:</strong> 8 (follow-up items + new ADRs to write)</li>
 </ul>
-<hr>
-<h2>What I plan for hour 2 (and beyond)</h2>
-<p>The next hour cron will fire at :13 (in ~25 minutes from this writing). When it does, I&#39;ll:</p>
+<hr/>
+<h2 id="what-i-plan-for-hour-2-and-beyond">What I plan for hour 2 (and beyond)</h2>
+<p>The next hour cron will fire at :13 (in ~25 minutes from this writing). When it does, I&#x27;ll:</p>
 <ol>
 <li>Check on the in-flight PR reviews for #22 and #23</li>
 <li>Address any should-fix items those reviews surface (in same-branch commits)</li>
 <li>Update TODO.md if anything new shipped</li>
 <li>Send a brief status check-in (probably shorter than this final report)</li>
 </ol>
-<p>Beyond that, my plan is to slow down and be conservative. The big shipping push is done. I&#39;ll:</p>
+<p>Beyond that, my plan is to slow down and be conservative. The big shipping push is done. I&#x27;ll:</p>
 <ul>
 <li>Watch for incoming Telegram messages from you</li>
-<li>Continue polishing what&#39;s open</li>
+<li>Continue polishing what&#x27;s open</li>
 <li>NOT start any new big features without your approval</li>
 <li>NOT touch any prod systems</li>
 <li>NOT merge anything</li>
 </ul>
 <p>If you wake up and want to fast-merge everything, the recommended order is at the top of this doc. If you want me to wait, just say so.</p>
-<hr>
-<h2>Sleep well, Liam.</h2>
-<p>The system is in good shape. Lots of value sitting in the PR queue waiting for your review. The big architectural conversations have concrete recommendations. The synthesis docs are ready to discuss when you&#39;re ready.</p>
-<p>— Claude</p>
-"
+<hr/>
+<h2 id="sleep-well-liam">Sleep well, Liam.</h2>
+<p>The system is in good shape. Lots of value sitting in the PR queue waiting for your review. The big architectural conversations have concrete recommendations. The synthesis docs are ready to discuss when you&#x27;re ready.</p>
+<p>— Claude</p></div>"
 `;
 
-exports[`MarkdownViewer (marked baseline) > renders 12-real-doc-collapsible-headings-plan.md consistently 1`] = `
-"<p>I have everything I need. Note that mermaid is not rendered interactively — there&#39;s no existing post-process pattern in MarkdownViewer using <code>createRoot</code>. Now I&#39;ll deliver the plan.</p>
-<hr>
-<h1>Collapsible Heading Sections — Implementation Plan</h1>
-<p><strong>Date:</strong> 2026-04-07<br><strong>Feature:</strong> Disclosure triangles next to headings in the CPC markdown viewer that collapse/expand sections, with optional sync to a future TOC drawer.<br><strong>Note on file output:</strong> This planning task is read-only — I cannot save the plan to <code>tmp/</code>. The full plan is below; copy/paste it wherever you&#39;d like it to live.</p>
-<hr>
-<h2>TL;DR</h2>
-<p>Add disclosure triangles next to every heading in <code>MarkdownViewer.tsx</code> so Liam can collapse long sections of a markdown doc. Use <strong>Option A (DOM post-processing via ref)</strong> because the existing component already uses <code>dangerouslySetInnerHTML</code>, the change is local, and we don&#39;t add a runtime dependency. Store fold state as a <code>Set&lt;string&gt;</code> of heading slugs in React state, <strong>lifted to <code>App.tsx</code></strong> so a future <code>TocSheet</code> component can share it. Implement collapse via <code>display: none</code> on the DOM nodes between a heading and the next same-or-higher-level heading. <strong>Effort: Medium — ~1 day standalone, ~1.5–2 days if shipped together with the TOC drawer (because heading-id assignment, the lift to <code>App.tsx</code>, and shared-state plumbing become a single coordinated PR).</strong></p>
+exports[`MarkdownViewer (react-markdown baseline) > renders 12-real-doc-collapsible-headings-plan.md consistently 1`] = `
+"<div class="md-content"><p>I have everything I need. Note that mermaid is not rendered interactively — there&#x27;s no existing post-process pattern in MarkdownViewer using <code>createRoot</code>. Now I&#x27;ll deliver the plan.</p>
+<hr/>
+<h1 id="collapsible-heading-sections--implementation-plan">Collapsible Heading Sections — Implementation Plan</h1>
+<p><strong>Date:</strong> 2026-04-07<br/>
+<strong>Feature:</strong> Disclosure triangles next to headings in the CPC markdown viewer that collapse/expand sections, with optional sync to a future TOC drawer.<br/>
+<strong>Note on file output:</strong> This planning task is read-only — I cannot save the plan to <code>tmp/</code>. The full plan is below; copy/paste it wherever you&#x27;d like it to live.</p>
+<hr/>
+<h2 id="tldr">TL;DR</h2>
+<p>Add disclosure triangles next to every heading in <code>MarkdownViewer.tsx</code> so Liam can collapse long sections of a markdown doc. Use <strong>Option A (DOM post-processing via ref)</strong> because the existing component already uses <code>dangerouslySetInnerHTML</code>, the change is local, and we don&#x27;t add a runtime dependency. Store fold state as a <code>Set&lt;string&gt;</code> of heading slugs in React state, <strong>lifted to <code>App.tsx</code></strong> so a future <code>TocSheet</code> component can share it. Implement collapse via <code>display: none</code> on the DOM nodes between a heading and the next same-or-higher-level heading. <strong>Effort: Medium — ~1 day standalone, ~1.5–2 days if shipped together with the TOC drawer (because heading-id assignment, the lift to <code>App.tsx</code>, and shared-state plumbing become a single coordinated PR).</strong></p>
 <p>The biggest discovery during scouting: <strong>marked v17 with <code>gfm: true</code> does NOT generate <code>id</code> attributes on headings.</strong> The v17 default <code>heading</code> renderer is literally <code>\`&lt;h\${depth}&gt;\${parseInline(tokens)}&lt;/h\${depth}&gt;\`</code> (verified in <code>apps/web/node_modules/marked/lib/marked.esm.js</code> line 57). The existing TOC proposal (<code>tmp/20260407-markdown-toc-and-audio-proposals.md</code> line 71) is wrong about this. Both this feature and the TOC feature need to assign IDs themselves, which is one more reason to ship them together: they share that prep work.</p>
-<hr>
-<h2>Part 1 — Current state scouting</h2>
-<h3>How markdown is rendered</h3>
+<hr/>
+<h2 id="part-1--current-state-scouting">Part 1 — Current state scouting</h2>
+<h3 id="how-markdown-is-rendered">How markdown is rendered</h3>
 <ul>
 <li><code>apps/web/src/components/MarkdownViewer.tsx</code> calls <code>marked.parse(content)</code> inside a <code>useMemo</code>, then injects the result via <code>dangerouslySetInnerHTML</code> into a <code>&lt;div className=&quot;md-content&quot;&gt;</code>. The component is otherwise styles + HTML; it has <strong>no ref, no post-processing, no event handlers</strong>.</li>
 <li><code>marked</code> is configured with <code>{ gfm: true, breaks: true }</code> only.</li>
 <li>The whole <code>.md-content</code> div lives inside an outer scrollable wrapper with <code>overflowY: auto</code>. Scroll position is managed by the browser.</li>
-<li>There&#39;s no virtual scrolling. Even very long docs render the entire DOM tree once.</li>
+<li>There&#x27;s no virtual scrolling. Even very long docs render the entire DOM tree once.</li>
 </ul>
-<h3>Heading IDs — the load-bearing finding</h3>
-<p>Marked v17&#39;s default renderer produces headings without <code>id</code> attributes. From <code>marked.esm.js</code>:</p>
+<h3 id="heading-ids--the-load-bearing-finding">Heading IDs — the load-bearing finding</h3>
+<p>Marked v17&#x27;s default renderer produces headings without <code>id</code> attributes. From <code>marked.esm.js</code>:</p>
 <pre><code>heading({tokens:e,depth:t}){return\`&lt;h\${t}&gt;\${this.parser.parseInline(e)}&lt;/h\${t}&gt;\\n\`}
 </code></pre>
 <p>So today the rendered HTML for <code>## Hello world</code> is just <code>&lt;h2&gt;Hello world&lt;/h2&gt;</code> — no anchor, no slug. Anything that needs to address headings (this feature, the TOC drawer, hash navigation) has to assign IDs after parse. That can be done either by:</p>
@@ -719,70 +631,70 @@ exports[`MarkdownViewer (marked baseline) > renders 12-real-doc-collapsible-head
 <li>Or post-processing the DOM after the inner HTML is set, walking <code>h1...h6</code>, generating slugs from <code>textContent</code>, and assigning <code>el.id</code>.</li>
 </ul>
 <p>The renderer-override approach is cleaner and the slug becomes part of the cached HTML (so it survives <code>useMemo</code> and stays stable across re-renders). I recommend that.</p>
-<h3>How long docs are typically rendered</h3>
+<h3 id="how-long-docs-are-typically-rendered">How long docs are typically rendered</h3>
 <ul>
 <li>No virtualization.</li>
 <li><code>padding: &quot;16px 16px&quot;</code> outer wrapper, with the styled <code>&lt;div class=&quot;md-content&quot;&gt;</code> inside.</li>
 <li>All children of <code>.md-content</code> are immediate siblings produced by marked: <code>h1</code>, <code>h2</code>, <code>p</code>, <code>ul</code>, <code>pre</code>, <code>blockquote</code>, <code>hr</code>, <code>table</code>, etc. <strong>This is critical for the collapse algorithm: section membership is determined by walking siblings, not descendants.</strong></li>
 </ul>
-<h3>Parent component</h3>
+<h3 id="parent-component">Parent component</h3>
 <ul>
 <li><code>FileViewer.tsx</code> hosts <code>&lt;MarkdownViewer content={fileContent} fileName={fileName} /&gt;</code> only when <code>fileContent !== null &amp;&amp; fileName.endsWith(&quot;.md&quot;)</code>.</li>
-<li><code>FileViewer</code> already maintains a <code>collapsedRanges: Set&lt;number&gt;</code> state for <strong>code-file line folding</strong> (line 76). It&#39;s per-file (reset in <code>loadDirectory</code>/<code>loadFile</code>/<code>handleBack</code>). That&#39;s the right pattern to mirror for markdown fold state, but it should live higher (in <code>App.tsx</code>) so the TOC drawer can share it.</li>
+<li><code>FileViewer</code> already maintains a <code>collapsedRanges: Set&lt;number&gt;</code> state for <strong>code-file line folding</strong> (line 76). It&#x27;s per-file (reset in <code>loadDirectory</code>/<code>loadFile</code>/<code>handleBack</code>). That&#x27;s the right pattern to mirror for markdown fold state, but it should live higher (in <code>App.tsx</code>) so the TOC drawer can share it.</li>
 </ul>
-<h3>Top-level state</h3>
+<h3 id="top-level-state">Top-level state</h3>
 <ul>
-<li><code>App.tsx</code> already tracks <code>viewingFile: { path, name } | null</code> (line 47), which is the file currently open in the markdown viewer. That&#39;s the natural key for fold state.</li>
+<li><code>App.tsx</code> already tracks <code>viewingFile: { path, name } | null</code> (line 47), which is the file currently open in the markdown viewer. That&#x27;s the natural key for fold state.</li>
 </ul>
-<h3>BottomSheet primitive</h3>
+<h3 id="bottomsheet-primitive">BottomSheet primitive</h3>
 <ul>
 <li><code>ActionBar.tsx</code> defines a local <code>BottomSheet</code> component (line 57) and uses it for ~10 modals already. The proposed TOC drawer would reuse it. Worth knowing because if/when the TOC ships, sync logic flows through whatever state lives in <code>App.tsx</code>.</li>
 </ul>
-<hr>
-<h2>Part 2 — Design decisions</h2>
-<h3>1. Triangle placement</h3>
+<hr/>
+<h2 id="part-2--design-decisions">Part 2 — Design decisions</h2>
+<h3 id="1-triangle-placement">1. Triangle placement</h3>
 <ul>
-<li><strong>Render position:</strong> outside the heading text, in the left margin. Use a span/button with <code>position: absolute; left: -20px; top: 50%; transform: translateY(-50%)</code> against an <code>h1...h6 { position: relative; padding-left: 0 }</code>. The viewer&#39;s outer wrapper has <code>padding: &quot;16px 16px&quot;</code> so there&#39;s 16px of room before content clips — enough for a 14px triangle plus a couple of px breathing room. If clipping is a concern on very narrow Telegram screens, bump the wrapper padding-left to 24px and place the triangle at <code>left: -22px</code>.</li>
+<li><strong>Render position:</strong> outside the heading text, in the left margin. Use a span/button with <code>position: absolute; left: -20px; top: 50%; transform: translateY(-50%)</code> against an <code>h1...h6 { position: relative; padding-left: 0 }</code>. The viewer&#x27;s outer wrapper has <code>padding: &quot;16px 16px&quot;</code> so there&#x27;s 16px of room before content clips — enough for a 14px triangle plus a couple of px breathing room. If clipping is a concern on very narrow Telegram screens, bump the wrapper padding-left to 24px and place the triangle at <code>left: -22px</code>.</li>
 <li><strong>Visual:</strong> triangle character (▼ expanded, ▶ collapsed) at ~14px, color <code>#565f89</code> (matches the dim-text color used elsewhere). On hover/focus, brighten to <code>#7aa2f7</code>.</li>
-<li><strong>Hit area:</strong> 32x32 transparent button centered on the triangle, so it&#39;s tappable on mobile. Use <code>padding</code> rather than width/height to keep visual size separate from hit area.</li>
+<li><strong>Hit area:</strong> 32x32 transparent button centered on the triangle, so it&#x27;s tappable on mobile. Use <code>padding</code> rather than width/height to keep visual size separate from hit area.</li>
 <li><strong>Default state:</strong> all expanded. Liam can always tap to collapse, but a doc that opens half-folded is confusing.</li>
 </ul>
-<h3>2. What counts as a &quot;section&quot;</h3>
+<h3 id="2-what-counts-as-a-section">2. What counts as a &quot;section&quot;</h3>
 <ul>
-<li>An <code>h\${N}</code> heading&#39;s section is <strong>every sibling DOM node after it, up to (but not including) the next sibling that is <code>h1</code>...<code>h\${N}</code></strong>. So an h2&#39;s section ends at the next h1 or h2; any h3/h4/h5/h6 in between belongs to the section.</li>
-<li>Nested triangles: a collapsed h2 hides everything after it including the h3 elements <em>and their triangles</em>. When the h2 expands again, those h3 triangles reappear in whatever state they were in before (if they were also collapsed, they stay collapsed). This falls out for free if the algorithm is just &quot;set <code>display: none</code> on the contained DOM nodes&quot; — re-expanding the parent restores the children&#39;s prior <code>display</code> state only if we&#39;re careful (see Part 4).</li>
+<li>An <code>h\${N}</code> heading&#x27;s section is <strong>every sibling DOM node after it, up to (but not including) the next sibling that is <code>h1</code>...<code>h\${N}</code></strong>. So an h2&#x27;s section ends at the next h1 or h2; any h3/h4/h5/h6 in between belongs to the section.</li>
+<li>Nested triangles: a collapsed h2 hides everything after it including the h3 elements <em>and their triangles</em>. When the h2 expands again, those h3 triangles reappear in whatever state they were in before (if they were also collapsed, they stay collapsed). This falls out for free if the algorithm is just &quot;set <code>display: none</code> on the contained DOM nodes&quot; — re-expanding the parent restores the children&#x27;s prior <code>display</code> state only if we&#x27;re careful (see Part 4).</li>
 <li><strong>First H1 special case:</strong> the top-level doc title (the first <code>h1</code> in the document) should NOT have a triangle. Collapsing it would hide everything. Detect by &quot;first H1 in the rendered output&quot; and skip it.</li>
-<li><strong>Empty section special case:</strong> if the next sibling is already a heading of same/higher level (i.e. the section has zero non-heading content), don&#39;t show a triangle for that heading. It would be a no-op.</li>
+<li><strong>Empty section special case:</strong> if the next sibling is already a heading of same/higher level (i.e. the section has zero non-heading content), don&#x27;t show a triangle for that heading. It would be a no-op.</li>
 </ul>
-<h3>3. State storage</h3>
+<h3 id="3-state-storage">3. State storage</h3>
 <ul>
-<li><code>foldedSections: Set&lt;string&gt;</code> keyed by heading <strong>slug</strong> (not by index — slugs are stable across re-renders, indices aren&#39;t if the user scrolls and React re-mounts).</li>
+<li><code>foldedSections: Set&lt;string&gt;</code> keyed by heading <strong>slug</strong> (not by index — slugs are stable across re-renders, indices aren&#x27;t if the user scrolls and React re-mounts).</li>
 <li><strong>Per-file:</strong> Reset whenever <code>viewingFile.path</code> changes. The simplest way is to key the state by file path: <code>foldedByFile: Map&lt;string, Set&lt;string&gt;&gt;</code>. Or even simpler: just drop the Set whenever <code>viewingFile.path</code> changes.</li>
 <li><strong>Persistence:</strong> none. Ephemeral React state. Recreating fold state on revisit is cheap (one tap), and persisting it to localStorage for every doc Liam ever opens would create stale entries forever.</li>
 <li><strong>Where it lives:</strong> Lift to <code>App.tsx</code>. Pass down to <code>MarkdownViewer</code> (which renders triangles + applies display: none) and to the future <code>TocSheet</code> (which renders the same fold indicators). See Part 5.</li>
 </ul>
-<h3>4. Animation</h3>
+<h3 id="4-animation">4. Animation</h3>
 <ul>
-<li><strong>v1: instant.</strong> No animation. <code>display: none</code> toggles immediately. Animating height is hard with <code>dangerouslySetInnerHTML</code> because we&#39;d need to wrap each section in a div with a known height for max-height transitions, which means more DOM mutation.</li>
+<li><strong>v1: instant.</strong> No animation. <code>display: none</code> toggles immediately. Animating height is hard with <code>dangerouslySetInnerHTML</code> because we&#x27;d need to wrap each section in a div with a known height for max-height transitions, which means more DOM mutation.</li>
 <li><strong>v2 (defer):</strong> if Liam asks for it, switch to wrapping each section in a <code>&lt;div data-section-of=&quot;\${slug}&quot;&gt;</code> during post-processing and animate via <code>max-height</code> + <code>overflow: hidden</code>. Skip for v1.</li>
 </ul>
-<h3>5. Interaction with the TOC drawer</h3>
+<h3 id="5-interaction-with-the-toc-drawer">5. Interaction with the TOC drawer</h3>
 <ul>
 <li><strong>Tap heading in TOC → expand on the way:</strong> When the user navigates to a heading, walk up its ancestor chain (h3 inside an h2 inside an h1) and remove all of those slugs from <code>foldedSections</code> before scrolling. This guarantees the target is visible.</li>
 <li><strong>TOC reflects collapse state:</strong> TOC entries whose ancestor heading is collapsed should be visually de-emphasized (grey) and clicking them still works (it expands the ancestor first, then scrolls).</li>
-<li><strong>TOC has its own triangles:</strong> Each parent heading row in the TOC gets its own little triangle that toggles the same <code>foldedSections</code> set. Tapping the triangle in the TOC collapses the section in the doc as well — they&#39;re literally the same state. This is the &quot;sync&quot; requirement and it falls out naturally if state is lifted.</li>
+<li><strong>TOC has its own triangles:</strong> Each parent heading row in the TOC gets its own little triangle that toggles the same <code>foldedSections</code> set. Tapping the triangle in the TOC collapses the section in the doc as well — they&#x27;re literally the same state. This is the &quot;sync&quot; requirement and it falls out naturally if state is lifted.</li>
 </ul>
-<h3>6. Click target semantics</h3>
+<h3 id="6-click-target-semantics">6. Click target semantics</h3>
 <ul>
-<li>Click triangle → toggle that section&#39;s slug in <code>foldedSections</code>.</li>
-<li>Click heading text → no-op. Don&#39;t toggle, don&#39;t scroll. Preserves text selection and the natural reading experience.</li>
+<li>Click triangle → toggle that section&#x27;s slug in <code>foldedSections</code>.</li>
+<li>Click heading text → no-op. Don&#x27;t toggle, don&#x27;t scroll. Preserves text selection and the natural reading experience.</li>
 <li>(Optional, defer) Long-press heading → collapse all siblings of same level — &quot;collapse all H2s&quot; gesture. Not in v1.</li>
 </ul>
-<hr>
-<h2>Part 3 — Technical approach</h2>
+<hr/>
+<h2 id="part-3--technical-approach">Part 3 — Technical approach</h2>
 <p>I evaluated all four options. <strong>Recommend: Option A — post-process the rendered HTML via a ref</strong>, with the small refinement that heading IDs are assigned by a custom marked renderer (not in the post-processing pass), so the slugs are stable and computed once.</p>
-<h3>Option A — Post-process the rendered HTML (RECOMMENDED)</h3>
-<p><strong>How:</strong> Keep <code>marked.parse</code> + <code>dangerouslySetInnerHTML</code> exactly as today. Add a <code>useRef&lt;HTMLDivElement&gt;</code> to the <code>.md-content</code> div. Add a <code>useLayoutEffect</code> that runs after each render: walk the children, find headings, compute each heading&#39;s section range (the sibling slice ending at the next same-or-higher heading), and:</p>
+<h3 id="option-a--post-process-the-rendered-html-recommended">Option A — Post-process the rendered HTML (RECOMMENDED)</h3>
+<p><strong>How:</strong> Keep <code>marked.parse</code> + <code>dangerouslySetInnerHTML</code> exactly as today. Add a <code>useRef&lt;HTMLDivElement&gt;</code> to the <code>.md-content</code> div. Add a <code>useLayoutEffect</code> that runs after each render: walk the children, find headings, compute each heading&#x27;s section range (the sibling slice ending at the next same-or-higher heading), and:</p>
 <ol>
 <li>Inject a triangle element (a <code>&lt;button&gt;</code> created with <code>document.createElement</code> is fine; no need for <code>createRoot</code> unless we want React to manage events) just before the heading text. Use event delegation on the wrapper div so we only attach one click listener total.</li>
 <li>For each heading whose slug is in <code>foldedSections</code>, set <code>style.display = &quot;none&quot;</code> on every node in its section range.</li>
@@ -791,7 +703,7 @@ exports[`MarkdownViewer (marked baseline) > renders 12-real-doc-collapsible-head
 <p><strong>Pros:</strong></p>
 <ul>
 <li>Zero new dependencies.</li>
-<li>Doesn&#39;t change the rendering pipeline.</li>
+<li>Doesn&#x27;t change the rendering pipeline.</li>
 <li>Easy to read and debug — the algorithm is one function.</li>
 <li>Handles the &quot;first H1 = title, no triangle&quot; case trivially.</li>
 <li>Heading-id assignment can be a one-line marked renderer override, decoupled from the fold logic.</li>
@@ -799,11 +711,11 @@ exports[`MarkdownViewer (marked baseline) > renders 12-real-doc-collapsible-head
 <p><strong>Cons:</strong></p>
 <ul>
 <li>Imperative DOM manipulation feels un-React-ish. Mitigate by keeping it in a single <code>useLayoutEffect</code> keyed on <code>[html, foldedSections]</code>.</li>
-<li>If marked re-runs and produces a new innerHTML, we re-walk the whole tree. That&#39;s fine — the doc isn&#39;t changing during fold/unfold, only fold state is.</li>
-<li>We have to remember the original <code>display</code> of each node we hide. Easiest: don&#39;t try to remember. Use a separate CSS class <code>.cpc-folded { display: none !important }</code> and toggle the class instead of inline styles. Then re-expanding just removes the class and the original display reappears. <strong>This is the cleanest fix.</strong></li>
+<li>If marked re-runs and produces a new innerHTML, we re-walk the whole tree. That&#x27;s fine — the doc isn&#x27;t changing during fold/unfold, only fold state is.</li>
+<li>We have to remember the original <code>display</code> of each node we hide. Easiest: don&#x27;t try to remember. Use a separate CSS class <code>.cpc-folded { display: none !important }</code> and toggle the class instead of inline styles. Then re-expanding just removes the class and the original display reappears. <strong>This is the cleanest fix.</strong></li>
 </ul>
-<h3>Option B — marked custom renderer + event delegation</h3>
-<p><strong>How:</strong> <code>marked.use({ renderer: { heading({ tokens, depth }) { return </code>&lt;h\${depth} id=&quot;\${slug}&quot;&gt;<button class="cpc-toggle" data-slug="\${slug}">▼</button>\${parseInline(tokens)}&lt;/h\${depth}&gt;<code> } } })</code>. Then in MarkdownViewer, attach one click handler to the wrapper that listens for clicks on <code>.cpc-toggle</code>.</p>
+<h3 id="option-b--marked-custom-renderer--event-delegation">Option B — marked custom renderer + event delegation</h3>
+<p><strong>How:</strong> <code>marked.use({ renderer: { heading({ tokens, depth }) { return </code>&lt;h\${depth} id=&quot;\${slug}&quot;&gt;&lt;button class=&quot;cpc-toggle&quot; data-slug=&quot;\${slug}&quot;&gt;▼&lt;/button&gt;\${parseInline(tokens)}&lt;/h\${depth}&gt;<code> } } })</code>. Then in MarkdownViewer, attach one click handler to the wrapper that listens for clicks on <code>.cpc-toggle</code>.</p>
 <p><strong>Pros:</strong></p>
 <ul>
 <li>The triangle is part of the HTML — no second DOM walk to inject buttons.</li>
@@ -811,11 +723,11 @@ exports[`MarkdownViewer (marked baseline) > renders 12-real-doc-collapsible-head
 </ul>
 <p><strong>Cons:</strong></p>
 <ul>
-<li>The triangle is now inside the heading&#39;s text flow, not in the margin. To get it back to the margin we&#39;d need absolute positioning anyway, which means CSS that depends on the heading being <code>position: relative</code>. Works, but uglier.</li>
+<li>The triangle is now inside the heading&#x27;s text flow, not in the margin. To get it back to the margin we&#x27;d need absolute positioning anyway, which means CSS that depends on the heading being <code>position: relative</code>. Works, but uglier.</li>
 <li>Still need a separate post-processing pass to apply <code>display: none</code> based on fold state, because the renderer runs once at parse time and the fold state changes after.</li>
-<li>So Option B = Option A&#39;s complexity + a renderer override. No win.</li>
+<li>So Option B = Option A&#x27;s complexity + a renderer override. No win.</li>
 </ul>
-<h3>Option C — Switch to react-markdown</h3>
+<h3 id="option-c--switch-to-react-markdown">Option C — Switch to react-markdown</h3>
 <p><strong>How:</strong> Replace marked with react-markdown. Headings become real React components that can have interactive children natively.</p>
 <p><strong>Pros:</strong></p>
 <ul>
@@ -826,41 +738,42 @@ exports[`MarkdownViewer (marked baseline) > renders 12-real-doc-collapsible-head
 <ul>
 <li>New dependency (react-markdown + rehype + remark — meaningfully larger bundle, ~50–80KB minified depending on plugins).</li>
 <li>Existing styles, table handling, code blocks, GFM behavior all need to be re-verified.</li>
-<li>It&#39;s a much bigger PR with more risk for a feature that doesn&#39;t strictly require it.</li>
-<li>Doesn&#39;t solve the &quot;section is the slice of siblings between headings&quot; problem any better — react-markdown still produces a flat list of sibling elements at the top level. You still need to compute section ranges and conditionally hide them.</li>
+<li>It&#x27;s a much bigger PR with more risk for a feature that doesn&#x27;t strictly require it.</li>
+<li>Doesn&#x27;t solve the &quot;section is the slice of siblings between headings&quot; problem any better — react-markdown still produces a flat list of sibling elements at the top level. You still need to compute section ranges and conditionally hide them.</li>
 </ul>
-<h3>Option D — Render token tree manually</h3>
-<p><strong>How:</strong> Use marked&#39;s tokenizer to get the AST, then render to React elements ourselves.</p>
+<h3 id="option-d--render-token-tree-manually">Option D — Render token tree manually</h3>
+<p><strong>How:</strong> Use marked&#x27;s tokenizer to get the AST, then render to React elements ourselves.</p>
 <p><strong>Pros:</strong></p>
 <ul>
 <li>Maximum control. Sections could be wrapped in real React components with proper conditional rendering.</li>
 </ul>
 <p><strong>Cons:</strong></p>
 <ul>
-<li>Massive scope: re-implementing tables, code blocks, lists, blockquotes, GFM. The current viewer leans on marked&#39;s HTML output for all of this.</li>
-<li>This is not a one-day task. It&#39;s a rewrite.</li>
+<li>Massive scope: re-implementing tables, code blocks, lists, blockquotes, GFM. The current viewer leans on marked&#x27;s HTML output for all of this.</li>
+<li>This is not a one-day task. It&#x27;s a rewrite.</li>
 </ul>
-<h3>Recommendation</h3>
+<h3 id="recommendation">Recommendation</h3>
 <p>Go with <strong>Option A</strong>. The fold logic stays in one <code>useLayoutEffect</code> in <code>MarkdownViewer.tsx</code>. Heading IDs come from a marked renderer override (the only thing we change about the parse pipeline). Triangles are injected as plain DOM buttons; clicks are handled via event delegation. State lives in <code>App.tsx</code>. No new dependencies.</p>
-<hr>
-<h2>Part 4 — The collapse mechanic</h2>
-<h3>Algorithm (sibling-slice walk)</h3>
+<hr/>
+<h2 id="part-4--the-collapse-mechanic">Part 4 — The collapse mechanic</h2>
+<h3 id="algorithm-sibling-slice-walk">Algorithm (sibling-slice walk)</h3>
 <p>After <code>marked.parse</code> runs and the HTML is in the DOM, in a <code>useLayoutEffect</code>:</p>
 <ol>
-<li>Get a flat list of <code>.md-content</code>&#39;s direct children: <code>const nodes = Array.from(rootRef.current.children)</code>. (They&#39;re already in document order — that&#39;s how marked emits them.)</li>
+<li>Get a flat list of <code>.md-content</code>&#x27;s direct children: <code>const nodes = Array.from(rootRef.current.children)</code>. (They&#x27;re already in document order — that&#x27;s how marked emits them.)</li>
 <li>Find headings: <code>const headings = nodes.filter(n =&gt; /^H[1-6]$/.test(n.tagName))</code>. Each heading remembers its index in <code>nodes</code> and its level (1–6, parsed from tagName).</li>
 <li>Skip the first H1 (the doc title) — no triangle.</li>
-<li>For every other heading at index <code>i</code> with level <code>L</code>:<ul>
+<li>For every other heading at index <code>i</code> with level <code>L</code>:
+<ul>
 <li>Find the next heading at index <code>j &gt; i</code> with level <code>&lt;= L</code>. If none, <code>j = nodes.length</code>.</li>
 <li>The section is <code>nodes.slice(i + 1, j)</code>.</li>
 <li>If the section is empty (i.e. <code>j === i + 1</code> and the next thing is another heading), this heading is non-foldable: skip injecting a triangle for it.</li>
-<li>Otherwise, inject a triangle button just before the heading&#39;s first child (or as a positioned-absolute child of the heading), with <code>data-slug=&quot;\${heading.id}&quot;</code>.</li>
+<li>Otherwise, inject a triangle button just before the heading&#x27;s first child (or as a positioned-absolute child of the heading), with <code>data-slug=&quot;\${heading.id}&quot;</code>.</li>
 </ul>
 </li>
 <li>After triangles are injected, apply fold state: for each heading whose slug is in <code>foldedSections</code>, add <code>cpc-folded</code> class to every node in its section. This is what hides them. For each heading NOT in the set, remove the class from its section.</li>
-<li>Update each triangle&#39;s text content: ▼ if expanded, ▶ if collapsed. Optional: append <code>(N)</code> where N is the count of non-empty paragraphs/elements in the section, so collapsed sections show &quot;▶ (12)&quot;.</li>
+<li>Update each triangle&#x27;s text content: ▼ if expanded, ▶ if collapsed. Optional: append <code>(N)</code> where N is the count of non-empty paragraphs/elements in the section, so collapsed sections show &quot;▶ (12)&quot;.</li>
 </ol>
-<h3>Hide mechanism: a single CSS class</h3>
+<h3 id="hide-mechanism-a-single-css-class">Hide mechanism: a single CSS class</h3>
 <p>Add to the existing <code>&lt;style&gt;</code> block:</p>
 <pre><code class="language-css">.cpc-folded { display: none !important; }
 .md-content h1, .md-content h2, .md-content h3,
@@ -881,14 +794,14 @@ exports[`MarkdownViewer (marked baseline) > renders 12-real-doc-collapsible-head
 .md-content .cpc-toggle:hover { color: #7aa2f7; }
 </code></pre>
 <p>Then <code>node.classList.add(&quot;cpc-folded&quot;)</code> / <code>removeAttribute(&quot;class&quot;)</code> is the entire collapse mechanic. We never touch <code>style.display</code>, so we never have to remember original display values. This cleanly handles <code>display: block</code>, <code>display: flex</code> (none of the markdown elements use it but defensively), <code>display: table</code> (for <code>&lt;table&gt;</code>), etc.</p>
-<h3>Nested fold preservation</h3>
-<p>Because hidden ancestors don&#39;t run their own fold logic (we just <code>display: none</code> everything inside them), a collapsed h3 stays in <code>foldedSections</code> even when its parent h2 is also collapsed. When the h2 expands, the h3 remains collapsed because its slug is still in the set and the next post-process pass re-applies it. Exactly what we want.</p>
-<h3>Click handling</h3>
+<h3 id="nested-fold-preservation">Nested fold preservation</h3>
+<p>Because hidden ancestors don&#x27;t run their own fold logic (we just <code>display: none</code> everything inside them), a collapsed h3 stays in <code>foldedSections</code> even when its parent h2 is also collapsed. When the h2 expands, the h3 remains collapsed because its slug is still in the set and the next post-process pass re-applies it. Exactly what we want.</p>
+<h3 id="click-handling">Click handling</h3>
 <p>Single delegated listener on <code>rootRef.current</code>:</p>
 <pre><code class="language-ts">const onClick = (e: MouseEvent) =&gt; {
-  const btn = (e.target as HTMLElement).closest(&#39;.cpc-toggle&#39;);
+  const btn = (e.target as HTMLElement).closest(&#x27;.cpc-toggle&#x27;);
   if (!btn) return;
-  const slug = btn.getAttribute(&#39;data-slug&#39;);
+  const slug = btn.getAttribute(&#x27;data-slug&#x27;);
   if (!slug) return;
   e.preventDefault();
   e.stopPropagation();
@@ -896,9 +809,9 @@ exports[`MarkdownViewer (marked baseline) > renders 12-real-doc-collapsible-head
 };
 </code></pre>
 <p>Where <code>toggleFold</code> is a callback passed from <code>App.tsx</code> (or <code>FileViewer</code>) that updates <code>foldedSections</code>.</p>
-<hr>
-<h2>Part 5 — TOC sync strategy</h2>
-<h3>State management — recommendation</h3>
+<hr/>
+<h2 id="part-5--toc-sync-strategy">Part 5 — TOC sync strategy</h2>
+<h3 id="state-management--recommendation">State management — recommendation</h3>
 <p><strong>Lift to <code>App.tsx</code>.</strong> Add:</p>
 <pre><code class="language-ts">const [foldedSections, setFoldedSections] = useState&lt;Set&lt;string&gt;&gt;(new Set());
 
@@ -922,86 +835,31 @@ const expandAncestors = useCallback((slugs: string[]) =&gt; {
 }, []);
 </code></pre>
 <p>Pass <code>foldedSections</code>, <code>toggleFold</code>, <code>expandAncestors</code> down to <code>FileViewer</code> → <code>MarkdownViewer</code>, and (when it ships) to <code>TocSheet</code>.</p>
-<h3>Why not React Context?</h3>
+<h3 id="why-not-react-context">Why not React Context?</h3>
 <ul>
 <li>Only 2 components need this state. Prop drilling through <code>FileViewer → MarkdownViewer</code> is one hop.</li>
 <li>Context invalidates everything in its tree on every change, causing the whole <code>FileViewer</code> to re-render on every fold toggle. Not catastrophic but unnecessary.</li>
 <li>Explicit props are easier to reason about and easier to remove later if Liam decides he hates this feature.</li>
 </ul>
-<h3>Why not a custom event bus?</h3>
+<h3 id="why-not-a-custom-event-bus">Why not a custom event bus?</h3>
 <ul>
 <li>The &quot;shared state&quot; requirement is the whole point. Event buses recreate state by accident and lose it on re-mount. React state is the right tool.</li>
 </ul>
-<h3>Sync flow when TOC ships</h3>
+<h3 id="sync-flow-when-toc-ships">Sync flow when TOC ships</h3>
 <ol>
 <li><code>TocSheet</code> parses the headings from the rendered markdown (or receives them as a prop from <code>MarkdownViewer</code>, which is cleaner — see &quot;shared headings list&quot; below).</li>
 <li>Each parent heading row in TocSheet has a triangle that calls <code>toggleFold(slug)</code>.</li>
-<li>Each leaf row that&#39;s an ancestor-of-folded shows greyed out.</li>
-<li>When a row is tapped, TocSheet computes the chain of ancestors (walks up the parsed-headings list to find every heading at a higher level whose section contains this slug), calls <code>expandAncestors(ancestors)</code>, and then triggers a smooth scroll to the slug&#39;s element. Both sides of the sync share the same <code>Set</code>, so the doc reflects the change automatically via <code>MarkdownViewer</code>&#39;s <code>useLayoutEffect</code>.</li>
+<li>Each leaf row that&#x27;s an ancestor-of-folded shows greyed out.</li>
+<li>When a row is tapped, TocSheet computes the chain of ancestors (walks up the parsed-headings list to find every heading at a higher level whose section contains this slug), calls <code>expandAncestors(ancestors)</code>, and then triggers a smooth scroll to the slug&#x27;s element. Both sides of the sync share the same <code>Set</code>, so the doc reflects the change automatically via <code>MarkdownViewer</code>&#x27;s <code>useLayoutEffect</code>.</li>
 </ol>
-<h3>Shared headings list</h3>
+<h3 id="shared-headings-list">Shared headings list</h3>
 <p>To avoid parsing headings twice (once in <code>MarkdownViewer</code> for triangles, once in <code>TocSheet</code> for the list), have <code>MarkdownViewer</code> parse headings during its <code>useLayoutEffect</code>, store them in a state variable, and pass them up via an <code>onHeadingsChange?: (headings: Heading[]) =&gt; void</code> callback. <code>App.tsx</code> holds the headings array and passes it into <code>TocSheet</code>. This is the same pattern as <code>onViewChange</code> already used in <code>FileViewer.tsx</code> (line 154).</p>
-<hr>
-<h2>Part 6 — Edge cases</h2>
-<table>
-<thead>
-<tr>
-<th>Case</th>
-<th>Behavior</th>
-</tr>
-</thead>
-<tbody><tr>
-<td>Doc has zero headings</td>
-<td>No triangles render. Loop in post-process finds no headings; nothing happens.</td>
-</tr>
-<tr>
-<td>First H1 = doc title</td>
-<td>Skip injecting triangle for it. Detected as &quot;first heading in document order at level 1&quot;.</td>
-</tr>
-<tr>
-<td>Heading with no content after it (just another heading)</td>
-<td>Section range is empty. Don&#39;t inject triangle. The heading still gets an <code>id</code> (for TOC linking) but no fold control.</td>
-</tr>
-<tr>
-<td>Heading is the very last element</td>
-<td>Section is <code>nodes.slice(i+1, nodes.length)</code>, which may be empty (no triangle) or contain trailing content.</td>
-</tr>
-<tr>
-<td>Two headings with the same text</td>
-<td>Slugger appends <code>-2</code>, <code>-3</code>, etc. for uniqueness. Standard slug behavior.</td>
-</tr>
-<tr>
-<td>Markdown contains raw HTML headings (<code>&lt;h2&gt;...&lt;/h2&gt;</code> typed by user)</td>
-<td>Marked passes them through if <code>gfm</code> mode allows. They become real <code>&lt;h2&gt;</code> elements in the output and get triangles like any other heading.</td>
-</tr>
-<tr>
-<td>User collapses a section, then scrolls</td>
-<td>No issue. Browser preserves scroll position relative to the document, and when content above the viewport disappears, the scroll position adjusts naturally. (If this looks jumpy in practice, we can record <code>scrollTop</code> before the toggle and restore it after — but try without first.)</td>
-</tr>
-<tr>
-<td>User switches files</td>
-<td><code>useEffect([viewingFile.path])</code> resets <code>foldedSections</code> to empty. Fresh slate per file.</td>
-</tr>
-<tr>
-<td>User collapses an H2, then collapses its parent H1</td>
-<td>Both slugs are in the set. The H1&#39;s hide-pass hides the H2 and everything inside it (the H2&#39;s triangle is hidden along with the rest). When the user re-expands the H1, the H2 is still in the set so it stays collapsed and shows ▶.</td>
-</tr>
-<tr>
-<td>Hash navigation <code>#some-heading</code></td>
-<td>Browser scrolls to the element. If that element is inside a collapsed section, it won&#39;t be visible. Solution: on mount and on hash change, walk up from the target heading to find any folded ancestors and remove them. Same <code>expandAncestors</code> helper TocSheet uses.</td>
-</tr>
-<tr>
-<td>Triangle click also bubbles to heading</td>
-<td>The delegated handler calls <code>e.preventDefault()</code> and <code>e.stopPropagation()</code>. Heading text click does nothing anyway.</td>
-</tr>
-<tr>
-<td>Marked renderer override breaks something</td>
-<td>Run the existing markdown viewer manually with several test docs (long ADRs, the overnight reports, code-heavy files) to confirm output is unchanged except for the new <code>id</code> attributes.</td>
-</tr>
-</tbody></table>
-<hr>
-<h2>Part 7 — Scope and effort</h2>
-<h3>Standalone (no TOC)</h3>
+<hr/>
+<h2 id="part-6--edge-cases">Part 6 — Edge cases</h2>
+<div class="md-table-scroll"><table><thead><tr><th>Case</th><th>Behavior</th></tr></thead><tbody><tr><td>Doc has zero headings</td><td>No triangles render. Loop in post-process finds no headings; nothing happens.</td></tr><tr><td>First H1 = doc title</td><td>Skip injecting triangle for it. Detected as &quot;first heading in document order at level 1&quot;.</td></tr><tr><td>Heading with no content after it (just another heading)</td><td>Section range is empty. Don&#x27;t inject triangle. The heading still gets an <code>id</code> (for TOC linking) but no fold control.</td></tr><tr><td>Heading is the very last element</td><td>Section is <code>nodes.slice(i+1, nodes.length)</code>, which may be empty (no triangle) or contain trailing content.</td></tr><tr><td>Two headings with the same text</td><td>Slugger appends <code>-2</code>, <code>-3</code>, etc. for uniqueness. Standard slug behavior.</td></tr><tr><td>Markdown contains raw HTML headings (<code>&lt;h2&gt;...&lt;/h2&gt;</code> typed by user)</td><td>Marked passes them through if <code>gfm</code> mode allows. They become real <code>&lt;h2&gt;</code> elements in the output and get triangles like any other heading.</td></tr><tr><td>User collapses a section, then scrolls</td><td>No issue. Browser preserves scroll position relative to the document, and when content above the viewport disappears, the scroll position adjusts naturally. (If this looks jumpy in practice, we can record <code>scrollTop</code> before the toggle and restore it after — but try without first.)</td></tr><tr><td>User switches files</td><td><code>useEffect([viewingFile.path])</code> resets <code>foldedSections</code> to empty. Fresh slate per file.</td></tr><tr><td>User collapses an H2, then collapses its parent H1</td><td>Both slugs are in the set. The H1&#x27;s hide-pass hides the H2 and everything inside it (the H2&#x27;s triangle is hidden along with the rest). When the user re-expands the H1, the H2 is still in the set so it stays collapsed and shows ▶.</td></tr><tr><td>Hash navigation <code>#some-heading</code></td><td>Browser scrolls to the element. If that element is inside a collapsed section, it won&#x27;t be visible. Solution: on mount and on hash change, walk up from the target heading to find any folded ancestors and remove them. Same <code>expandAncestors</code> helper TocSheet uses.</td></tr><tr><td>Triangle click also bubbles to heading</td><td>The delegated handler calls <code>e.preventDefault()</code> and <code>e.stopPropagation()</code>. Heading text click does nothing anyway.</td></tr><tr><td>Marked renderer override breaks something</td><td>Run the existing markdown viewer manually with several test docs (long ADRs, the overnight reports, code-heavy files) to confirm output is unchanged except for the new <code>id</code> attributes.</td></tr></tbody></table></div>
+<hr/>
+<h2 id="part-7--scope-and-effort">Part 7 — Scope and effort</h2>
+<h3 id="standalone-no-toc">Standalone (no TOC)</h3>
 <p><strong>Medium — about 1 day (6–8 hours).</strong></p>
 <p>Breakdown:</p>
 <ul>
@@ -1012,7 +870,7 @@ const expandAncestors = useCallback((slugs: string[]) =&gt; {
 <li>1h: edge cases (first H1, empty sections, hash navigation)</li>
 <li>1h: manual testing on real docs (overnight reports, ADRs, long synthesis docs)</li>
 </ul>
-<h3>With TOC sync (if TOC ships in the same PR or right after)</h3>
+<h3 id="with-toc-sync-if-toc-ships-in-the-same-pr-or-right-after">With TOC sync (if TOC ships in the same PR or right after)</h3>
 <p><strong>Medium-large — about 1.5–2 days.</strong></p>
 <p>The TOC drawer itself is independently estimated at 4–6 hours in the existing proposal, but it shares a bunch of work with this feature:</p>
 <ul>
@@ -1028,29 +886,30 @@ const expandAncestors = useCallback((slugs: string[]) =&gt; {
 <li>Total: ~12–17h, call it 1.5–2 days</li>
 </ul>
 <p>Strong recommendation: <strong>ship them together as one PR</strong> if both are wanted. The shared work (renderer override, heading parsing, lifted state) is half the value, and doing them in two separate PRs duplicates the prep and risks divergent slug schemes.</p>
-<hr>
-<h2>Open questions</h2>
+<hr/>
+<h2 id="open-questions">Open questions</h2>
 <ol>
 <li><strong>Triangle character or SVG?</strong> Character (▼/▶) is simplest and matches the existing emoji-heavy visual style of the file viewer (📁/📄). SVG would be sharper but adds icon-system overhead. Recommend character for v1.</li>
 <li><strong>Show item count when collapsed?</strong> &quot;▶ (12 items)&quot; is informative but adds clutter. Recommend: skip for v1, add if Liam asks.</li>
-<li><strong>Should the H1 doc title be stylable separately?</strong> The &quot;skip triangle on first H1&quot; rule is content-agnostic — it&#39;s positional. If Liam writes a doc that doesn&#39;t start with an H1, the first H2 still gets a triangle. Confirm this is fine.</li>
-<li><strong>Per-file persistence?</strong> The recommendation is no persistence. If Liam routinely re-opens the same long doc (an ADR he&#39;s reviewing for a week), a localStorage cache keyed by <code>file path → Set&lt;slug&gt;</code> would be a small addition. Defer until requested.</li>
-<li><strong>Markdown re-render churn:</strong> the <code>useMemo</code> keys on <code>[content]</code>, so toggling fold state doesn&#39;t re-parse markdown. Triangles persist, fold logic just toggles classes. Confirmed safe.</li>
-<li><strong>Does the existing TOC proposal&#39;s effort estimate need updating?</strong> Yes — the proposal claims marked already generates IDs (<code>tmp/20260407-markdown-toc-and-audio-proposals.md</code> line 71). It doesn&#39;t. Add ~30 minutes to the TOC estimate for the renderer override + slugger.</li>
-<li><strong>Telegram WebApp viewport quirks:</strong> the markdown viewer is inside a Telegram mini app. Triangles positioned absolutely with <code>left: -22px</code> need to not get clipped by the outer scrollable container&#39;s overflow rules. The current outer wrapper has <code>overflowX: &quot;auto&quot;</code> (line 25) — this is fine because the triangles are still inside <code>.md-content</code> which has <code>padding: 16px 16px</code> (line 23). The 16px of left padding is enough room. Verify on a narrow device.</li>
-<li><strong>Accessibility:</strong> the triangle button needs <code>aria-expanded={!folded}</code>, <code>aria-controls={sectionId}</code>, and a screen-reader label like <code>aria-label=&quot;Collapse section: {heading text}&quot;</code>. Add this in v1; it&#39;s cheap.</li>
+<li><strong>Should the H1 doc title be stylable separately?</strong> The &quot;skip triangle on first H1&quot; rule is content-agnostic — it&#x27;s positional. If Liam writes a doc that doesn&#x27;t start with an H1, the first H2 still gets a triangle. Confirm this is fine.</li>
+<li><strong>Per-file persistence?</strong> The recommendation is no persistence. If Liam routinely re-opens the same long doc (an ADR he&#x27;s reviewing for a week), a localStorage cache keyed by <code>file path → Set&lt;slug&gt;</code> would be a small addition. Defer until requested.</li>
+<li><strong>Markdown re-render churn:</strong> the <code>useMemo</code> keys on <code>[content]</code>, so toggling fold state doesn&#x27;t re-parse markdown. Triangles persist, fold logic just toggles classes. Confirmed safe.</li>
+<li><strong>Does the existing TOC proposal&#x27;s effort estimate need updating?</strong> Yes — the proposal claims marked already generates IDs (<code>tmp/20260407-markdown-toc-and-audio-proposals.md</code> line 71). It doesn&#x27;t. Add ~30 minutes to the TOC estimate for the renderer override + slugger.</li>
+<li><strong>Telegram WebApp viewport quirks:</strong> the markdown viewer is inside a Telegram mini app. Triangles positioned absolutely with <code>left: -22px</code> need to not get clipped by the outer scrollable container&#x27;s overflow rules. The current outer wrapper has <code>overflowX: &quot;auto&quot;</code> (line 25) — this is fine because the triangles are still inside <code>.md-content</code> which has <code>padding: 16px 16px</code> (line 23). The 16px of left padding is enough room. Verify on a narrow device.</li>
+<li><strong>Accessibility:</strong> the triangle button needs <code>aria-expanded={!folded}</code>, <code>aria-controls={sectionId}</code>, and a screen-reader label like <code>aria-label=&quot;Collapse section: {heading text}&quot;</code>. Add this in v1; it&#x27;s cheap.</li>
 </ol>
-<hr>
-<h2>Phased implementation plan</h2>
-<h3>Phase 0 — Prep (do this first)</h3>
+<hr/>
+<h2 id="phased-implementation-plan">Phased implementation plan</h2>
+<h3 id="phase-0--prep-do-this-first">Phase 0 — Prep (do this first)</h3>
 <ol>
 <li>Add a slug helper in <code>MarkdownViewer.tsx</code> (or a new <code>lib/slug.ts</code> if you prefer): <code>function slugify(text: string, used: Set&lt;string&gt;): string</code> that lowercases, strips punctuation, replaces whitespace with <code>-</code>, and appends <code>-2</code>, <code>-3</code> for duplicates.</li>
-<li>Override marked&#39;s heading renderer:<pre><code class="language-ts">const slugCounts = new Map&lt;string, number&gt;();
+<li>Override marked&#x27;s heading renderer:
+<pre><code class="language-ts">const slugCounts = new Map&lt;string, number&gt;();
 marked.use({
   renderer: {
     heading({ tokens, depth }) {
       const text = this.parser.parseInline(tokens);
-      const plain = text.replace(/&lt;[^&gt;]*&gt;/g, &#39;&#39;);  // strip inline HTML for slug
+      const plain = text.replace(/&lt;[^&gt;]*&gt;/g, &#x27;&#x27;);  // strip inline HTML for slug
       const base = slugify(plain);
       const n = (slugCounts.get(base) ?? 0) + 1;
       slugCounts.set(base, n);
@@ -1060,39 +919,39 @@ marked.use({
   }
 });
 </code></pre>
-Important: reset <code>slugCounts</code> per <code>marked.parse</code> call. Cleanest way: build the override inside the <code>useMemo</code> so each parse call gets a fresh Map. Or use a <code>marked.use</code> extension hook. (The simplest pattern: declare a renderer object once at module scope but reset its <code>slugCounts</code> Map at the start of each <code>useMemo</code> body — slightly hacky. The extension hook is cleaner; if it&#39;s too fiddly, just call <code>marked.use</code> once per parse, which works because <code>marked.use</code> is idempotent for renderer overrides.)</li>
+Important: reset <code>slugCounts</code> per <code>marked.parse</code> call. Cleanest way: build the override inside the <code>useMemo</code> so each parse call gets a fresh Map. Or use a <code>marked.use</code> extension hook. (The simplest pattern: declare a renderer object once at module scope but reset its <code>slugCounts</code> Map at the start of each <code>useMemo</code> body — slightly hacky. The extension hook is cleaner; if it&#x27;s too fiddly, just call <code>marked.use</code> once per parse, which works because <code>marked.use</code> is idempotent for renderer overrides.)</li>
 </ol>
-<h3>Phase 1 — Visual triangles, no logic</h3>
+<h3 id="phase-1--visual-triangles-no-logic">Phase 1 — Visual triangles, no logic</h3>
 <ol>
-<li>Add <code>cpc-toggle</code> and <code>cpc-folded</code> CSS to <code>MarkdownViewer</code>&#39;s <code>&lt;style&gt;</code> block.</li>
-<li>Add a <code>useLayoutEffect</code> that walks <code>.md-content</code> children, finds headings, and injects a triangle button before each heading&#39;s content. Skip the first H1.</li>
+<li>Add <code>cpc-toggle</code> and <code>cpc-folded</code> CSS to <code>MarkdownViewer</code>&#x27;s <code>&lt;style&gt;</code> block.</li>
+<li>Add a <code>useLayoutEffect</code> that walks <code>.md-content</code> children, finds headings, and injects a triangle button before each heading&#x27;s content. Skip the first H1.</li>
 <li>Verify visually: triangles appear in the left margin of every heading except the doc title.</li>
 <li>No fold logic yet. Triangles are inert.</li>
 </ol>
-<h3>Phase 2 — Fold logic locally in MarkdownViewer</h3>
+<h3 id="phase-2--fold-logic-locally-in-markdownviewer">Phase 2 — Fold logic locally in MarkdownViewer</h3>
 <ol>
 <li>Add local <code>useState&lt;Set&lt;string&gt;&gt;</code> for fold state inside <code>MarkdownViewer</code> temporarily.</li>
 <li>Compute section ranges (sibling slice between headings) for each heading.</li>
-<li>Apply <code>cpc-folded</code> class to all nodes in the range when the heading&#39;s slug is in the set.</li>
+<li>Apply <code>cpc-folded</code> class to all nodes in the range when the heading&#x27;s slug is in the set.</li>
 <li>Wire up the delegated click handler so triangles toggle.</li>
 <li>Test: collapse h2, collapse nested h3, expand parent h2, confirm h3 stays collapsed.</li>
 <li>Test edge cases: first H1, empty sections, last heading.</li>
 </ol>
-<h3>Phase 3 — Lift state to App.tsx</h3>
+<h3 id="phase-3--lift-state-to-apptsx">Phase 3 — Lift state to App.tsx</h3>
 <ol>
 <li>Move <code>foldedSections</code>, <code>toggleFold</code> from <code>MarkdownViewer</code> to <code>App.tsx</code>.</li>
 <li>Add <code>useEffect([viewingFile?.path])</code> reset.</li>
 <li>Pass through <code>FileViewer</code> as props, then to <code>MarkdownViewer</code>.</li>
 <li>Verify: switching files resets fold state. Switching tabs and back preserves it (unless file changed).</li>
 </ol>
-<h3>Phase 4 — Polish</h3>
+<h3 id="phase-4--polish">Phase 4 — Polish</h3>
 <ol>
 <li>Add <code>aria-expanded</code>, <code>aria-controls</code>, <code>aria-label</code> to triangle buttons.</li>
 <li>Test mobile hit area on a real device or browser devtools touch simulator.</li>
 <li>Test with the longest markdown docs you can find (overnight reports, ADRs).</li>
 <li>Verify hash navigation: <code>#some-heading-inside-folded-section</code> should auto-expand ancestors. Add <code>expandAncestors</code> walker if not done in Phase 3.</li>
 </ol>
-<h3>Phase 5 — TOC sync (only if TOC drawer is in scope)</h3>
+<h3 id="phase-5--toc-sync-only-if-toc-drawer-is-in-scope">Phase 5 — TOC sync (only if TOC drawer is in scope)</h3>
 <ol>
 <li>Add <code>headings: Heading[]</code> state in <code>App.tsx</code>.</li>
 <li>Add <code>onHeadingsChange</code> callback in <code>MarkdownViewer</code>, fire it from the same <code>useLayoutEffect</code> that builds triangles.</li>
@@ -1101,56 +960,53 @@ Important: reset <code>slugCounts</code> per <code>marked.parse</code> call. Cle
 <li>On row tap: compute ancestor slugs, call <code>expandAncestors</code>, scroll to slug.</li>
 <li>Test the round trip: collapse h2 in doc → its h3 children grey out in TOC. Tap an h3 in TOC → ancestor h2 expands in doc → scroll lands on h3.</li>
 </ol>
-<h3>Phase 6 — (Defer) Animation</h3>
+<h3 id="phase-6--defer-animation">Phase 6 — (Defer) Animation</h3>
 <p>Wrap each section in a data-attributed div during post-processing, animate via max-height + overflow. Only do this if Liam asks.</p>
-<hr>
-<h2>Critical Files for Implementation</h2>
+<hr/>
+<h2 id="critical-files-for-implementation">Critical Files for Implementation</h2>
 <ul>
 <li><code>/home/claude/code/claude-pocket-console/apps/web/src/components/MarkdownViewer.tsx</code> — primary changes: add ref, useLayoutEffect for triangle injection + fold application, marked renderer override for heading IDs, CSS for <code>.cpc-toggle</code> and <code>.cpc-folded</code>. Receives <code>foldedSections</code> and <code>toggleFold</code> as props.</li>
 <li><code>/home/claude/code/claude-pocket-console/apps/web/src/App.tsx</code> — add <code>foldedSections: Set&lt;string&gt;</code> state, <code>toggleFold</code> and <code>expandAncestors</code> callbacks, reset effect on <code>viewingFile.path</code> change. Pass props down through <code>FileViewer</code>.</li>
 <li><code>/home/claude/code/claude-pocket-console/apps/web/src/components/FileViewer.tsx</code> — add prop pass-through for fold state and callbacks; otherwise unchanged. (Already manages its own <code>collapsedRanges</code> for code-file folding — that stays separate; markdown fold is a different feature that lives at App level.)</li>
 <li><code>/home/claude/code/claude-pocket-console/apps/web/src/components/ActionBar.tsx</code> — only relevant if TOC drawer ships in the same pass. Reference for the existing <code>BottomSheet</code> component that the future <code>TocSheet</code> should reuse.</li>
 <li><code>/home/claude/claudes-world/tmp/20260407-markdown-toc-and-audio-proposals.md</code> — the related TOC proposal. Note that its claim about marked auto-generating IDs is incorrect; if both features ship, they share the heading-id assignment work described here.</li>
-</ul>
-"
+</ul></div>"
 `;
 
-exports[`MarkdownViewer (marked baseline) > renders 13-mermaid.md consistently 1`] = `
-"<h1>Mermaid Test</h1>
-<p>This is a quick test of Mermaid rendering in CPC&#39;s MarkdownViewer.</p>
-<h2>Flowchart</h2>
-<pre><code class="language-mermaid">graph TD
-  A[Start] --&gt; B{Decision}
-  B --&gt;|Yes| C[Continue]
-  B --&gt;|No| D[Stop]
-</code></pre>
-<h2>Regular code block (should stay as code)</h2>
+exports[`MarkdownViewer (react-markdown baseline) > renders 13-mermaid.md consistently 1`] = `
+"<div class="md-content"><h1 id="mermaid-test">Mermaid Test</h1>
+<p>This is a quick test of Mermaid rendering in CPC&#x27;s MarkdownViewer.</p>
+<h2 id="flowchart">Flowchart</h2>
+<div class="mermaid-mount"><div class="mermaid-loading">Loading diagram…</div></div>
+<h2 id="regular-code-block-should-stay-as-code">Regular code block (should stay as code)</h2>
 <pre><code class="language-js">const hello = &quot;world&quot;;
 console.log(hello);
 </code></pre>
-<p>Done.</p>
-"
+<p>Done.</p></div>"
 `;
 
-exports[`MarkdownViewer (marked baseline) > renders 14-empty.md consistently 1`] = `
-"<p>Just a single line of text and nothing else.</p>
-"
-`;
+exports[`MarkdownViewer (react-markdown baseline) > renders 14-empty.md consistently 1`] = `"<div class="md-content"><p>Just a single line of text and nothing else.</p></div>"`;
 
-exports[`MarkdownViewer (marked baseline) > renders 15-pathological.md consistently 1`] = `
-"<h1>Pathological shapes</h1>
+exports[`MarkdownViewer (react-markdown baseline) > renders 15-pathological.md consistently 1`] = `
+"<div class="md-content"><h1 id="pathological-shapes">Pathological shapes</h1>
 <p>Raw HTML mixed in (marked passes through by default):</p>
-<div class="custom-box" style="padding: 8px;">
-  <p>Inline HTML paragraph with <strong>bold</strong> and a <a href="https://example.com">raw anchor</a>.</p>
-</div>
-
-<p>Single-newline-as-break (relies on <code>breaks: true</code>):<br>Line A<br>Line B<br>Line C</p>
+&lt;div class=&quot;custom-box&quot; style=&quot;padding: 8px;&quot;&gt;
+  &lt;p&gt;Inline HTML paragraph with &lt;strong&gt;bold&lt;/strong&gt; and a &lt;a href=&quot;https://example.com&quot;&gt;raw anchor&lt;/a&gt;.&lt;/p&gt;
+&lt;/div&gt;
+<p>Single-newline-as-break (relies on <code>breaks: true</code>):<br/>
+Line A<br/>
+Line B<br/>
+Line C</p>
 <p>Deeply nested list (5 levels):</p>
 <ul>
-<li>L1<ul>
-<li>L2<ul>
-<li>L3<ul>
-<li>L4<ul>
+<li>L1
+<ul>
+<li>L2
+<ul>
+<li>L3
+<ul>
+<li>L4
+<ul>
 <li>L5 leaf</li>
 </ul>
 </li>
@@ -1162,21 +1018,19 @@ exports[`MarkdownViewer (marked baseline) > renders 15-pathological.md consisten
 </li>
 </ul>
 <p>Unicode smorgasbord: café, naïve, façade, résumé, 日本語, 中文, العربية, עברית, emoji: hello duck, math: α + β = γ, ∑ x_i, ∫ f(x) dx.</p>
-<p>Inline HTML inside a paragraph: this is <span style="color: red;">red text</span> and <code>raw code</code> inside a normal paragraph.</p>
+<p>Inline HTML inside a paragraph: this is &lt;span style=&quot;color: red;&quot;&gt;red text&lt;/span&gt; and &lt;code&gt;raw code&lt;/code&gt; inside a normal paragraph.</p>
 <p>A horizontal rule:</p>
-<hr>
+<hr/>
 <p>A heading immediately after the hr:</p>
-<h2>Heading right after hr</h2>
+<h2 id="heading-right-after-hr">Heading right after hr</h2>
 <p>Backtick-heavy inline: <code>a\`b</code> and <code>\`\`nested\`\`</code> and <code>\`\`\`triple\`\`\`</code>.</p>
 <p>Escape sequences: *not italic*, \`not code\`, [not link](nope).</p>
 <p>Empty code block:</p>
-<pre><code>
-</code></pre>
+<pre><code></code></pre>
 <p>Code block with no language:</p>
 <pre><code>plain text
 multiple lines
   indented
 </code></pre>
-<p>A paragraph ending without a trailing newline and no more content after it.</p>
-"
+<p>A paragraph ending without a trailing newline and no more content after it.</p></div>"
 `;

--- a/apps/web/src/__tests__/markdown-snapshots.test.ts
+++ b/apps/web/src/__tests__/markdown-snapshots.test.ts
@@ -2,20 +2,37 @@ import { describe, it, expect } from "vitest";
 import { readFileSync, readdirSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { Marked } from "marked";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import ReactMarkdown from "react-markdown";
+import {
+  markdownComponents,
+  markdownRehypePlugins,
+  markdownRemarkPlugins,
+} from "../components/MarkdownViewer";
 
-// Use the same marked parser options as MarkdownViewer.tsx, but snapshot only
-// the raw HTML emitted by marked.parse(). This is intentionally a parser-level
-// baseline and does not cover any MarkdownViewer post-processing that happens
-// after parsing (for example, React-rendered replacements such as mermaid).
-// When the react-markdown migration lands, a follow-up test can render the
-// same fixtures through the component and compare the resulting DOM output.
-const marked = new Marked({ gfm: true, breaks: true });
+function renderMarkdown(content: string): string {
+  return renderToStaticMarkup(
+    createElement(
+      "div",
+      { className: "md-content" },
+      createElement(
+        ReactMarkdown,
+        {
+          remarkPlugins: markdownRemarkPlugins,
+          rehypePlugins: markdownRehypePlugins,
+          components: markdownComponents,
+        },
+        content,
+      ),
+    ),
+  );
+}
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const FIXTURE_DIR = resolve(__dirname, "../__fixtures__/markdown");
 
-describe("MarkdownViewer (marked baseline)", () => {
+describe("MarkdownViewer (react-markdown baseline)", () => {
   const fixtures = readdirSync(FIXTURE_DIR)
     .filter((f) => f.endsWith(".md"))
     .sort();
@@ -23,8 +40,7 @@ describe("MarkdownViewer (marked baseline)", () => {
   for (const fixture of fixtures) {
     it(`renders ${fixture} consistently`, () => {
       const content = readFileSync(resolve(FIXTURE_DIR, fixture), "utf-8");
-      const html = marked.parse(content);
-      expect(html).toMatchSnapshot();
+      expect(renderMarkdown(content)).toMatchSnapshot();
     });
   }
 });

--- a/apps/web/src/components/MarkdownViewer.tsx
+++ b/apps/web/src/components/MarkdownViewer.tsx
@@ -1,6 +1,8 @@
-import { useEffect, useMemo, useRef } from "react";
-import { createRoot, type Root } from "react-dom/client";
-import { marked } from "marked";
+import { Children, isValidElement, type ReactNode } from "react";
+import ReactMarkdown, { type Components } from "react-markdown";
+import remarkGfm from "remark-gfm";
+import remarkBreaks from "remark-breaks";
+import rehypeSlug from "rehype-slug";
 import { MermaidDiagram } from "./MermaidDiagram";
 
 interface MarkdownViewerProps {
@@ -8,67 +10,90 @@ interface MarkdownViewerProps {
   fileName: string;
 }
 
-// Configure marked for safe rendering
-marked.setOptions({
-  gfm: true,
-  breaks: true,
-});
+export const markdownRemarkPlugins = [remarkGfm, remarkBreaks];
 
-export function MarkdownViewer({ content, fileName: _fileName }: MarkdownViewerProps) {
-  const html = useMemo(() => {
-    return marked.parse(content) as string;
-  }, [content]);
+// rehype-slug is pinned to major 6 in package.json. Heading IDs are a contract
+// for deep links, TOC state, and collapsible headings.
+export const markdownRehypePlugins = [rehypeSlug];
 
-  const contentRef = useRef<HTMLDivElement | null>(null);
+function getLanguage(className?: string): string {
+  return (
+    className
+      ?.split(/\s+/)
+      .find((part) => part.startsWith("language-"))
+      ?.replace("language-", "") ?? ""
+  );
+}
 
-  // After marked renders the HTML, find any ```mermaid code blocks and
-  // replace them with a React-rendered MermaidDiagram component. We track
-  // each root we create so we can unmount them on cleanup to avoid leaks.
-  useEffect(() => {
-    const container = contentRef.current;
-    if (!container) return;
+function getTextContent(children: ReactNode): string {
+  return Children.toArray(children)
+    .map((child) => {
+      if (typeof child === "string" || typeof child === "number") {
+        return String(child);
+      }
 
-    const codeBlocks = container.querySelectorAll<HTMLElement>(
-      "code.language-mermaid"
+      return "";
+    })
+    .join("");
+}
+
+function CodeBlock({ className, children, node: _node, ...props }: any) {
+  const language = getLanguage(className);
+
+  if (language === "mermaid") {
+    return (
+      <div className="mermaid-mount">
+        <MermaidDiagram source={getTextContent(children).trim()} />
+      </div>
     );
-    const roots: Root[] = [];
-
-    codeBlocks.forEach((codeEl) => {
-      const pre = codeEl.closest("pre");
-      if (!pre || !pre.parentNode) return;
-
-      const source = codeEl.textContent ?? "";
-      const mountPoint = document.createElement("div");
-      mountPoint.className = "mermaid-mount";
-      pre.parentNode.replaceChild(mountPoint, pre);
-
-      const root = createRoot(mountPoint);
-      root.render(<MermaidDiagram source={source} />);
-      roots.push(root);
-    });
-
-    return () => {
-      // Defer unmount to avoid "synchronously unmounting a root while React
-      // was already rendering" warnings (React 18+ StrictMode double-invoke).
-      const toUnmount = roots.slice();
-      queueMicrotask(() => {
-        toUnmount.forEach((root) => {
-          try {
-            root.unmount();
-          } catch {
-            // Best-effort cleanup.
-          }
-        });
-      });
-    };
-  }, [html]);
+  }
 
   return (
+    <code className={className} {...props}>
+      {children}
+    </code>
+  );
+}
+
+function ScrollableTable({ children, node: _node, ...props }: any) {
+  return (
+    <div className="md-table-scroll">
+      <table {...props}>{children}</table>
+    </div>
+  );
+}
+
+function isMermaidCodeChild(child: ReactNode): boolean {
+  return (
+    isValidElement<{ className?: string }>(child) &&
+    getLanguage(child.props.className) === "mermaid"
+  );
+}
+
+function PreBlock({ children, node: _node, ...props }: any) {
+  const childArray = Children.toArray(children);
+
+  if (childArray.length === 1 && isMermaidCodeChild(childArray[0])) {
+    return <>{children}</>;
+  }
+
+  return <pre {...props}>{children}</pre>;
+}
+
+export const markdownComponents: Components = {
+  code: CodeBlock,
+  table: ScrollableTable,
+  pre: PreBlock,
+};
+
+export function MarkdownViewer({ content, fileName: _fileName }: MarkdownViewerProps) {
+  return (
     <div
+      className="md-viewer-scroll"
       style={{
         padding: "16px 16px",
         overflowY: "auto",
-        overflowX: "auto",
+        overflowX: "hidden",
         height: "100%",
         width: "100%",
         maxWidth: "100%",
@@ -149,12 +174,18 @@ export function MarkdownViewer({ content, fileName: _fileName }: MarkdownViewerP
           white-space: pre;
           max-width: none;
         }
-        .md-content table {
-          display: block;
-          overflow-x: auto;
+        .md-content .md-table-scroll {
           width: 100%;
-          border-collapse: collapse;
+          max-width: 100%;
+          overflow-x: auto;
+          -webkit-overflow-scrolling: touch;
           margin: 12px 0;
+        }
+        .md-content table {
+          width: max-content;
+          min-width: 100%;
+          border-collapse: collapse;
+          margin: 0;
           font-size: 13px;
         }
         .md-content th {
@@ -244,11 +275,15 @@ export function MarkdownViewer({ content, fileName: _fileName }: MarkdownViewerP
           margin: 0;
         }
       `}</style>
-      <div
-        ref={contentRef}
-        className="md-content"
-        dangerouslySetInnerHTML={{ __html: html }}
-      />
+      <div className="md-content">
+        <ReactMarkdown
+          remarkPlugins={markdownRemarkPlugins}
+          rehypePlugins={markdownRehypePlugins}
+          components={markdownComponents}
+        >
+          {content}
+        </ReactMarkdown>
+      </div>
     </div>
   );
 }

--- a/apps/web/src/components/MarkdownViewer.tsx
+++ b/apps/web/src/components/MarkdownViewer.tsx
@@ -1,4 +1,4 @@
-import { Children, isValidElement, type ReactNode } from "react";
+import React, { Children, isValidElement, type ReactNode } from "react";
 import ReactMarkdown, { type Components } from "react-markdown";
 import remarkGfm from "remark-gfm";
 import remarkBreaks from "remark-breaks";
@@ -37,7 +37,7 @@ function getTextContent(children: ReactNode): string {
     .join("");
 }
 
-function CodeBlock({ className, children, node: _node, ...props }: any) {
+function CodeBlock({ className, children, node: _node, ...props }: React.ComponentPropsWithoutRef<'code'> & { node?: any; className?: string }) {
   const language = getLanguage(className);
 
   if (language === "mermaid") {
@@ -55,7 +55,7 @@ function CodeBlock({ className, children, node: _node, ...props }: any) {
   );
 }
 
-function ScrollableTable({ children, node: _node, ...props }: any) {
+function ScrollableTable({ children, node: _node, ...props }: React.ComponentPropsWithoutRef<'table'> & { node?: any }) {
   return (
     <div className="md-table-scroll">
       <table {...props}>{children}</table>
@@ -70,7 +70,7 @@ function isMermaidCodeChild(child: ReactNode): boolean {
   );
 }
 
-function PreBlock({ children, node: _node, ...props }: any) {
+function PreBlock({ children, node: _node, ...props }: React.ComponentPropsWithoutRef<'pre'> & { node?: any }) {
   const childArray = Children.toArray(children);
 
   if (childArray.length === 1 && isMermaidCodeChild(childArray[0])) {

--- a/apps/web/src/components/__tests__/__snapshots__/markdown-parity.test.ts.snap
+++ b/apps/web/src/components/__tests__/__snapshots__/markdown-parity.test.ts.snap
@@ -1,0 +1,372 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Markdown parity baseline (marked) > renders basic through marked 1`] = `
+"<h1>CPC Markdown Basics</h1>
+<p>The file viewer opens markdown from docs, notes, and generated plans. This<br>fixture keeps the everyday inline formatting stable before the renderer changes.</p>
+<p>Operators often scan for <strong>urgent actions</strong>, <em>quiet context</em>, and links to<br><a href="../../../../docs/guides/deploying.md">the deployment guide</a> while standing in a<br>Telegram WebView. Inline code like <code>pnpm --filter @cpc/web build</code> should keep its<br>compact chip styling and should not disturb wrapping in a narrow viewport.</p>
+<p>Use bold and italic together when a note is both <strong><em>important and tentative</em></strong>.<br>Use literal punctuation such as <code>apps/web/src/components/MarkdownViewer.tsx</code>,<br><code>ALLOWED_TELEGRAM_USERS</code>, and <code>cpc.claude.do</code> without surprising escapes.</p>
+<p>An external reference can point to <a href="https://core.telegram.org/bots/webapps">Telegram Mini Apps</a>,<br>and a local note can point to <a href="../../../../docs/conventions/touch-handling.md">touch handling</a>.<br>Both are common in CPC runbooks.</p>
+"
+`;
+
+exports[`Markdown parity baseline (marked) > renders breaks through marked 1`] = `
+"<h1>Soft And Hard Breaks</h1>
+<p>This paragraph has a soft break after this line<br>and marked currently turns it into a <code>&lt;br&gt;</code>.<br>The third source line should also stay inside the same paragraph with breaks.</p>
+<p>This paragraph uses two spaces before the newline.<br>That is a markdown hard break regardless of the <code>breaks</code> setting.</p>
+<p>This paragraph ends here.</p>
+<p>This is a new paragraph after a blank line.</p>
+<ul>
+<li>List item with a soft break<br>inside the same item</li>
+<li>Second list item with two trailing spaces<br>before this continuation line</li>
+</ul>
+<blockquote>
+<p>Blockquote line one<br>blockquote line two</p>
+<p>New quoted paragraph after a blank quoted line.</p>
+</blockquote>
+"
+`;
+
+exports[`Markdown parity baseline (marked) > renders code-blocks through marked 1`] = `
+"<h1>Code Blocks And Commands</h1>
+<p>Inline code such as <code>getAuthHeaders()</code> and <code>Telegram.WebApp.disableVerticalSwipes()</code><br>appears beside fenced examples in CPC docs.</p>
+<pre><code class="language-ts">type SessionStatus = &quot;connected&quot; | &quot;paused&quot; | &quot;failed&quot;;
+
+export function labelForStatus(status: SessionStatus): string {
+  switch (status) {
+    case &quot;connected&quot;:
+      return &quot;Connected&quot;;
+    case &quot;paused&quot;:
+      return &quot;Paused&quot;;
+    case &quot;failed&quot;:
+      return &quot;Needs attention&quot;;
+  }
+}
+</code></pre>
+<pre><code class="language-bash">cd /home/claude/code/cpc-impl-react-markdown
+pnpm install --silent
+pnpm --filter @cpc/web exec tsc -b
+pnpm --filter @cpc/web test
+</code></pre>
+<pre><code class="language-json">{
+  &quot;server&quot;: {
+    &quot;port&quot;: 38830,
+    &quot;prodTunnel&quot;: &quot;https://cpc.claude.do&quot;,
+    &quot;devTunnel&quot;: &quot;https://cpc-dev.claude.do&quot;
+  },
+  &quot;features&quot;: [&quot;files&quot;, &quot;terminal&quot;, &quot;voice&quot;]
+}
+</code></pre>
+<p>An unlabelled block still matters:</p>
+<pre><code>Actions -&gt; Develop -&gt; Voice
+</code></pre>
+<p>The paragraph after code must resume normal wrapping and link handling.</p>
+"
+`;
+
+exports[`Markdown parity baseline (marked) > renders edge-cases through marked 1`] = `
+"<h1>Edge Cases</h1>
+<h2>Consecutive Heading A</h2>
+<h2>Consecutive Heading B</h2>
+<h3>Consecutive Heading C</h3>
+<p>The blank lines above and the consecutive headings below should not create<br>unexpected empty paragraphs.</p>
+<ul>
+<li>Top level item<ul>
+<li>Nested item with <code>inline code</code><ul>
+<li>Third level item<ol>
+<li>Ordered detail</li>
+<li>Ordered detail with a <a href="../../../../AGENTS.md">relative link</a></li>
+</ol>
+</li>
+</ul>
+</li>
+</ul>
+</li>
+<li>Second top level item</li>
+</ul>
+<ol>
+<li>Ordered root<ul>
+<li>Unordered child<blockquote>
+<p>Quote inside a list item.</p>
+<pre><code class="language-bash">pnpm --filter @cpc/web test
+</code></pre>
+</blockquote>
+</li>
+</ul>
+</li>
+</ol>
+<blockquote>
+<p>A blockquote with a paragraph.</p>
+<ul>
+<li>A quoted list item</li>
+<li>Another quoted list item with <code>code</code></li>
+</ul>
+<pre><code class="language-ts">const source = &quot;quoted code&quot;;
+</code></pre>
+</blockquote>
+<hr>
+<p>Text after a thematic break should remain visible and separated.</p>
+"
+`;
+
+exports[`Markdown parity baseline (marked) > renders gfm-table through marked 1`] = `
+"<h1>Session Triage Matrix</h1>
+<p>The action sheet often summarizes multiple sessions. Tables need GFM alignment,<br>inline formatting, and escaped pipes to render consistently.</p>
+<table>
+<thead>
+<tr>
+<th align="left">Session</th>
+<th align="center">State</th>
+<th>Last line</th>
+<th align="right">Priority</th>
+</tr>
+</thead>
+<tbody><tr>
+<td align="left"><code>alpha</code></td>
+<td align="center">connected</td>
+<td><strong>ready</strong> for <code>pnpm test</code></td>
+<td align="right">1</td>
+</tr>
+<tr>
+<td align="left"><code>deploy-web</code></td>
+<td align="center">paused</td>
+<td>waiting on <code>cpc.service</code> restart</td>
+<td align="right">2</td>
+</tr>
+<tr>
+<td align="left"><code>docs-sync</code></td>
+<td align="center">active</td>
+<td>copied <code>foo | bar</code> from a plan table</td>
+<td align="right">3</td>
+</tr>
+<tr>
+<td align="left"><code>voice-notes</code></td>
+<td align="center">failed</td>
+<td>transcript contains <code>&lt;kbd&gt;Ctrl&lt;/kbd&gt;</code> text</td>
+<td align="right">4</td>
+</tr>
+</tbody></table>
+<table>
+<thead>
+<tr>
+<th>Path</th>
+<th>Owner</th>
+<th>Notes</th>
+</tr>
+</thead>
+<tbody><tr>
+<td><code>apps/web/</code></td>
+<td>frontend</td>
+<td>Telegram WebView constraints apply</td>
+</tr>
+<tr>
+<td><code>apps/server/</code></td>
+<td>backend</td>
+<td>Hono routes, auth, and static serving</td>
+</tr>
+<tr>
+<td><code>docs/</code></td>
+<td>shared</td>
+<td>Progressive discovery, not a dumping ground</td>
+</tr>
+</tbody></table>
+<p>Trailing prose verifies paragraph flow after a block table. The next renderer<br>should preserve table cells with code, emphasis, escaped pipes, and raw-looking<br>text without collapsing the surrounding content.</p>
+"
+`;
+
+exports[`Markdown parity baseline (marked) > renders headings through marked 1`] = `
+"<h1>CPC Plan: Markdown Renderer</h1>
+<h2>Phase 0: Baseline</h2>
+<h3>Fixture Corpus</h3>
+<h4>Headings With Special Characters: <code>/files/:path?tab=docs</code></h4>
+<h5>Duplicate Heading</h5>
+<h6>Tiny Detail</h6>
+<p>The smallest heading appears in some generated plans when a tool dumps nested<br>subsections.</p>
+<h2>Phase 0: Baseline</h2>
+<p>The duplicate <code>h2</code> is intentional. Future heading IDs should make the duplicate<br>stable and reviewable rather than surprising.</p>
+<h3>Fixture Corpus</h3>
+<p>Repeated <code>h3</code> content tests duplicate slug behavior once <code>rehype-slug</code> becomes<br>part of the renderer.</p>
+<h2>Phase 1: Renderer Swap</h2>
+<h3>Keep <code>breaks: true</code></h3>
+<p>The current marked configuration treats single newlines as breaks. The migration<br>must preserve that until a separate behavior-change PR says otherwise.</p>
+<h3>Raw HTML Decision</h3>
+<h4><code>&lt;details&gt;</code> Blocks</h4>
+<p>Raw HTML occurs in docs copied from GitHub. This fixture keeps that input visible<br>in the baseline snapshots.</p>
+<h2>Phase 2: Bundle Mitigation</h2>
+<h3>Lazy Loading</h3>
+<p>Bundle work belongs after correctness, so this fixture should not imply any<br>chunking change.</p>
+"
+`;
+
+exports[`Markdown parity baseline (marked) > renders links-images through marked 1`] = `
+"<h1>Links And Images</h1>
+<p>The file viewer handles project-relative docs, external references, and images<br>embedded in markdown notes.</p>
+<ul>
+<li>Relative guide: <a href="../../../../docs/guides/adding-a-modal.md">adding a modal</a></li>
+<li>Absolute URL: <a href="https://cpc.claude.do">CPC production tunnel</a></li>
+<li>Mail link: <a href="mailto:ops@example.invalid">ops inbox</a></li>
+<li>Anchor-only link: <a href="#raw-html-decision">jump to raw HTML</a></li>
+<li>Path with spaces: <a href="../fixtures/Voice%20Notes.md">voice notes</a></li>
+</ul>
+<p><img src="../../../../public/icon.svg" alt="CPC app tile" title="App icon"></p>
+<p>Reference-style links keep long paragraphs readable. See the <a href="../../../../docs/reference/telegram-webview-rules.md">Telegram WebView<br>rules</a> before changing touch handling, and check the <a href="../../../../docs/conventions/host-tools.md">host tools<br>notes</a> when a workflow depends on <code>~/bin</code>.</p>
+<p>Bare URLs are common in copied notes: <a href="https://cpc-dev.claude.do/status">https://cpc-dev.claude.do/status</a></p>
+"
+`;
+
+exports[`Markdown parity baseline (marked) > renders long-document through marked 1`] = `
+"<h1>Overnight CPC Implementation Notes</h1>
+<h2>1. Summary</h2>
+<p>The mobile console stayed usable while the web process restarted twice. The<br>highest value fix was keeping the file viewer readable in a narrow WebView.</p>
+<h2>2. Current Topology</h2>
+<ul>
+<li><code>apps/web</code> owns the React SPA.</li>
+<li><code>apps/server</code> owns Hono routes and WebSocket transport.</li>
+<li><code>~/bin/launcher-hook</code> owns Telegram keyboard buttons.</li>
+<li><code>~/bin/session-history</code> owns forensic session lookup.</li>
+</ul>
+<h2>3. Important Constraints</h2>
+<p>Do not call <code>preventDefault()</code> on <code>touchstart</code>.<br>Use <code>stopPropagation()</code> only on targeted interaction zones.<br>Disable Telegram vertical swipes while a modal or sheet is open.<br>Re-enable Telegram vertical swipes on cleanup.<br>Do not edit the external Telegram plugin.</p>
+<h2>4. File Viewer Flow</h2>
+<ol>
+<li>User taps the Files tab.</li>
+<li>The server returns a directory listing.</li>
+<li>The UI shows file icons and path breadcrumbs.</li>
+<li>A markdown file opens in the MarkdownViewer.</li>
+<li>Wide code blocks must scroll horizontally.</li>
+<li>Tables must not push the viewport wider than the app.</li>
+</ol>
+<h2>5. Manual Check Table</h2>
+<table>
+<thead>
+<tr>
+<th>Check</th>
+<th>Command</th>
+<th>Expected</th>
+</tr>
+</thead>
+<tbody><tr>
+<td>TypeScript</td>
+<td><code>pnpm --filter @cpc/web exec tsc -b</code></td>
+<td>clean</td>
+</tr>
+<tr>
+<td>Unit tests</td>
+<td><code>pnpm --filter @cpc/web test</code></td>
+<td>snapshots pass</td>
+</tr>
+<tr>
+<td>Build</td>
+<td><code>pnpm --filter @cpc/web build</code></td>
+<td>Vite emits <code>dist/</code></td>
+</tr>
+<tr>
+<td>Health</td>
+<td><code>curl -fsS localhost:38830/health</code></td>
+<td>ok</td>
+</tr>
+</tbody></table>
+<h2>6. Example Route Notes</h2>
+<p>The web app uses a base path from Vite. Static assets should keep working at<br>both <code>https://cpc.claude.do</code> and <code>https://cpc-dev.claude.do</code>.</p>
+<pre><code class="language-ts">export function buildAssetPath(baseUrl: string, name: string): string {
+  const base = baseUrl.endsWith(&quot;/&quot;) ? baseUrl : \`\${baseUrl}/\`;
+  return new URL(name, base).toString();
+}
+</code></pre>
+<h2>7. Shell Recipe</h2>
+<pre><code class="language-bash">set -euo pipefail
+pnpm install --silent
+pnpm --filter @cpc/web exec tsc -b
+pnpm --filter @cpc/web test
+pnpm --filter @cpc/web build
+</code></pre>
+<h2>8. Failure Modes</h2>
+<blockquote>
+<p>A sheet that forgets to re-enable vertical swipes makes Telegram feel broken.</p>
+</blockquote>
+<blockquote>
+<p>A wide code block without horizontal scrolling makes the terminal transcript<br>unreadable on mobile.</p>
+</blockquote>
+<blockquote>
+<p>A raw HTML block silently stripped by a markdown renderer can hide operational<br>instructions from the person holding the phone.</p>
+</blockquote>
+<h2>9. Task List</h2>
+<ul>
+<li><input checked="" disabled="" type="checkbox"> Confirm branch before edits.</li>
+<li><input checked="" disabled="" type="checkbox"> Keep <code>marked</code> installed during the baseline setup.</li>
+<li><input disabled="" type="checkbox"> Swap the renderer in Wave 2.</li>
+<li><input disabled="" type="checkbox"> Document snapshot deltas in the migration PR.</li>
+</ul>
+<h2>10. Deep Link Candidates</h2>
+<h3>Session Selection</h3>
+<p>The future heading IDs may support direct links into long docs. Duplicate<br>headings need stable suffixes.</p>
+<h3>Session Selection</h3>
+<p>This duplicate heading is intentional.</p>
+<h3>Voice Recorder</h3>
+<p>The voice recorder uses file capture rather than <code>getUserMedia</code> because Telegram<br>WebView does not expose the browser media prompt consistently.</p>
+<h3>Terminal</h3>
+<p>Terminal output can include long paths such as<br><code>/home/claude/code/cpc-impl-react-markdown/apps/web/src/components/MarkdownViewer.tsx</code>.</p>
+<h2>11. JSON Payload</h2>
+<pre><code class="language-json">{
+  &quot;kind&quot;: &quot;SessionStart&quot;,
+  &quot;buttons&quot;: [&quot;Actions&quot;, &quot;Develop&quot;, &quot;Voice&quot;],
+  &quot;viewer&quot;: {
+    &quot;markdown&quot;: true,
+    &quot;mermaid&quot;: true,
+    &quot;rawHtml&quot;: &quot;baseline-only&quot;
+  }
+}
+</code></pre>
+<h2>12. Closing Notes</h2>
+<p>Soft breaks appear here<br>as single newlines<br>inside one paragraph.</p>
+<p>A blank line starts a new paragraph. The snapshot should make that distinction<br>obvious.</p>
+<h2>13. Appendix</h2>
+<p>The appendix exists mostly to make the fixture long enough to exercise file<br>loading, snapshot readability, and parser behavior on realistic content.</p>
+<p>Keep the prose plain.<br>Keep commands copyable.<br>Keep the renderer honest.</p>
+"
+`;
+
+exports[`Markdown parity baseline (marked) > renders mermaid through marked 1`] = `
+"<h1>Mermaid Preview Fixture</h1>
+<p>Current production output parses mermaid as a fenced code block first; the<br>viewer then replaces <code>code.language-mermaid</code> with a React-rendered diagram. This<br>fixture pins the parser-level baseline that Wave 2 must account for.</p>
+<pre><code class="language-mermaid">flowchart TD
+  Start([Open file])
+  Detect{Markdown?}
+  Render[Render with viewer]
+  Mermaid{Contains mermaid fence?}
+  Diagram[Mount MermaidDiagram]
+  Done([Readable in Telegram])
+
+  Start --&gt; Detect
+  Detect --&gt;|yes| Render
+  Detect --&gt;|no| Done
+  Render --&gt; Mermaid
+  Mermaid --&gt;|yes| Diagram
+  Mermaid --&gt;|no| Done
+  Diagram --&gt; Done
+</code></pre>
+<p>Text after the diagram should remain a separate paragraph.</p>
+"
+`;
+
+exports[`Markdown parity baseline (marked) > renders raw-html through marked 1`] = `
+"<h1>Raw HTML From Copied Docs</h1>
+<p>Some project documents include GitHub-flavored raw HTML. Marked currently keeps<br>these nodes in the emitted HTML, so the baseline should capture the exact shape.</p>
+<details>
+<summary>Deployment checklist</summary>
+
+<ul>
+<li>Build <code>apps/web</code></li>
+<li>Restart the CPC server</li>
+<li>Check <code>/health</code></li>
+</ul>
+</details>
+
+<p>Keyboard hints appear inline: press <kbd>Esc</kbd> to dismiss a sheet, or<br><kbd>Ctrl</kbd> + <kbd>C</kbd> to stop a local dev server.</p>
+<p>Line one<br><br>Line two after a manual break.</p>
+<div data-cpc-note="copied-from-github">
+  <strong>Note:</strong> this block is raw HTML and should be called out in any
+  renderer parity review.
+</div>
+
+"
+`;

--- a/apps/web/src/components/__tests__/__snapshots__/markdown-parity.test.ts.snap
+++ b/apps/web/src/components/__tests__/__snapshots__/markdown-parity.test.ts.snap
@@ -1,34 +1,47 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`Markdown parity baseline (marked) > renders basic through marked 1`] = `
-"<h1>CPC Markdown Basics</h1>
-<p>The file viewer opens markdown from docs, notes, and generated plans. This<br>fixture keeps the everyday inline formatting stable before the renderer changes.</p>
-<p>Operators often scan for <strong>urgent actions</strong>, <em>quiet context</em>, and links to<br><a href="../../../../docs/guides/deploying.md">the deployment guide</a> while standing in a<br>Telegram WebView. Inline code like <code>pnpm --filter @cpc/web build</code> should keep its<br>compact chip styling and should not disturb wrapping in a narrow viewport.</p>
-<p>Use bold and italic together when a note is both <strong><em>important and tentative</em></strong>.<br>Use literal punctuation such as <code>apps/web/src/components/MarkdownViewer.tsx</code>,<br><code>ALLOWED_TELEGRAM_USERS</code>, and <code>cpc.claude.do</code> without surprising escapes.</p>
-<p>An external reference can point to <a href="https://core.telegram.org/bots/webapps">Telegram Mini Apps</a>,<br>and a local note can point to <a href="../../../../docs/conventions/touch-handling.md">touch handling</a>.<br>Both are common in CPC runbooks.</p>
-"
+exports[`Markdown parity baseline (react-markdown) > renders basic through react-markdown 1`] = `
+"<div class="md-content"><h1 id="cpc-markdown-basics">CPC Markdown Basics</h1>
+<p>The file viewer opens markdown from docs, notes, and generated plans. This<br/>
+fixture keeps the everyday inline formatting stable before the renderer changes.</p>
+<p>Operators often scan for <strong>urgent actions</strong>, <em>quiet context</em>, and links to<br/>
+<a href="../../../../docs/guides/deploying.md">the deployment guide</a> while standing in a<br/>
+Telegram WebView. Inline code like <code>pnpm --filter @cpc/web build</code> should keep its<br/>
+compact chip styling and should not disturb wrapping in a narrow viewport.</p>
+<p>Use bold and italic together when a note is both <strong><em>important and tentative</em></strong>.<br/>
+Use literal punctuation such as <code>apps/web/src/components/MarkdownViewer.tsx</code>,<br/>
+<code>ALLOWED_TELEGRAM_USERS</code>, and <code>cpc.claude.do</code> without surprising escapes.</p>
+<p>An external reference can point to <a href="https://core.telegram.org/bots/webapps">Telegram Mini Apps</a>,<br/>
+and a local note can point to <a href="../../../../docs/conventions/touch-handling.md">touch handling</a>.<br/>
+Both are common in CPC runbooks.</p></div>"
 `;
 
-exports[`Markdown parity baseline (marked) > renders breaks through marked 1`] = `
-"<h1>Soft And Hard Breaks</h1>
-<p>This paragraph has a soft break after this line<br>and marked currently turns it into a <code>&lt;br&gt;</code>.<br>The third source line should also stay inside the same paragraph with breaks.</p>
-<p>This paragraph uses two spaces before the newline.<br>That is a markdown hard break regardless of the <code>breaks</code> setting.</p>
+exports[`Markdown parity baseline (react-markdown) > renders breaks through react-markdown 1`] = `
+"<div class="md-content"><h1 id="soft-and-hard-breaks">Soft And Hard Breaks</h1>
+<p>This paragraph has a soft break after this line<br/>
+and marked currently turns it into a <code>&lt;br&gt;</code>.<br/>
+The third source line should also stay inside the same paragraph with breaks.</p>
+<p>This paragraph uses two spaces before the newline.<br/>
+That is a markdown hard break regardless of the <code>breaks</code> setting.</p>
 <p>This paragraph ends here.</p>
 <p>This is a new paragraph after a blank line.</p>
 <ul>
-<li>List item with a soft break<br>inside the same item</li>
-<li>Second list item with two trailing spaces<br>before this continuation line</li>
+<li>List item with a soft break<br/>
+inside the same item</li>
+<li>Second list item with two trailing spaces<br/>
+before this continuation line</li>
 </ul>
 <blockquote>
-<p>Blockquote line one<br>blockquote line two</p>
+<p>Blockquote line one<br/>
+blockquote line two</p>
 <p>New quoted paragraph after a blank quoted line.</p>
-</blockquote>
-"
+</blockquote></div>"
 `;
 
-exports[`Markdown parity baseline (marked) > renders code-blocks through marked 1`] = `
-"<h1>Code Blocks And Commands</h1>
-<p>Inline code such as <code>getAuthHeaders()</code> and <code>Telegram.WebApp.disableVerticalSwipes()</code><br>appears beside fenced examples in CPC docs.</p>
+exports[`Markdown parity baseline (react-markdown) > renders code-blocks through react-markdown 1`] = `
+"<div class="md-content"><h1 id="code-blocks-and-commands">Code Blocks And Commands</h1>
+<p>Inline code such as <code>getAuthHeaders()</code> and <code>Telegram.WebApp.disableVerticalSwipes()</code><br/>
+appears beside fenced examples in CPC docs.</p>
 <pre><code class="language-ts">type SessionStatus = &quot;connected&quot; | &quot;paused&quot; | &quot;failed&quot;;
 
 export function labelForStatus(status: SessionStatus): string {
@@ -59,20 +72,23 @@ pnpm --filter @cpc/web test
 <p>An unlabelled block still matters:</p>
 <pre><code>Actions -&gt; Develop -&gt; Voice
 </code></pre>
-<p>The paragraph after code must resume normal wrapping and link handling.</p>
-"
+<p>The paragraph after code must resume normal wrapping and link handling.</p></div>"
 `;
 
-exports[`Markdown parity baseline (marked) > renders edge-cases through marked 1`] = `
-"<h1>Edge Cases</h1>
-<h2>Consecutive Heading A</h2>
-<h2>Consecutive Heading B</h2>
-<h3>Consecutive Heading C</h3>
-<p>The blank lines above and the consecutive headings below should not create<br>unexpected empty paragraphs.</p>
+exports[`Markdown parity baseline (react-markdown) > renders edge-cases through react-markdown 1`] = `
+"<div class="md-content"><h1 id="edge-cases">Edge Cases</h1>
+<h2 id="consecutive-heading-a">Consecutive Heading A</h2>
+<h2 id="consecutive-heading-b">Consecutive Heading B</h2>
+<h3 id="consecutive-heading-c">Consecutive Heading C</h3>
+<p>The blank lines above and the consecutive headings below should not create<br/>
+unexpected empty paragraphs.</p>
 <ul>
-<li>Top level item<ul>
-<li>Nested item with <code>inline code</code><ul>
-<li>Third level item<ol>
+<li>Top level item
+<ul>
+<li>Nested item with <code>inline code</code>
+<ul>
+<li>Third level item
+<ol>
 <li>Ordered detail</li>
 <li>Ordered detail with a <a href="../../../../AGENTS.md">relative link</a></li>
 </ol>
@@ -84,8 +100,10 @@ exports[`Markdown parity baseline (marked) > renders edge-cases through marked 1
 <li>Second top level item</li>
 </ul>
 <ol>
-<li>Ordered root<ul>
-<li>Unordered child<blockquote>
+<li>Ordered root
+<ul>
+<li>Unordered child
+<blockquote>
 <p>Quote inside a list item.</p>
 <pre><code class="language-bash">pnpm --filter @cpc/web test
 </code></pre>
@@ -103,103 +121,54 @@ exports[`Markdown parity baseline (marked) > renders edge-cases through marked 1
 <pre><code class="language-ts">const source = &quot;quoted code&quot;;
 </code></pre>
 </blockquote>
-<hr>
-<p>Text after a thematic break should remain visible and separated.</p>
-"
+<hr/>
+<p>Text after a thematic break should remain visible and separated.</p></div>"
 `;
 
-exports[`Markdown parity baseline (marked) > renders gfm-table through marked 1`] = `
-"<h1>Session Triage Matrix</h1>
-<p>The action sheet often summarizes multiple sessions. Tables need GFM alignment,<br>inline formatting, and escaped pipes to render consistently.</p>
-<table>
-<thead>
-<tr>
-<th align="left">Session</th>
-<th align="center">State</th>
-<th>Last line</th>
-<th align="right">Priority</th>
-</tr>
-</thead>
-<tbody><tr>
-<td align="left"><code>alpha</code></td>
-<td align="center">connected</td>
-<td><strong>ready</strong> for <code>pnpm test</code></td>
-<td align="right">1</td>
-</tr>
-<tr>
-<td align="left"><code>deploy-web</code></td>
-<td align="center">paused</td>
-<td>waiting on <code>cpc.service</code> restart</td>
-<td align="right">2</td>
-</tr>
-<tr>
-<td align="left"><code>docs-sync</code></td>
-<td align="center">active</td>
-<td>copied <code>foo | bar</code> from a plan table</td>
-<td align="right">3</td>
-</tr>
-<tr>
-<td align="left"><code>voice-notes</code></td>
-<td align="center">failed</td>
-<td>transcript contains <code>&lt;kbd&gt;Ctrl&lt;/kbd&gt;</code> text</td>
-<td align="right">4</td>
-</tr>
-</tbody></table>
-<table>
-<thead>
-<tr>
-<th>Path</th>
-<th>Owner</th>
-<th>Notes</th>
-</tr>
-</thead>
-<tbody><tr>
-<td><code>apps/web/</code></td>
-<td>frontend</td>
-<td>Telegram WebView constraints apply</td>
-</tr>
-<tr>
-<td><code>apps/server/</code></td>
-<td>backend</td>
-<td>Hono routes, auth, and static serving</td>
-</tr>
-<tr>
-<td><code>docs/</code></td>
-<td>shared</td>
-<td>Progressive discovery, not a dumping ground</td>
-</tr>
-</tbody></table>
-<p>Trailing prose verifies paragraph flow after a block table. The next renderer<br>should preserve table cells with code, emphasis, escaped pipes, and raw-looking<br>text without collapsing the surrounding content.</p>
-"
+exports[`Markdown parity baseline (react-markdown) > renders gfm-table through react-markdown 1`] = `
+"<div class="md-content"><h1 id="session-triage-matrix">Session Triage Matrix</h1>
+<p>The action sheet often summarizes multiple sessions. Tables need GFM alignment,<br/>
+inline formatting, and escaped pipes to render consistently.</p>
+<div class="md-table-scroll"><table><thead><tr><th style="text-align:left">Session</th><th style="text-align:center">State</th><th>Last line</th><th style="text-align:right">Priority</th></tr></thead><tbody><tr><td style="text-align:left"><code>alpha</code></td><td style="text-align:center">connected</td><td><strong>ready</strong> for <code>pnpm test</code></td><td style="text-align:right">1</td></tr><tr><td style="text-align:left"><code>deploy-web</code></td><td style="text-align:center">paused</td><td>waiting on <code>cpc.service</code> restart</td><td style="text-align:right">2</td></tr><tr><td style="text-align:left"><code>docs-sync</code></td><td style="text-align:center">active</td><td>copied <code>foo | bar</code> from a plan table</td><td style="text-align:right">3</td></tr><tr><td style="text-align:left"><code>voice-notes</code></td><td style="text-align:center">failed</td><td>transcript contains <code>&lt;kbd&gt;Ctrl&lt;/kbd&gt;</code> text</td><td style="text-align:right">4</td></tr></tbody></table></div>
+<div class="md-table-scroll"><table><thead><tr><th>Path</th><th>Owner</th><th>Notes</th></tr></thead><tbody><tr><td><code>apps/web/</code></td><td>frontend</td><td>Telegram WebView constraints apply</td></tr><tr><td><code>apps/server/</code></td><td>backend</td><td>Hono routes, auth, and static serving</td></tr><tr><td><code>docs/</code></td><td>shared</td><td>Progressive discovery, not a dumping ground</td></tr></tbody></table></div>
+<p>Trailing prose verifies paragraph flow after a block table. The next renderer<br/>
+should preserve table cells with code, emphasis, escaped pipes, and raw-looking<br/>
+text without collapsing the surrounding content.</p></div>"
 `;
 
-exports[`Markdown parity baseline (marked) > renders headings through marked 1`] = `
-"<h1>CPC Plan: Markdown Renderer</h1>
-<h2>Phase 0: Baseline</h2>
-<h3>Fixture Corpus</h3>
-<h4>Headings With Special Characters: <code>/files/:path?tab=docs</code></h4>
-<h5>Duplicate Heading</h5>
-<h6>Tiny Detail</h6>
-<p>The smallest heading appears in some generated plans when a tool dumps nested<br>subsections.</p>
-<h2>Phase 0: Baseline</h2>
-<p>The duplicate <code>h2</code> is intentional. Future heading IDs should make the duplicate<br>stable and reviewable rather than surprising.</p>
-<h3>Fixture Corpus</h3>
-<p>Repeated <code>h3</code> content tests duplicate slug behavior once <code>rehype-slug</code> becomes<br>part of the renderer.</p>
-<h2>Phase 1: Renderer Swap</h2>
-<h3>Keep <code>breaks: true</code></h3>
-<p>The current marked configuration treats single newlines as breaks. The migration<br>must preserve that until a separate behavior-change PR says otherwise.</p>
-<h3>Raw HTML Decision</h3>
-<h4><code>&lt;details&gt;</code> Blocks</h4>
-<p>Raw HTML occurs in docs copied from GitHub. This fixture keeps that input visible<br>in the baseline snapshots.</p>
-<h2>Phase 2: Bundle Mitigation</h2>
-<h3>Lazy Loading</h3>
-<p>Bundle work belongs after correctness, so this fixture should not imply any<br>chunking change.</p>
-"
+exports[`Markdown parity baseline (react-markdown) > renders headings through react-markdown 1`] = `
+"<div class="md-content"><h1 id="cpc-plan-markdown-renderer">CPC Plan: Markdown Renderer</h1>
+<h2 id="phase-0-baseline">Phase 0: Baseline</h2>
+<h3 id="fixture-corpus">Fixture Corpus</h3>
+<h4 id="headings-with-special-characters-filespathtabdocs">Headings With Special Characters: <code>/files/:path?tab=docs</code></h4>
+<h5 id="duplicate-heading">Duplicate Heading</h5>
+<h6 id="tiny-detail">Tiny Detail</h6>
+<p>The smallest heading appears in some generated plans when a tool dumps nested<br/>
+subsections.</p>
+<h2 id="phase-0-baseline-1">Phase 0: Baseline</h2>
+<p>The duplicate <code>h2</code> is intentional. Future heading IDs should make the duplicate<br/>
+stable and reviewable rather than surprising.</p>
+<h3 id="fixture-corpus-1">Fixture Corpus</h3>
+<p>Repeated <code>h3</code> content tests duplicate slug behavior once <code>rehype-slug</code> becomes<br/>
+part of the renderer.</p>
+<h2 id="phase-1-renderer-swap">Phase 1: Renderer Swap</h2>
+<h3 id="keep-breaks-true">Keep <code>breaks: true</code></h3>
+<p>The current marked configuration treats single newlines as breaks. The migration<br/>
+must preserve that until a separate behavior-change PR says otherwise.</p>
+<h3 id="raw-html-decision">Raw HTML Decision</h3>
+<h4 id="details-blocks"><code>&lt;details&gt;</code> Blocks</h4>
+<p>Raw HTML occurs in docs copied from GitHub. This fixture keeps that input visible<br/>
+in the baseline snapshots.</p>
+<h2 id="phase-2-bundle-mitigation">Phase 2: Bundle Mitigation</h2>
+<h3 id="lazy-loading">Lazy Loading</h3>
+<p>Bundle work belongs after correctness, so this fixture should not imply any<br/>
+chunking change.</p></div>"
 `;
 
-exports[`Markdown parity baseline (marked) > renders links-images through marked 1`] = `
-"<h1>Links And Images</h1>
-<p>The file viewer handles project-relative docs, external references, and images<br>embedded in markdown notes.</p>
+exports[`Markdown parity baseline (react-markdown) > renders links-images through react-markdown 1`] = `
+"<link rel="preload" as="image" href="../../../../public/icon.svg"/><div class="md-content"><h1 id="links-and-images">Links And Images</h1>
+<p>The file viewer handles project-relative docs, external references, and images<br/>
+embedded in markdown notes.</p>
 <ul>
 <li>Relative guide: <a href="../../../../docs/guides/adding-a-modal.md">adding a modal</a></li>
 <li>Absolute URL: <a href="https://cpc.claude.do">CPC production tunnel</a></li>
@@ -207,26 +176,32 @@ exports[`Markdown parity baseline (marked) > renders links-images through marked
 <li>Anchor-only link: <a href="#raw-html-decision">jump to raw HTML</a></li>
 <li>Path with spaces: <a href="../fixtures/Voice%20Notes.md">voice notes</a></li>
 </ul>
-<p><img src="../../../../public/icon.svg" alt="CPC app tile" title="App icon"></p>
-<p>Reference-style links keep long paragraphs readable. See the <a href="../../../../docs/reference/telegram-webview-rules.md">Telegram WebView<br>rules</a> before changing touch handling, and check the <a href="../../../../docs/conventions/host-tools.md">host tools<br>notes</a> when a workflow depends on <code>~/bin</code>.</p>
-<p>Bare URLs are common in copied notes: <a href="https://cpc-dev.claude.do/status">https://cpc-dev.claude.do/status</a></p>
-"
+<p><img src="../../../../public/icon.svg" alt="CPC app tile" title="App icon"/></p>
+<p>Reference-style links keep long paragraphs readable. See the <a href="../../../../docs/reference/telegram-webview-rules.md">Telegram WebView<br/>
+rules</a> before changing touch handling, and check the <a href="../../../../docs/conventions/host-tools.md">host tools<br/>
+notes</a> when a workflow depends on <code>~/bin</code>.</p>
+<p>Bare URLs are common in copied notes: <a href="https://cpc-dev.claude.do/status">https://cpc-dev.claude.do/status</a></p></div>"
 `;
 
-exports[`Markdown parity baseline (marked) > renders long-document through marked 1`] = `
-"<h1>Overnight CPC Implementation Notes</h1>
-<h2>1. Summary</h2>
-<p>The mobile console stayed usable while the web process restarted twice. The<br>highest value fix was keeping the file viewer readable in a narrow WebView.</p>
-<h2>2. Current Topology</h2>
+exports[`Markdown parity baseline (react-markdown) > renders long-document through react-markdown 1`] = `
+"<div class="md-content"><h1 id="overnight-cpc-implementation-notes">Overnight CPC Implementation Notes</h1>
+<h2 id="1-summary">1. Summary</h2>
+<p>The mobile console stayed usable while the web process restarted twice. The<br/>
+highest value fix was keeping the file viewer readable in a narrow WebView.</p>
+<h2 id="2-current-topology">2. Current Topology</h2>
 <ul>
 <li><code>apps/web</code> owns the React SPA.</li>
 <li><code>apps/server</code> owns Hono routes and WebSocket transport.</li>
 <li><code>~/bin/launcher-hook</code> owns Telegram keyboard buttons.</li>
 <li><code>~/bin/session-history</code> owns forensic session lookup.</li>
 </ul>
-<h2>3. Important Constraints</h2>
-<p>Do not call <code>preventDefault()</code> on <code>touchstart</code>.<br>Use <code>stopPropagation()</code> only on targeted interaction zones.<br>Disable Telegram vertical swipes while a modal or sheet is open.<br>Re-enable Telegram vertical swipes on cleanup.<br>Do not edit the external Telegram plugin.</p>
-<h2>4. File Viewer Flow</h2>
+<h2 id="3-important-constraints">3. Important Constraints</h2>
+<p>Do not call <code>preventDefault()</code> on <code>touchstart</code>.<br/>
+Use <code>stopPropagation()</code> only on targeted interaction zones.<br/>
+Disable Telegram vertical swipes while a modal or sheet is open.<br/>
+Re-enable Telegram vertical swipes on cleanup.<br/>
+Do not edit the external Telegram plugin.</p>
+<h2 id="4-file-viewer-flow">4. File Viewer Flow</h2>
 <ol>
 <li>User taps the Files tab.</li>
 <li>The server returns a directory listing.</li>
@@ -235,77 +210,55 @@ exports[`Markdown parity baseline (marked) > renders long-document through marke
 <li>Wide code blocks must scroll horizontally.</li>
 <li>Tables must not push the viewport wider than the app.</li>
 </ol>
-<h2>5. Manual Check Table</h2>
-<table>
-<thead>
-<tr>
-<th>Check</th>
-<th>Command</th>
-<th>Expected</th>
-</tr>
-</thead>
-<tbody><tr>
-<td>TypeScript</td>
-<td><code>pnpm --filter @cpc/web exec tsc -b</code></td>
-<td>clean</td>
-</tr>
-<tr>
-<td>Unit tests</td>
-<td><code>pnpm --filter @cpc/web test</code></td>
-<td>snapshots pass</td>
-</tr>
-<tr>
-<td>Build</td>
-<td><code>pnpm --filter @cpc/web build</code></td>
-<td>Vite emits <code>dist/</code></td>
-</tr>
-<tr>
-<td>Health</td>
-<td><code>curl -fsS localhost:38830/health</code></td>
-<td>ok</td>
-</tr>
-</tbody></table>
-<h2>6. Example Route Notes</h2>
-<p>The web app uses a base path from Vite. Static assets should keep working at<br>both <code>https://cpc.claude.do</code> and <code>https://cpc-dev.claude.do</code>.</p>
+<h2 id="5-manual-check-table">5. Manual Check Table</h2>
+<div class="md-table-scroll"><table><thead><tr><th>Check</th><th>Command</th><th>Expected</th></tr></thead><tbody><tr><td>TypeScript</td><td><code>pnpm --filter @cpc/web exec tsc -b</code></td><td>clean</td></tr><tr><td>Unit tests</td><td><code>pnpm --filter @cpc/web test</code></td><td>snapshots pass</td></tr><tr><td>Build</td><td><code>pnpm --filter @cpc/web build</code></td><td>Vite emits <code>dist/</code></td></tr><tr><td>Health</td><td><code>curl -fsS localhost:38830/health</code></td><td>ok</td></tr></tbody></table></div>
+<h2 id="6-example-route-notes">6. Example Route Notes</h2>
+<p>The web app uses a base path from Vite. Static assets should keep working at<br/>
+both <code>https://cpc.claude.do</code> and <code>https://cpc-dev.claude.do</code>.</p>
 <pre><code class="language-ts">export function buildAssetPath(baseUrl: string, name: string): string {
   const base = baseUrl.endsWith(&quot;/&quot;) ? baseUrl : \`\${baseUrl}/\`;
   return new URL(name, base).toString();
 }
 </code></pre>
-<h2>7. Shell Recipe</h2>
+<h2 id="7-shell-recipe">7. Shell Recipe</h2>
 <pre><code class="language-bash">set -euo pipefail
 pnpm install --silent
 pnpm --filter @cpc/web exec tsc -b
 pnpm --filter @cpc/web test
 pnpm --filter @cpc/web build
 </code></pre>
-<h2>8. Failure Modes</h2>
+<h2 id="8-failure-modes">8. Failure Modes</h2>
 <blockquote>
 <p>A sheet that forgets to re-enable vertical swipes makes Telegram feel broken.</p>
 </blockquote>
 <blockquote>
-<p>A wide code block without horizontal scrolling makes the terminal transcript<br>unreadable on mobile.</p>
+<p>A wide code block without horizontal scrolling makes the terminal transcript<br/>
+unreadable on mobile.</p>
 </blockquote>
 <blockquote>
-<p>A raw HTML block silently stripped by a markdown renderer can hide operational<br>instructions from the person holding the phone.</p>
+<p>A raw HTML block silently stripped by a markdown renderer can hide operational<br/>
+instructions from the person holding the phone.</p>
 </blockquote>
-<h2>9. Task List</h2>
-<ul>
-<li><input checked="" disabled="" type="checkbox"> Confirm branch before edits.</li>
-<li><input checked="" disabled="" type="checkbox"> Keep <code>marked</code> installed during the baseline setup.</li>
-<li><input disabled="" type="checkbox"> Swap the renderer in Wave 2.</li>
-<li><input disabled="" type="checkbox"> Document snapshot deltas in the migration PR.</li>
+<h2 id="9-task-list">9. Task List</h2>
+<ul class="contains-task-list">
+<li class="task-list-item"><input type="checkbox" disabled="" checked=""/> Confirm branch before edits.</li>
+<li class="task-list-item"><input type="checkbox" disabled="" checked=""/> Keep <code>marked</code> installed during the baseline setup.</li>
+<li class="task-list-item"><input type="checkbox" disabled=""/> Swap the renderer in Wave 2.</li>
+<li class="task-list-item"><input type="checkbox" disabled=""/> Document snapshot deltas in the migration PR.</li>
 </ul>
-<h2>10. Deep Link Candidates</h2>
-<h3>Session Selection</h3>
-<p>The future heading IDs may support direct links into long docs. Duplicate<br>headings need stable suffixes.</p>
-<h3>Session Selection</h3>
+<h2 id="10-deep-link-candidates">10. Deep Link Candidates</h2>
+<h3 id="session-selection">Session Selection</h3>
+<p>The future heading IDs may support direct links into long docs. Duplicate<br/>
+headings need stable suffixes.</p>
+<h3 id="session-selection-1">Session Selection</h3>
 <p>This duplicate heading is intentional.</p>
-<h3>Voice Recorder</h3>
-<p>The voice recorder uses file capture rather than <code>getUserMedia</code> because Telegram<br>WebView does not expose the browser media prompt consistently.</p>
-<h3>Terminal</h3>
-<p>Terminal output can include long paths such as<br><code>/home/claude/code/cpc-impl-react-markdown/apps/web/src/components/MarkdownViewer.tsx</code>.</p>
-<h2>11. JSON Payload</h2>
+<h3 id="voice-recorder">Voice Recorder</h3>
+<p>The voice recorder uses file capture rather than <code>getUserMedia</code> because Telegram<br/>
+WebView does not expose the browser media prompt consistently.</p>
+<h3 id="terminal">Terminal</h3>
+<p>Terminal output can include long paths such as<br/>
+<code>/home/claude/code/cpc-impl-react-markdown/apps/web/src/components/MarkdownViewer.tsx</code>.</p>
+<h2 id="11-json-payload">11. JSON Payload</h2>
 <pre><code class="language-json">{
   &quot;kind&quot;: &quot;SessionStart&quot;,
   &quot;buttons&quot;: [&quot;Actions&quot;, &quot;Develop&quot;, &quot;Voice&quot;],
@@ -316,57 +269,47 @@ pnpm --filter @cpc/web build
   }
 }
 </code></pre>
-<h2>12. Closing Notes</h2>
-<p>Soft breaks appear here<br>as single newlines<br>inside one paragraph.</p>
-<p>A blank line starts a new paragraph. The snapshot should make that distinction<br>obvious.</p>
-<h2>13. Appendix</h2>
-<p>The appendix exists mostly to make the fixture long enough to exercise file<br>loading, snapshot readability, and parser behavior on realistic content.</p>
-<p>Keep the prose plain.<br>Keep commands copyable.<br>Keep the renderer honest.</p>
-"
+<h2 id="12-closing-notes">12. Closing Notes</h2>
+<p>Soft breaks appear here<br/>
+as single newlines<br/>
+inside one paragraph.</p>
+<p>A blank line starts a new paragraph. The snapshot should make that distinction<br/>
+obvious.</p>
+<h2 id="13-appendix">13. Appendix</h2>
+<p>The appendix exists mostly to make the fixture long enough to exercise file<br/>
+loading, snapshot readability, and parser behavior on realistic content.</p>
+<p>Keep the prose plain.<br/>
+Keep commands copyable.<br/>
+Keep the renderer honest.</p></div>"
 `;
 
-exports[`Markdown parity baseline (marked) > renders mermaid through marked 1`] = `
-"<h1>Mermaid Preview Fixture</h1>
-<p>Current production output parses mermaid as a fenced code block first; the<br>viewer then replaces <code>code.language-mermaid</code> with a React-rendered diagram. This<br>fixture pins the parser-level baseline that Wave 2 must account for.</p>
-<pre><code class="language-mermaid">flowchart TD
-  Start([Open file])
-  Detect{Markdown?}
-  Render[Render with viewer]
-  Mermaid{Contains mermaid fence?}
-  Diagram[Mount MermaidDiagram]
-  Done([Readable in Telegram])
-
-  Start --&gt; Detect
-  Detect --&gt;|yes| Render
-  Detect --&gt;|no| Done
-  Render --&gt; Mermaid
-  Mermaid --&gt;|yes| Diagram
-  Mermaid --&gt;|no| Done
-  Diagram --&gt; Done
-</code></pre>
-<p>Text after the diagram should remain a separate paragraph.</p>
-"
+exports[`Markdown parity baseline (react-markdown) > renders mermaid through react-markdown 1`] = `
+"<div class="md-content"><h1 id="mermaid-preview-fixture">Mermaid Preview Fixture</h1>
+<p>Current production output parses mermaid as a fenced code block first; the<br/>
+viewer then replaces <code>code.language-mermaid</code> with a React-rendered diagram. This<br/>
+fixture pins the parser-level baseline that Wave 2 must account for.</p>
+<div class="mermaid-mount"><div class="mermaid-loading">Loading diagram…</div></div>
+<p>Text after the diagram should remain a separate paragraph.</p></div>"
 `;
 
-exports[`Markdown parity baseline (marked) > renders raw-html through marked 1`] = `
-"<h1>Raw HTML From Copied Docs</h1>
-<p>Some project documents include GitHub-flavored raw HTML. Marked currently keeps<br>these nodes in the emitted HTML, so the baseline should capture the exact shape.</p>
-<details>
-<summary>Deployment checklist</summary>
-
+exports[`Markdown parity baseline (react-markdown) > renders raw-html through react-markdown 1`] = `
+"<div class="md-content"><h1 id="raw-html-from-copied-docs">Raw HTML From Copied Docs</h1>
+<p>Some project documents include GitHub-flavored raw HTML. Marked currently keeps<br/>
+these nodes in the emitted HTML, so the baseline should capture the exact shape.</p>
+&lt;details&gt;
+&lt;summary&gt;Deployment checklist&lt;/summary&gt;
 <ul>
 <li>Build <code>apps/web</code></li>
 <li>Restart the CPC server</li>
 <li>Check <code>/health</code></li>
 </ul>
-</details>
-
-<p>Keyboard hints appear inline: press <kbd>Esc</kbd> to dismiss a sheet, or<br><kbd>Ctrl</kbd> + <kbd>C</kbd> to stop a local dev server.</p>
-<p>Line one<br><br>Line two after a manual break.</p>
-<div data-cpc-note="copied-from-github">
-  <strong>Note:</strong> this block is raw HTML and should be called out in any
+&lt;/details&gt;
+<p>Keyboard hints appear inline: press &lt;kbd&gt;Esc&lt;/kbd&gt; to dismiss a sheet, or<br/>
+&lt;kbd&gt;Ctrl&lt;/kbd&gt; + &lt;kbd&gt;C&lt;/kbd&gt; to stop a local dev server.</p>
+<p>Line one&lt;br&gt;<br/>
+Line two after a manual break.</p>
+&lt;div data-cpc-note=&quot;copied-from-github&quot;&gt;
+  &lt;strong&gt;Note:&lt;/strong&gt; this block is raw HTML and should be called out in any
   renderer parity review.
-</div>
-
-"
+&lt;/div&gt;</div>"
 `;

--- a/apps/web/src/components/__tests__/markdown-fixtures/basic.md
+++ b/apps/web/src/components/__tests__/markdown-fixtures/basic.md
@@ -1,0 +1,18 @@
+# CPC Markdown Basics
+
+The file viewer opens markdown from docs, notes, and generated plans. This
+fixture keeps the everyday inline formatting stable before the renderer changes.
+
+Operators often scan for **urgent actions**, _quiet context_, and links to
+[the deployment guide](../../../../docs/guides/deploying.md) while standing in a
+Telegram WebView. Inline code like `pnpm --filter @cpc/web build` should keep its
+compact chip styling and should not disturb wrapping in a narrow viewport.
+
+Use bold and italic together when a note is both **_important and tentative_**.
+Use literal punctuation such as `apps/web/src/components/MarkdownViewer.tsx`,
+`ALLOWED_TELEGRAM_USERS`, and `cpc.claude.do` without surprising escapes.
+
+An external reference can point to [Telegram Mini Apps](https://core.telegram.org/bots/webapps),
+and a local note can point to [touch handling](../../../../docs/conventions/touch-handling.md).
+Both are common in CPC runbooks.
+

--- a/apps/web/src/components/__tests__/markdown-fixtures/breaks.md
+++ b/apps/web/src/components/__tests__/markdown-fixtures/breaks.md
@@ -1,0 +1,23 @@
+# Soft And Hard Breaks
+
+This paragraph has a soft break after this line
+and marked currently turns it into a `<br>`.
+The third source line should also stay inside the same paragraph with breaks.
+
+This paragraph uses two spaces before the newline.  
+That is a markdown hard break regardless of the `breaks` setting.
+
+This paragraph ends here.
+
+This is a new paragraph after a blank line.
+
+- List item with a soft break
+  inside the same item
+- Second list item with two trailing spaces  
+  before this continuation line
+
+> Blockquote line one
+> blockquote line two
+>
+> New quoted paragraph after a blank quoted line.
+

--- a/apps/web/src/components/__tests__/markdown-fixtures/code-blocks.md
+++ b/apps/web/src/components/__tests__/markdown-fixtures/code-blocks.md
@@ -1,0 +1,46 @@
+# Code Blocks And Commands
+
+Inline code such as `getAuthHeaders()` and `Telegram.WebApp.disableVerticalSwipes()`
+appears beside fenced examples in CPC docs.
+
+```ts
+type SessionStatus = "connected" | "paused" | "failed";
+
+export function labelForStatus(status: SessionStatus): string {
+  switch (status) {
+    case "connected":
+      return "Connected";
+    case "paused":
+      return "Paused";
+    case "failed":
+      return "Needs attention";
+  }
+}
+```
+
+```bash
+cd /home/claude/code/cpc-impl-react-markdown
+pnpm install --silent
+pnpm --filter @cpc/web exec tsc -b
+pnpm --filter @cpc/web test
+```
+
+```json
+{
+  "server": {
+    "port": 38830,
+    "prodTunnel": "https://cpc.claude.do",
+    "devTunnel": "https://cpc-dev.claude.do"
+  },
+  "features": ["files", "terminal", "voice"]
+}
+```
+
+An unlabelled block still matters:
+
+```
+Actions -> Develop -> Voice
+```
+
+The paragraph after code must resume normal wrapping and link handling.
+

--- a/apps/web/src/components/__tests__/markdown-fixtures/edge-cases.md
+++ b/apps/web/src/components/__tests__/markdown-fixtures/edge-cases.md
@@ -1,0 +1,38 @@
+# Edge Cases
+
+
+## Consecutive Heading A
+## Consecutive Heading B
+### Consecutive Heading C
+
+The blank lines above and the consecutive headings below should not create
+unexpected empty paragraphs.
+
+- Top level item
+  - Nested item with `inline code`
+    - Third level item
+      1. Ordered detail
+      2. Ordered detail with a [relative link](../../../../AGENTS.md)
+- Second top level item
+
+1. Ordered root
+   - Unordered child
+     > Quote inside a list item.
+     >
+     > ```bash
+     > pnpm --filter @cpc/web test
+     > ```
+
+> A blockquote with a paragraph.
+>
+> - A quoted list item
+> - Another quoted list item with `code`
+>
+> ```ts
+> const source = "quoted code";
+> ```
+
+---
+
+Text after a thematic break should remain visible and separated.
+

--- a/apps/web/src/components/__tests__/markdown-fixtures/gfm-table.md
+++ b/apps/web/src/components/__tests__/markdown-fixtures/gfm-table.md
@@ -1,0 +1,22 @@
+# Session Triage Matrix
+
+The action sheet often summarizes multiple sessions. Tables need GFM alignment,
+inline formatting, and escaped pipes to render consistently.
+
+| Session | State | Last line | Priority |
+| :--- | :---: | --- | ---: |
+| `alpha` | connected | **ready** for `pnpm test` | 1 |
+| `deploy-web` | paused | waiting on `cpc.service` restart | 2 |
+| `docs-sync` | active | copied `foo \| bar` from a plan table | 3 |
+| `voice-notes` | failed | transcript contains `<kbd>Ctrl</kbd>` text | 4 |
+
+| Path | Owner | Notes |
+| --- | --- | --- |
+| `apps/web/` | frontend | Telegram WebView constraints apply |
+| `apps/server/` | backend | Hono routes, auth, and static serving |
+| `docs/` | shared | Progressive discovery, not a dumping ground |
+
+Trailing prose verifies paragraph flow after a block table. The next renderer
+should preserve table cells with code, emphasis, escaped pipes, and raw-looking
+text without collapsing the surrounding content.
+

--- a/apps/web/src/components/__tests__/markdown-fixtures/headings.md
+++ b/apps/web/src/components/__tests__/markdown-fixtures/headings.md
@@ -1,0 +1,46 @@
+# CPC Plan: Markdown Renderer
+
+## Phase 0: Baseline
+
+### Fixture Corpus
+
+#### Headings With Special Characters: `/files/:path?tab=docs`
+
+##### Duplicate Heading
+
+###### Tiny Detail
+
+The smallest heading appears in some generated plans when a tool dumps nested
+subsections.
+
+## Phase 0: Baseline
+
+The duplicate `h2` is intentional. Future heading IDs should make the duplicate
+stable and reviewable rather than surprising.
+
+### Fixture Corpus
+
+Repeated `h3` content tests duplicate slug behavior once `rehype-slug` becomes
+part of the renderer.
+
+## Phase 1: Renderer Swap
+
+### Keep `breaks: true`
+
+The current marked configuration treats single newlines as breaks. The migration
+must preserve that until a separate behavior-change PR says otherwise.
+
+### Raw HTML Decision
+
+#### `<details>` Blocks
+
+Raw HTML occurs in docs copied from GitHub. This fixture keeps that input visible
+in the baseline snapshots.
+
+## Phase 2: Bundle Mitigation
+
+### Lazy Loading
+
+Bundle work belongs after correctness, so this fixture should not imply any
+chunking change.
+

--- a/apps/web/src/components/__tests__/markdown-fixtures/links-images.md
+++ b/apps/web/src/components/__tests__/markdown-fixtures/links-images.md
@@ -1,0 +1,22 @@
+# Links And Images
+
+The file viewer handles project-relative docs, external references, and images
+embedded in markdown notes.
+
+- Relative guide: [adding a modal](../../../../docs/guides/adding-a-modal.md)
+- Absolute URL: [CPC production tunnel](https://cpc.claude.do)
+- Mail link: [ops inbox](mailto:ops@example.invalid)
+- Anchor-only link: [jump to raw HTML](#raw-html-decision)
+- Path with spaces: [voice notes](../fixtures/Voice%20Notes.md)
+
+![CPC app tile](../../../../public/icon.svg "App icon")
+
+Reference-style links keep long paragraphs readable. See the [Telegram WebView
+rules][webview-rules] before changing touch handling, and check the [host tools
+notes][host-tools] when a workflow depends on `~/bin`.
+
+[webview-rules]: ../../../../docs/reference/telegram-webview-rules.md
+[host-tools]: ../../../../docs/conventions/host-tools.md
+
+Bare URLs are common in copied notes: https://cpc-dev.claude.do/status
+

--- a/apps/web/src/components/__tests__/markdown-fixtures/long-document.md
+++ b/apps/web/src/components/__tests__/markdown-fixtures/long-document.md
@@ -1,0 +1,132 @@
+# Overnight CPC Implementation Notes
+
+## 1. Summary
+
+The mobile console stayed usable while the web process restarted twice. The
+highest value fix was keeping the file viewer readable in a narrow WebView.
+
+## 2. Current Topology
+
+- `apps/web` owns the React SPA.
+- `apps/server` owns Hono routes and WebSocket transport.
+- `~/bin/launcher-hook` owns Telegram keyboard buttons.
+- `~/bin/session-history` owns forensic session lookup.
+
+## 3. Important Constraints
+
+Do not call `preventDefault()` on `touchstart`.
+Use `stopPropagation()` only on targeted interaction zones.
+Disable Telegram vertical swipes while a modal or sheet is open.
+Re-enable Telegram vertical swipes on cleanup.
+Do not edit the external Telegram plugin.
+
+## 4. File Viewer Flow
+
+1. User taps the Files tab.
+2. The server returns a directory listing.
+3. The UI shows file icons and path breadcrumbs.
+4. A markdown file opens in the MarkdownViewer.
+5. Wide code blocks must scroll horizontally.
+6. Tables must not push the viewport wider than the app.
+
+## 5. Manual Check Table
+
+| Check | Command | Expected |
+| --- | --- | --- |
+| TypeScript | `pnpm --filter @cpc/web exec tsc -b` | clean |
+| Unit tests | `pnpm --filter @cpc/web test` | snapshots pass |
+| Build | `pnpm --filter @cpc/web build` | Vite emits `dist/` |
+| Health | `curl -fsS localhost:38830/health` | ok |
+
+## 6. Example Route Notes
+
+The web app uses a base path from Vite. Static assets should keep working at
+both `https://cpc.claude.do` and `https://cpc-dev.claude.do`.
+
+```ts
+export function buildAssetPath(baseUrl: string, name: string): string {
+  const base = baseUrl.endsWith("/") ? baseUrl : `${baseUrl}/`;
+  return new URL(name, base).toString();
+}
+```
+
+## 7. Shell Recipe
+
+```bash
+set -euo pipefail
+pnpm install --silent
+pnpm --filter @cpc/web exec tsc -b
+pnpm --filter @cpc/web test
+pnpm --filter @cpc/web build
+```
+
+## 8. Failure Modes
+
+> A sheet that forgets to re-enable vertical swipes makes Telegram feel broken.
+
+> A wide code block without horizontal scrolling makes the terminal transcript
+> unreadable on mobile.
+
+> A raw HTML block silently stripped by a markdown renderer can hide operational
+> instructions from the person holding the phone.
+
+## 9. Task List
+
+- [x] Confirm branch before edits.
+- [x] Keep `marked` installed during the baseline setup.
+- [ ] Swap the renderer in Wave 2.
+- [ ] Document snapshot deltas in the migration PR.
+
+## 10. Deep Link Candidates
+
+### Session Selection
+
+The future heading IDs may support direct links into long docs. Duplicate
+headings need stable suffixes.
+
+### Session Selection
+
+This duplicate heading is intentional.
+
+### Voice Recorder
+
+The voice recorder uses file capture rather than `getUserMedia` because Telegram
+WebView does not expose the browser media prompt consistently.
+
+### Terminal
+
+Terminal output can include long paths such as
+`/home/claude/code/cpc-impl-react-markdown/apps/web/src/components/MarkdownViewer.tsx`.
+
+## 11. JSON Payload
+
+```json
+{
+  "kind": "SessionStart",
+  "buttons": ["Actions", "Develop", "Voice"],
+  "viewer": {
+    "markdown": true,
+    "mermaid": true,
+    "rawHtml": "baseline-only"
+  }
+}
+```
+
+## 12. Closing Notes
+
+Soft breaks appear here
+as single newlines
+inside one paragraph.
+
+A blank line starts a new paragraph. The snapshot should make that distinction
+obvious.
+
+## 13. Appendix
+
+The appendix exists mostly to make the fixture long enough to exercise file
+loading, snapshot readability, and parser behavior on realistic content.
+
+Keep the prose plain.
+Keep commands copyable.
+Keep the renderer honest.
+

--- a/apps/web/src/components/__tests__/markdown-fixtures/mermaid.md
+++ b/apps/web/src/components/__tests__/markdown-fixtures/mermaid.md
@@ -1,0 +1,26 @@
+# Mermaid Preview Fixture
+
+Current production output parses mermaid as a fenced code block first; the
+viewer then replaces `code.language-mermaid` with a React-rendered diagram. This
+fixture pins the parser-level baseline that Wave 2 must account for.
+
+```mermaid
+flowchart TD
+  Start([Open file])
+  Detect{Markdown?}
+  Render[Render with viewer]
+  Mermaid{Contains mermaid fence?}
+  Diagram[Mount MermaidDiagram]
+  Done([Readable in Telegram])
+
+  Start --> Detect
+  Detect -->|yes| Render
+  Detect -->|no| Done
+  Render --> Mermaid
+  Mermaid -->|yes| Diagram
+  Mermaid -->|no| Done
+  Diagram --> Done
+```
+
+Text after the diagram should remain a separate paragraph.
+

--- a/apps/web/src/components/__tests__/markdown-fixtures/raw-html.md
+++ b/apps/web/src/components/__tests__/markdown-fixtures/raw-html.md
@@ -1,0 +1,25 @@
+# Raw HTML From Copied Docs
+
+Some project documents include GitHub-flavored raw HTML. Marked currently keeps
+these nodes in the emitted HTML, so the baseline should capture the exact shape.
+
+<details>
+<summary>Deployment checklist</summary>
+
+- Build `apps/web`
+- Restart the CPC server
+- Check `/health`
+
+</details>
+
+Keyboard hints appear inline: press <kbd>Esc</kbd> to dismiss a sheet, or
+<kbd>Ctrl</kbd> + <kbd>C</kbd> to stop a local dev server.
+
+Line one<br>
+Line two after a manual break.
+
+<div data-cpc-note="copied-from-github">
+  <strong>Note:</strong> this block is raw HTML and should be called out in any
+  renderer parity review.
+</div>
+

--- a/apps/web/src/components/__tests__/markdown-parity.test.ts
+++ b/apps/web/src/components/__tests__/markdown-parity.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync, readdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { Marked } from "marked";
+
+const marked = new Marked({ gfm: true, breaks: true });
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const FIXTURE_DIR = join(__dirname, "markdown-fixtures");
+
+const fixtures = readdirSync(FIXTURE_DIR)
+  .filter((f) => f.endsWith(".md"))
+  .sort()
+  .map((f) => ({
+    name: f.replace(".md", ""),
+    content: readFileSync(join(FIXTURE_DIR, f), "utf-8"),
+  }));
+
+describe("Markdown parity baseline (marked)", () => {
+  for (const fixture of fixtures) {
+    it(`renders ${fixture.name} through marked`, () => {
+      const html = marked.parse(fixture.content);
+      expect(html).toMatchSnapshot();
+    });
+  }
+});

--- a/apps/web/src/components/__tests__/markdown-parity.test.ts
+++ b/apps/web/src/components/__tests__/markdown-parity.test.ts
@@ -2,9 +2,32 @@ import { describe, it, expect } from "vitest";
 import { readFileSync, readdirSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { Marked } from "marked";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import ReactMarkdown from "react-markdown";
+import {
+  markdownComponents,
+  markdownRehypePlugins,
+  markdownRemarkPlugins,
+} from "../MarkdownViewer";
 
-const marked = new Marked({ gfm: true, breaks: true });
+function renderMarkdown(content: string): string {
+  return renderToStaticMarkup(
+    createElement(
+      "div",
+      { className: "md-content" },
+      createElement(
+        ReactMarkdown,
+        {
+          remarkPlugins: markdownRemarkPlugins,
+          rehypePlugins: markdownRehypePlugins,
+          components: markdownComponents,
+        },
+        content,
+      ),
+    ),
+  );
+}
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const FIXTURE_DIR = join(__dirname, "markdown-fixtures");
@@ -17,11 +40,10 @@ const fixtures = readdirSync(FIXTURE_DIR)
     content: readFileSync(join(FIXTURE_DIR, f), "utf-8"),
   }));
 
-describe("Markdown parity baseline (marked)", () => {
+describe("Markdown parity baseline (react-markdown)", () => {
   for (const fixture of fixtures) {
-    it(`renders ${fixture.name} through marked`, () => {
-      const html = marked.parse(fixture.content);
-      expect(html).toMatchSnapshot();
+    it(`renders ${fixture.name} through react-markdown`, () => {
+      expect(renderMarkdown(fixture.content)).toMatchSnapshot();
     });
   }
 });

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -66,7 +66,6 @@ export default defineConfig(({ command }) => ({
             "@xterm/addon-fit",
             "@xterm/addon-web-links",
           ],
-          "vendor-marked": ["marked"],
         },
       },
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,6 +106,9 @@ importers:
       jsdom:
         specifier: ^29.0.2
         version: 29.0.2
+      rollup-plugin-visualizer:
+        specifier: ^7.0.1
+        version: 7.0.1(rollup@4.60.1)
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -1113,6 +1116,14 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  ansi-regex@6.2.2:
+    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
+    engines: {node: '>=12'}
+
+  ansi-styles@6.2.3:
+    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
+    engines: {node: '>=12'}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
@@ -1149,6 +1160,10 @@ packages:
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
+  bundle-name@4.1.0:
+    resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
+    engines: {node: '>=18'}
+
   caniuse-lite@1.0.30001786:
     resolution: {integrity: sha512-4oxTZEvqmLLrERwxO76yfKM7acZo310U+v4kqexI2TL1DkkUEMT8UijrxxcnVdxR3qkVf5awGRX+4Z6aPHVKrA==}
 
@@ -1182,6 +1197,10 @@ packages:
 
   chownr@1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
+
+  cliui@9.0.1:
+    resolution: {integrity: sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==}
+    engines: {node: '>=20'}
 
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
@@ -1399,6 +1418,18 @@ packages:
     resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
     engines: {node: '>=4.0.0'}
 
+  default-browser-id@5.0.1:
+    resolution: {integrity: sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==}
+    engines: {node: '>=18'}
+
+  default-browser@5.5.0:
+    resolution: {integrity: sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==}
+    engines: {node: '>=18'}
+
+  define-lazy-prop@3.0.0:
+    resolution: {integrity: sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==}
+    engines: {node: '>=12'}
+
   delaunator@5.1.0:
     resolution: {integrity: sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==}
 
@@ -1418,6 +1449,9 @@ packages:
 
   electron-to-chromium@1.5.332:
     resolution: {integrity: sha512-7OOtytmh/rINMLwaFTbcMVvYXO3AUm029X0LcyfYk0B557RlPkdpTpnH9+htMlfu5dKwOmT0+Zs2Aw+lnn6TeQ==}
+
+  emoji-regex@10.6.0:
+    resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
 
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
@@ -1503,6 +1537,14 @@ packages:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
 
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
+
+  get-east-asian-width@1.5.0:
+    resolution: {integrity: sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==}
+    engines: {node: '>=18'}
+
   get-tsconfig@4.13.7:
     resolution: {integrity: sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==}
 
@@ -1573,8 +1615,22 @@ packages:
   is-decimal@2.0.1:
     resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
 
+  is-docker@3.0.0:
+    resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    hasBin: true
+
   is-hexadecimal@2.0.1:
     resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
+
+  is-in-ssh@1.0.0:
+    resolution: {integrity: sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==}
+    engines: {node: '>=20'}
+
+  is-inside-container@1.0.0:
+    resolution: {integrity: sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==}
+    engines: {node: '>=14.16'}
+    hasBin: true
 
   is-plain-obj@4.1.0:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
@@ -1582,6 +1638,10 @@ packages:
 
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
+  is-wsl@3.1.1:
+    resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
+    engines: {node: '>=16'}
 
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
@@ -1904,6 +1964,10 @@ packages:
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
+  open@11.0.0:
+    resolution: {integrity: sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==}
+    engines: {node: '>=20'}
+
   package-manager-detector@1.6.0:
     resolution: {integrity: sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==}
 
@@ -1948,6 +2012,10 @@ packages:
   postcss@8.5.8:
     resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
     engines: {node: ^10 || ^12 || >=14}
+
+  powershell-utils@0.1.0:
+    resolution: {integrity: sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==}
+    engines: {node: '>=20'}
 
   prebuild-install@7.1.3:
     resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
@@ -2025,6 +2093,19 @@ packages:
   robust-predicates@3.0.3:
     resolution: {integrity: sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==}
 
+  rollup-plugin-visualizer@7.0.1:
+    resolution: {integrity: sha512-UJUT4+1Ho4OcWmPYU3sYXgUqI8B8Ayfe06MX7y0qCJ1K8aGoKtR/NDd/2nZqM7ADkrzny+I99Ul7GgyoiVNAgg==}
+    engines: {node: '>=22'}
+    hasBin: true
+    peerDependencies:
+      rolldown: 1.x || ^1.0.0-beta || ^1.0.0-rc
+      rollup: 2.x || 3.x || 4.x
+    peerDependenciesMeta:
+      rolldown:
+        optional: true
+      rollup:
+        optional: true
+
   rollup@4.60.1:
     resolution: {integrity: sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -2032,6 +2113,10 @@ packages:
 
   roughjs@4.6.6:
     resolution: {integrity: sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==}
+
+  run-applescript@7.1.0:
+    resolution: {integrity: sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==}
+    engines: {node: '>=18'}
 
   rw@1.3.3:
     resolution: {integrity: sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==}
@@ -2075,6 +2160,10 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
+  source-map@0.7.6:
+    resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
+    engines: {node: '>= 12'}
+
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
 
@@ -2084,11 +2173,19 @@ packages:
   std-env@4.0.0:
     resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
 
+  string-width@7.2.0:
+    resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
+    engines: {node: '>=18'}
+
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
 
   stringify-entities@4.0.4:
     resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
+
+  strip-ansi@7.2.0:
+    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
+    engines: {node: '>=12'}
 
   strip-json-comments@2.0.1:
     resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
@@ -2350,6 +2447,10 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  wrap-ansi@9.0.2:
+    resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
+    engines: {node: '>=18'}
+
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
@@ -2365,6 +2466,10 @@ packages:
       utf-8-validate:
         optional: true
 
+  wsl-utils@0.3.1:
+    resolution: {integrity: sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==}
+    engines: {node: '>=20'}
+
   xml-name-validator@5.0.0:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
     engines: {node: '>=18'}
@@ -2372,8 +2477,20 @@ packages:
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
+  y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
+
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+  yargs-parser@22.0.0:
+    resolution: {integrity: sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=23}
+
+  yargs@18.0.0:
+    resolution: {integrity: sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=23}
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -3204,6 +3321,10 @@ snapshots:
 
   acorn@8.16.0: {}
 
+  ansi-regex@6.2.2: {}
+
+  ansi-styles@6.2.3: {}
+
   assertion-error@2.0.1: {}
 
   bail@2.0.2: {}
@@ -3244,6 +3365,10 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
+  bundle-name@4.1.0:
+    dependencies:
+      run-applescript: 7.1.0
+
   caniuse-lite@1.0.30001786: {}
 
   ccount@2.0.1: {}
@@ -3272,6 +3397,12 @@ snapshots:
       '@chevrotain/utils': 12.0.0
 
   chownr@1.1.4: {}
+
+  cliui@9.0.1:
+    dependencies:
+      string-width: 7.2.0
+      strip-ansi: 7.2.0
+      wrap-ansi: 9.0.2
 
   comma-separated-tokens@2.0.3: {}
 
@@ -3507,6 +3638,15 @@ snapshots:
 
   deep-extend@0.6.0: {}
 
+  default-browser-id@5.0.1: {}
+
+  default-browser@5.5.0:
+    dependencies:
+      bundle-name: 4.1.0
+      default-browser-id: 5.0.1
+
+  define-lazy-prop@3.0.0: {}
+
   delaunator@5.1.0:
     dependencies:
       robust-predicates: 3.0.3
@@ -3524,6 +3664,8 @@ snapshots:
       '@types/trusted-types': 2.0.7
 
   electron-to-chromium@1.5.332: {}
+
+  emoji-regex@10.6.0: {}
 
   end-of-stream@1.4.5:
     dependencies:
@@ -3632,6 +3774,10 @@ snapshots:
 
   gensync@1.0.0-beta.2: {}
 
+  get-caller-file@2.0.5: {}
+
+  get-east-asian-width@1.5.0: {}
+
   get-tsconfig@4.13.7:
     dependencies:
       resolve-pkg-maps: 1.0.0
@@ -3711,11 +3857,23 @@ snapshots:
 
   is-decimal@2.0.1: {}
 
+  is-docker@3.0.0: {}
+
   is-hexadecimal@2.0.1: {}
+
+  is-in-ssh@1.0.0: {}
+
+  is-inside-container@1.0.0:
+    dependencies:
+      is-docker: 3.0.0
 
   is-plain-obj@4.1.0: {}
 
   is-potential-custom-element-name@1.0.1: {}
+
+  is-wsl@3.1.1:
+    dependencies:
+      is-inside-container: 1.0.0
 
   jiti@2.6.1: {}
 
@@ -4247,6 +4405,15 @@ snapshots:
     dependencies:
       wrappy: 1.0.2
 
+  open@11.0.0:
+    dependencies:
+      default-browser: 5.5.0
+      define-lazy-prop: 3.0.0
+      is-in-ssh: 1.0.0
+      is-inside-container: 1.0.0
+      powershell-utils: 0.1.0
+      wsl-utils: 0.3.1
+
   package-manager-detector@1.6.0: {}
 
   parse-entities@4.0.2:
@@ -4297,6 +4464,8 @@ snapshots:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  powershell-utils@0.1.0: {}
 
   prebuild-install@7.1.3:
     dependencies:
@@ -4420,6 +4589,15 @@ snapshots:
 
   robust-predicates@3.0.3: {}
 
+  rollup-plugin-visualizer@7.0.1(rollup@4.60.1):
+    dependencies:
+      open: 11.0.0
+      picomatch: 4.0.4
+      source-map: 0.7.6
+      yargs: 18.0.0
+    optionalDependencies:
+      rollup: 4.60.1
+
   rollup@4.60.1:
     dependencies:
       '@types/estree': 1.0.8
@@ -4458,6 +4636,8 @@ snapshots:
       points-on-curve: 0.2.0
       points-on-path: 0.2.1
 
+  run-applescript@7.1.0: {}
+
   rw@1.3.3: {}
 
   safe-buffer@5.2.1: {}
@@ -4492,11 +4672,19 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
+  source-map@0.7.6: {}
+
   space-separated-tokens@2.0.2: {}
 
   stackback@0.0.2: {}
 
   std-env@4.0.0: {}
+
+  string-width@7.2.0:
+    dependencies:
+      emoji-regex: 10.6.0
+      get-east-asian-width: 1.5.0
+      strip-ansi: 7.2.0
 
   string_decoder@1.3.0:
     dependencies:
@@ -4506,6 +4694,10 @@ snapshots:
     dependencies:
       character-entities-html4: 2.1.0
       character-entities-legacy: 3.0.0
+
+  strip-ansi@7.2.0:
+    dependencies:
+      ansi-regex: 6.2.2
 
   strip-json-comments@2.0.1: {}
 
@@ -4736,14 +4928,38 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
+  wrap-ansi@9.0.2:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 7.2.0
+      strip-ansi: 7.2.0
+
   wrappy@1.0.2: {}
 
   ws@8.20.0: {}
+
+  wsl-utils@0.3.1:
+    dependencies:
+      is-wsl: 3.1.1
+      powershell-utils: 0.1.0
 
   xml-name-validator@5.0.0: {}
 
   xmlchars@2.2.0: {}
 
+  y18n@5.0.8: {}
+
   yallist@3.1.1: {}
+
+  yargs-parser@22.0.0: {}
+
+  yargs@18.0.0:
+    dependencies:
+      cliui: 9.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      string-width: 7.2.0
+      y18n: 5.0.8
+      yargs-parser: 22.0.0
 
   zwitch@2.0.4: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,6 +75,18 @@ importers:
       react-icons:
         specifier: ^5.6.0
         version: 5.6.0(react@19.2.4)
+      react-markdown:
+        specifier: ^10.1.0
+        version: 10.1.0(@types/react@19.2.14)(react@19.2.4)
+      rehype-slug:
+        specifier: ^6.0.0
+        version: 6.0.0
+      remark-breaks:
+        specifier: ^4.0.0
+        version: 4.0.0
+      remark-gfm:
+        specifier: ^4.0.1
+        version: 4.0.1
     devDependencies:
       '@tailwindcss/vite':
         specifier: ^4.2.2
@@ -97,9 +109,6 @@ importers:
       jsdom:
         specifier: ^29.0.2
         version: 29.0.2
-      rollup-plugin-visualizer:
-        specifier: ^7.0.1
-        version: 7.0.1(rollup@4.60.1)
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -999,14 +1008,29 @@ packages:
   '@types/d3@7.4.3':
     resolution: {integrity: sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==}
 
+  '@types/debug@4.1.13':
+    resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree-jsx@1.0.5':
+    resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
   '@types/geojson@7946.0.16':
     resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
+
+  '@types/hast@3.0.4':
+    resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
+
+  '@types/mdast@4.0.4':
+    resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
+
+  '@types/ms@2.1.0':
+    resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
   '@types/node@22.19.17':
     resolution: {integrity: sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==}
@@ -1021,6 +1045,15 @@ packages:
 
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
+  '@types/unist@2.0.11':
+    resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
+
+  '@types/unist@3.0.3':
+    resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
+
+  '@ungap/structured-clone@1.3.0':
+    resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
 
   '@upsetjs/venn.js@2.0.0':
     resolution: {integrity: sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==}
@@ -1083,17 +1116,12 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  ansi-regex@6.2.2:
-    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
-    engines: {node: '>=12'}
-
-  ansi-styles@6.2.3:
-    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
-    engines: {node: '>=12'}
-
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
+
+  bail@2.0.2:
+    resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
 
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
@@ -1124,16 +1152,27 @@ packages:
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
-  bundle-name@4.1.0:
-    resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
-    engines: {node: '>=18'}
-
   caniuse-lite@1.0.30001786:
     resolution: {integrity: sha512-4oxTZEvqmLLrERwxO76yfKM7acZo310U+v4kqexI2TL1DkkUEMT8UijrxxcnVdxR3qkVf5awGRX+4Z6aPHVKrA==}
+
+  ccount@2.0.1:
+    resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
 
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
+
+  character-entities-html4@2.1.0:
+    resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
+
+  character-entities-legacy@3.0.0:
+    resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
+
+  character-entities@2.0.2:
+    resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
+
+  character-reference-invalid@2.0.1:
+    resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
 
   chevrotain-allstar@0.4.1:
     resolution: {integrity: sha512-PvVJm3oGqrveUVW2Vt/eZGeiAIsJszYweUcYwcskg9e+IubNYKKD+rHHem7A6XVO22eDAL+inxNIGAzZ/VIWlA==}
@@ -1147,9 +1186,8 @@ packages:
   chownr@1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
 
-  cliui@9.0.1:
-    resolution: {integrity: sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==}
-    engines: {node: '>=20'}
+  comma-separated-tokens@2.0.3:
+    resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
   commander@7.2.0:
     resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
@@ -1353,6 +1391,9 @@ packages:
   decimal.js@10.6.0:
     resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
+  decode-named-character-reference@1.3.0:
+    resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
+
   decompress-response@6.0.0:
     resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
     engines: {node: '>=10'}
@@ -1361,33 +1402,25 @@ packages:
     resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
     engines: {node: '>=4.0.0'}
 
-  default-browser-id@5.0.1:
-    resolution: {integrity: sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==}
-    engines: {node: '>=18'}
-
-  default-browser@5.5.0:
-    resolution: {integrity: sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==}
-    engines: {node: '>=18'}
-
-  define-lazy-prop@3.0.0:
-    resolution: {integrity: sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==}
-    engines: {node: '>=12'}
-
   delaunator@5.1.0:
     resolution: {integrity: sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==}
+
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
 
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
+
+  devlop@1.1.0:
+    resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
   dompurify@3.3.3:
     resolution: {integrity: sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==}
 
   electron-to-chromium@1.5.332:
     resolution: {integrity: sha512-7OOtytmh/rINMLwaFTbcMVvYXO3AUm029X0LcyfYk0B557RlPkdpTpnH9+htMlfu5dKwOmT0+Zs2Aw+lnn6TeQ==}
-
-  emoji-regex@10.6.0:
-    resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
 
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
@@ -1417,6 +1450,13 @@ packages:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
 
+  escape-string-regexp@5.0.0:
+    resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
+    engines: {node: '>=12'}
+
+  estree-util-is-identifier-name@3.0.0:
+    resolution: {integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==}
+
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
@@ -1427,6 +1467,9 @@ packages:
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
+
+  extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -1463,25 +1506,32 @@ packages:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
 
-  get-caller-file@2.0.5:
-    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
-    engines: {node: 6.* || 8.* || >= 10.*}
-
-  get-east-asian-width@1.5.0:
-    resolution: {integrity: sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==}
-    engines: {node: '>=18'}
-
   get-tsconfig@4.13.7:
     resolution: {integrity: sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==}
 
   github-from-package@0.0.0:
     resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
 
+  github-slugger@2.0.0:
+    resolution: {integrity: sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==}
+
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
   hachure-fill@0.5.2:
     resolution: {integrity: sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==}
+
+  hast-util-heading-rank@3.0.0:
+    resolution: {integrity: sha512-EJKb8oMUXVHcWZTDepnr+WNbfnXKFNf9duMesmr4S8SXTJBJ9M4Yok08pu9vxdJwdlGRhVumk9mEhkEvKGifwA==}
+
+  hast-util-to-jsx-runtime@2.3.6:
+    resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
+
+  hast-util-to-string@3.0.1:
+    resolution: {integrity: sha512-XelQVTDWvqcl3axRfI0xSeoVKzyIFPwsAGSLIsKdJKQMXDYJS4WYrBNF/8J7RdhIcFI2BOHgAifggsvsxp/3+A==}
+
+  hast-util-whitespace@3.0.0:
+    resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
 
   hono@4.12.12:
     resolution: {integrity: sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==}
@@ -1490,6 +1540,9 @@ packages:
   html-encoding-sniffer@6.0.0:
     resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  html-url-attributes@3.0.1:
+    resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
 
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
@@ -1504,6 +1557,9 @@ packages:
   ini@1.3.8:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
 
+  inline-style-parser@0.2.7:
+    resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
+
   internmap@1.0.1:
     resolution: {integrity: sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==}
 
@@ -1511,26 +1567,24 @@ packages:
     resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
     engines: {node: '>=12'}
 
-  is-docker@3.0.0:
-    resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-    hasBin: true
+  is-alphabetical@2.0.1:
+    resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
 
-  is-in-ssh@1.0.0:
-    resolution: {integrity: sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==}
-    engines: {node: '>=20'}
+  is-alphanumerical@2.0.1:
+    resolution: {integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==}
 
-  is-inside-container@1.0.0:
-    resolution: {integrity: sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==}
-    engines: {node: '>=14.16'}
-    hasBin: true
+  is-decimal@2.0.1:
+    resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
+
+  is-hexadecimal@2.0.1:
+    resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
+
+  is-plain-obj@4.1.0:
+    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
+    engines: {node: '>=12'}
 
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
-
-  is-wsl@3.1.1:
-    resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
-    engines: {node: '>=16'}
 
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
@@ -1648,6 +1702,9 @@ packages:
   lodash-es@4.18.1:
     resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
 
+  longest-streak@3.1.0:
+    resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
+
   lru-cache@11.3.2:
     resolution: {integrity: sha512-wgWa6FWQ3QRRJbIjbsldRJZxdxYngT/dO0I5Ynmlnin8qy7tC6xYzbcJjtN4wHLXtkbVwHzk0C+OejVw1XM+DQ==}
     engines: {node: 20 || >=22}
@@ -1657,6 +1714,9 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  markdown-table@3.0.4:
+    resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
 
   marked@16.4.2:
     resolution: {integrity: sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==}
@@ -1668,11 +1728,143 @@ packages:
     engines: {node: '>= 20'}
     hasBin: true
 
+  mdast-util-find-and-replace@3.0.2:
+    resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
+
+  mdast-util-from-markdown@2.0.3:
+    resolution: {integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==}
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    resolution: {integrity: sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==}
+
+  mdast-util-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==}
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    resolution: {integrity: sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==}
+
+  mdast-util-gfm-table@2.0.0:
+    resolution: {integrity: sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==}
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    resolution: {integrity: sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==}
+
+  mdast-util-gfm@3.1.0:
+    resolution: {integrity: sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==}
+
+  mdast-util-mdx-expression@2.0.1:
+    resolution: {integrity: sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==}
+
+  mdast-util-mdx-jsx@3.2.0:
+    resolution: {integrity: sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==}
+
+  mdast-util-mdxjs-esm@2.0.1:
+    resolution: {integrity: sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==}
+
+  mdast-util-newline-to-break@2.0.0:
+    resolution: {integrity: sha512-MbgeFca0hLYIEx/2zGsszCSEJJ1JSCdiY5xQxRcLDDGa8EPvlLPupJ4DSajbMPAnC0je8jfb9TiUATnxxrHUog==}
+
+  mdast-util-phrasing@4.1.0:
+    resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
+
+  mdast-util-to-hast@13.2.1:
+    resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
+
+  mdast-util-to-markdown@2.1.2:
+    resolution: {integrity: sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==}
+
+  mdast-util-to-string@4.0.0:
+    resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
+
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
   mermaid@11.14.0:
     resolution: {integrity: sha512-GSGloRsBs+JINmmhl0JDwjpuezCsHB4WGI4NASHxL3fHo3o/BRXTxhDLKnln8/Q0lRFRyDdEjmk1/d5Sn1Xz8g==}
+
+  micromark-core-commonmark@2.0.3:
+    resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    resolution: {integrity: sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==}
+
+  micromark-extension-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==}
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    resolution: {integrity: sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==}
+
+  micromark-extension-gfm-table@2.1.1:
+    resolution: {integrity: sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==}
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    resolution: {integrity: sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==}
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    resolution: {integrity: sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==}
+
+  micromark-extension-gfm@3.0.0:
+    resolution: {integrity: sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==}
+
+  micromark-factory-destination@2.0.1:
+    resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
+
+  micromark-factory-label@2.0.1:
+    resolution: {integrity: sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==}
+
+  micromark-factory-space@2.0.1:
+    resolution: {integrity: sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==}
+
+  micromark-factory-title@2.0.1:
+    resolution: {integrity: sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==}
+
+  micromark-factory-whitespace@2.0.1:
+    resolution: {integrity: sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==}
+
+  micromark-util-character@2.1.1:
+    resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
+
+  micromark-util-chunked@2.0.1:
+    resolution: {integrity: sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==}
+
+  micromark-util-classify-character@2.0.1:
+    resolution: {integrity: sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==}
+
+  micromark-util-combine-extensions@2.0.1:
+    resolution: {integrity: sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==}
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    resolution: {integrity: sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==}
+
+  micromark-util-decode-string@2.0.1:
+    resolution: {integrity: sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==}
+
+  micromark-util-encode@2.0.1:
+    resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
+
+  micromark-util-html-tag-name@2.0.1:
+    resolution: {integrity: sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==}
+
+  micromark-util-normalize-identifier@2.0.1:
+    resolution: {integrity: sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==}
+
+  micromark-util-resolve-all@2.0.1:
+    resolution: {integrity: sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==}
+
+  micromark-util-sanitize-uri@2.0.1:
+    resolution: {integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==}
+
+  micromark-util-subtokenize@2.1.0:
+    resolution: {integrity: sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==}
+
+  micromark-util-symbol@2.0.1:
+    resolution: {integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==}
+
+  micromark-util-types@2.0.2:
+    resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
+
+  micromark@4.0.2:
+    resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
 
   mimic-response@3.1.0:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
@@ -1720,12 +1912,11 @@ packages:
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
-  open@11.0.0:
-    resolution: {integrity: sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==}
-    engines: {node: '>=20'}
-
   package-manager-detector@1.6.0:
     resolution: {integrity: sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==}
+
+  parse-entities@4.0.2:
+    resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
 
   parse5@8.0.0:
     resolution: {integrity: sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==}
@@ -1766,15 +1957,14 @@ packages:
     resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
     engines: {node: ^10 || ^12 || >=14}
 
-  powershell-utils@0.1.0:
-    resolution: {integrity: sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==}
-    engines: {node: '>=20'}
-
   prebuild-install@7.1.3:
     resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
     engines: {node: '>=10'}
     deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
     hasBin: true
+
+  property-information@7.1.0:
+    resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
 
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
@@ -1797,6 +1987,12 @@ packages:
     peerDependencies:
       react: '*'
 
+  react-markdown@10.1.0:
+    resolution: {integrity: sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==}
+    peerDependencies:
+      '@types/react': '>=18'
+      react: '>=18'
+
   react-refresh@0.17.0:
     resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
     engines: {node: '>=0.10.0'}
@@ -1809,6 +2005,24 @@ packages:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
     engines: {node: '>= 6'}
 
+  rehype-slug@6.0.0:
+    resolution: {integrity: sha512-lWyvf/jwu+oS5+hL5eClVd3hNdmwM1kAC0BUvEGD19pajQMIzcNUd/k9GsfQ+FfECvX+JE+e9/btsKH0EjJT6A==}
+
+  remark-breaks@4.0.0:
+    resolution: {integrity: sha512-IjEjJOkH4FuJvHZVIW0QCDWxcG96kCq7An/KVH2NfJe6rKZU2AsHeB3OEjPNRxi4QC34Xdx7I2KGYn6IpT7gxQ==}
+
+  remark-gfm@4.0.1:
+    resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
+
+  remark-parse@11.0.0:
+    resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
+
+  remark-rehype@11.1.2:
+    resolution: {integrity: sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==}
+
+  remark-stringify@11.0.0:
+    resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
+
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
@@ -1819,19 +2033,6 @@ packages:
   robust-predicates@3.0.3:
     resolution: {integrity: sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==}
 
-  rollup-plugin-visualizer@7.0.1:
-    resolution: {integrity: sha512-UJUT4+1Ho4OcWmPYU3sYXgUqI8B8Ayfe06MX7y0qCJ1K8aGoKtR/NDd/2nZqM7ADkrzny+I99Ul7GgyoiVNAgg==}
-    engines: {node: '>=22'}
-    hasBin: true
-    peerDependencies:
-      rolldown: 1.x || ^1.0.0-beta || ^1.0.0-rc
-      rollup: 2.x || 3.x || 4.x
-    peerDependenciesMeta:
-      rolldown:
-        optional: true
-      rollup:
-        optional: true
-
   rollup@4.60.1:
     resolution: {integrity: sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -1839,10 +2040,6 @@ packages:
 
   roughjs@4.6.6:
     resolution: {integrity: sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==}
-
-  run-applescript@7.1.0:
-    resolution: {integrity: sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==}
-    engines: {node: '>=18'}
 
   rw@1.3.3:
     resolution: {integrity: sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==}
@@ -1886,9 +2083,8 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
-  source-map@0.7.6:
-    resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
-    engines: {node: '>= 12'}
+  space-separated-tokens@2.0.2:
+    resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
@@ -1896,20 +2092,21 @@ packages:
   std-env@4.0.0:
     resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
 
-  string-width@7.2.0:
-    resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
-    engines: {node: '>=18'}
-
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
 
-  strip-ansi@7.2.0:
-    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
-    engines: {node: '>=12'}
+  stringify-entities@4.0.4:
+    resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
 
   strip-json-comments@2.0.1:
     resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
     engines: {node: '>=0.10.0'}
+
+  style-to-js@1.1.21:
+    resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
+
+  style-to-object@1.0.14:
+    resolution: {integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==}
 
   stylis@4.3.6:
     resolution: {integrity: sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==}
@@ -1965,6 +2162,12 @@ packages:
     resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
     engines: {node: '>=20'}
 
+  trim-lines@3.0.1:
+    resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
+
+  trough@2.2.0:
+    resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
+
   ts-dedent@2.2.0:
     resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
     engines: {node: '>=6.10'}
@@ -1996,6 +2199,24 @@ packages:
     resolution: {integrity: sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ==}
     engines: {node: '>=20.18.1'}
 
+  unified@11.0.5:
+    resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
+
+  unist-util-is@6.0.1:
+    resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
+
+  unist-util-position@5.0.0:
+    resolution: {integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==}
+
+  unist-util-stringify-position@4.0.0:
+    resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
+
+  unist-util-visit-parents@6.0.2:
+    resolution: {integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==}
+
+  unist-util-visit@5.1.0:
+    resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
+
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
     hasBin: true
@@ -2008,6 +2229,12 @@ packages:
   uuid@11.1.0:
     resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
     hasBin: true
+
+  vfile-message@4.0.3:
+    resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
+
+  vfile@6.0.3:
+    resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
   vite@6.4.2:
     resolution: {integrity: sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==}
@@ -2131,10 +2358,6 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
-  wrap-ansi@9.0.2:
-    resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
-    engines: {node: '>=18'}
-
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
@@ -2150,10 +2373,6 @@ packages:
       utf-8-validate:
         optional: true
 
-  wsl-utils@0.3.1:
-    resolution: {integrity: sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==}
-    engines: {node: '>=20'}
-
   xml-name-validator@5.0.0:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
     engines: {node: '>=18'}
@@ -2161,20 +2380,11 @@ packages:
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
-  y18n@5.0.8:
-    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
-    engines: {node: '>=10'}
-
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
-  yargs-parser@22.0.0:
-    resolution: {integrity: sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==}
-    engines: {node: ^20.19.0 || ^22.12.0 || >=23}
-
-  yargs@18.0.0:
-    resolution: {integrity: sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==}
-    engines: {node: ^20.19.0 || ^22.12.0 || >=23}
+  zwitch@2.0.4:
+    resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
 
@@ -2876,11 +3086,29 @@ snapshots:
       '@types/d3-transition': 3.0.9
       '@types/d3-zoom': 3.0.8
 
+  '@types/debug@4.1.13':
+    dependencies:
+      '@types/ms': 2.1.0
+
   '@types/deep-eql@4.0.2': {}
+
+  '@types/estree-jsx@1.0.5':
+    dependencies:
+      '@types/estree': 1.0.8
 
   '@types/estree@1.0.8': {}
 
   '@types/geojson@7946.0.16': {}
+
+  '@types/hast@3.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
+  '@types/mdast@4.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
+  '@types/ms@2.1.0': {}
 
   '@types/node@22.19.17':
     dependencies:
@@ -2896,6 +3124,12 @@ snapshots:
 
   '@types/trusted-types@2.0.7':
     optional: true
+
+  '@types/unist@2.0.11': {}
+
+  '@types/unist@3.0.3': {}
+
+  '@ungap/structured-clone@1.3.0': {}
 
   '@upsetjs/venn.js@2.0.0':
     optionalDependencies:
@@ -2978,11 +3212,9 @@ snapshots:
 
   acorn@8.16.0: {}
 
-  ansi-regex@6.2.2: {}
-
-  ansi-styles@6.2.3: {}
-
   assertion-error@2.0.1: {}
+
+  bail@2.0.2: {}
 
   base64-js@1.5.1: {}
 
@@ -3020,13 +3252,19 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
-  bundle-name@4.1.0:
-    dependencies:
-      run-applescript: 7.1.0
-
   caniuse-lite@1.0.30001786: {}
 
+  ccount@2.0.1: {}
+
   chai@6.2.2: {}
+
+  character-entities-html4@2.1.0: {}
+
+  character-entities-legacy@3.0.0: {}
+
+  character-entities@2.0.2: {}
+
+  character-reference-invalid@2.0.1: {}
 
   chevrotain-allstar@0.4.1(chevrotain@12.0.0):
     dependencies:
@@ -3043,11 +3281,7 @@ snapshots:
 
   chownr@1.1.4: {}
 
-  cliui@9.0.1:
-    dependencies:
-      string-width: 7.2.0
-      strip-ansi: 7.2.0
-      wrap-ansi: 9.0.2
+  comma-separated-tokens@2.0.3: {}
 
   commander@7.2.0: {}
 
@@ -3271,34 +3505,33 @@ snapshots:
 
   decimal.js@10.6.0: {}
 
+  decode-named-character-reference@1.3.0:
+    dependencies:
+      character-entities: 2.0.2
+
   decompress-response@6.0.0:
     dependencies:
       mimic-response: 3.1.0
 
   deep-extend@0.6.0: {}
 
-  default-browser-id@5.0.1: {}
-
-  default-browser@5.5.0:
-    dependencies:
-      bundle-name: 4.1.0
-      default-browser-id: 5.0.1
-
-  define-lazy-prop@3.0.0: {}
-
   delaunator@5.1.0:
     dependencies:
       robust-predicates: 3.0.3
 
+  dequal@2.0.3: {}
+
   detect-libc@2.1.2: {}
+
+  devlop@1.1.0:
+    dependencies:
+      dequal: 2.0.3
 
   dompurify@3.3.3:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
   electron-to-chromium@1.5.332: {}
-
-  emoji-regex@10.6.0: {}
 
   end-of-stream@1.4.5:
     dependencies:
@@ -3373,6 +3606,10 @@ snapshots:
 
   escalade@3.2.0: {}
 
+  escape-string-regexp@5.0.0: {}
+
+  estree-util-is-identifier-name@3.0.0: {}
+
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.8
@@ -3380,6 +3617,8 @@ snapshots:
   expand-template@2.0.3: {}
 
   expect-type@1.3.0: {}
+
+  extend@3.0.2: {}
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
@@ -3401,19 +3640,49 @@ snapshots:
 
   gensync@1.0.0-beta.2: {}
 
-  get-caller-file@2.0.5: {}
-
-  get-east-asian-width@1.5.0: {}
-
   get-tsconfig@4.13.7:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
   github-from-package@0.0.0: {}
 
+  github-slugger@2.0.0: {}
+
   graceful-fs@4.2.11: {}
 
   hachure-fill@0.5.2: {}
+
+  hast-util-heading-rank@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
+  hast-util-to-jsx-runtime@2.3.6:
+    dependencies:
+      '@types/estree': 1.0.8
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      comma-separated-tokens: 2.0.3
+      devlop: 1.1.0
+      estree-util-is-identifier-name: 3.0.0
+      hast-util-whitespace: 3.0.0
+      mdast-util-mdx-expression: 2.0.1
+      mdast-util-mdx-jsx: 3.2.0
+      mdast-util-mdxjs-esm: 2.0.1
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
+      style-to-js: 1.1.21
+      unist-util-position: 5.0.0
+      vfile-message: 4.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  hast-util-to-string@3.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+
+  hast-util-whitespace@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
 
   hono@4.12.12: {}
 
@@ -3422,6 +3691,8 @@ snapshots:
       '@exodus/bytes': 1.15.0
     transitivePeerDependencies:
       - '@noble/hashes'
+
+  html-url-attributes@3.0.1: {}
 
   iconv-lite@0.6.3:
     dependencies:
@@ -3433,23 +3704,26 @@ snapshots:
 
   ini@1.3.8: {}
 
+  inline-style-parser@0.2.7: {}
+
   internmap@1.0.1: {}
 
   internmap@2.0.3: {}
 
-  is-docker@3.0.0: {}
+  is-alphabetical@2.0.1: {}
 
-  is-in-ssh@1.0.0: {}
-
-  is-inside-container@1.0.0:
+  is-alphanumerical@2.0.1:
     dependencies:
-      is-docker: 3.0.0
+      is-alphabetical: 2.0.1
+      is-decimal: 2.0.1
+
+  is-decimal@2.0.1: {}
+
+  is-hexadecimal@2.0.1: {}
+
+  is-plain-obj@4.1.0: {}
 
   is-potential-custom-element-name@1.0.1: {}
-
-  is-wsl@3.1.1:
-    dependencies:
-      is-inside-container: 1.0.0
 
   jiti@2.6.1: {}
 
@@ -3555,6 +3829,8 @@ snapshots:
 
   lodash-es@4.18.1: {}
 
+  longest-streak@3.1.0: {}
+
   lru-cache@11.3.2: {}
 
   lru-cache@5.1.1:
@@ -3565,9 +3841,169 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  markdown-table@3.0.4: {}
+
   marked@16.4.2: {}
 
   marked@17.0.6: {}
+
+  mdast-util-find-and-replace@3.0.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      escape-string-regexp: 5.0.0
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
+  mdast-util-from-markdown@2.0.3:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      mdast-util-to-string: 4.0.0
+      micromark: 4.0.2
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-decode-string: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      unist-util-stringify-position: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-find-and-replace: 3.0.2
+      micromark-util-character: 2.1.1
+
+  mdast-util-gfm-footnote@2.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      micromark-util-normalize-identifier: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-table@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      markdown-table: 3.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm@3.1.0:
+    dependencies:
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-gfm-autolink-literal: 2.0.1
+      mdast-util-gfm-footnote: 2.1.0
+      mdast-util-gfm-strikethrough: 2.0.0
+      mdast-util-gfm-table: 2.0.0
+      mdast-util-gfm-task-list-item: 2.0.0
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-expression@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-jsx@3.2.0:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      parse-entities: 4.0.2
+      stringify-entities: 4.0.4
+      unist-util-stringify-position: 4.0.0
+      vfile-message: 4.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdxjs-esm@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-newline-to-break@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-find-and-replace: 3.0.2
+
+  mdast-util-phrasing@4.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      unist-util-is: 6.0.1
+
+  mdast-util-to-hast@13.2.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@ungap/structured-clone': 1.3.0
+      devlop: 1.1.0
+      micromark-util-sanitize-uri: 2.0.1
+      trim-lines: 3.0.1
+      unist-util-position: 5.0.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+
+  mdast-util-to-markdown@2.1.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      longest-streak: 3.1.0
+      mdast-util-phrasing: 4.1.0
+      mdast-util-to-string: 4.0.0
+      micromark-util-classify-character: 2.0.1
+      micromark-util-decode-string: 2.0.1
+      unist-util-visit: 5.1.0
+      zwitch: 2.0.4
+
+  mdast-util-to-string@4.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
 
   mdn-data@2.27.1: {}
 
@@ -3594,6 +4030,197 @@ snapshots:
       stylis: 4.3.6
       ts-dedent: 2.2.0
       uuid: 11.1.0
+
+  micromark-core-commonmark@2.0.3:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-factory-destination: 2.0.1
+      micromark-factory-label: 2.0.1
+      micromark-factory-space: 2.0.1
+      micromark-factory-title: 2.0.1
+      micromark-factory-whitespace: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-html-tag-name: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-footnote@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-table@2.1.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm@3.0.0:
+    dependencies:
+      micromark-extension-gfm-autolink-literal: 2.1.0
+      micromark-extension-gfm-footnote: 2.1.0
+      micromark-extension-gfm-strikethrough: 2.1.0
+      micromark-extension-gfm-table: 2.1.1
+      micromark-extension-gfm-tagfilter: 2.0.0
+      micromark-extension-gfm-task-list-item: 2.1.0
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-destination@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-label@2.0.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-space@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-title@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-whitespace@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-character@2.1.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-chunked@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-classify-character@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-combine-extensions@2.0.1:
+    dependencies:
+      micromark-util-chunked: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-decode-string@2.0.1:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      micromark-util-character: 2.1.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-encode@2.0.1: {}
+
+  micromark-util-html-tag-name@2.0.1: {}
+
+  micromark-util-normalize-identifier@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-resolve-all@2.0.1:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-util-sanitize-uri@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-encode: 2.0.1
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-subtokenize@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-symbol@2.0.1: {}
+
+  micromark-util-types@2.0.2: {}
+
+  micromark@4.0.2:
+    dependencies:
+      '@types/debug': 4.1.13
+      debug: 4.4.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-encode: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   mimic-response@3.1.0: {}
 
@@ -3630,16 +4257,17 @@ snapshots:
     dependencies:
       wrappy: 1.0.2
 
-  open@11.0.0:
-    dependencies:
-      default-browser: 5.5.0
-      define-lazy-prop: 3.0.0
-      is-in-ssh: 1.0.0
-      is-inside-container: 1.0.0
-      powershell-utils: 0.1.0
-      wsl-utils: 0.3.1
-
   package-manager-detector@1.6.0: {}
+
+  parse-entities@4.0.2:
+    dependencies:
+      '@types/unist': 2.0.11
+      character-entities-legacy: 3.0.0
+      character-reference-invalid: 2.0.1
+      decode-named-character-reference: 1.3.0
+      is-alphanumerical: 2.0.1
+      is-decimal: 2.0.1
+      is-hexadecimal: 2.0.1
 
   parse5@8.0.0:
     dependencies:
@@ -3680,8 +4308,6 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  powershell-utils@0.1.0: {}
-
   prebuild-install@7.1.3:
     dependencies:
       detect-libc: 2.1.2
@@ -3696,6 +4322,8 @@ snapshots:
       simple-get: 4.0.1
       tar-fs: 2.1.4
       tunnel-agent: 0.6.0
+
+  property-information@7.1.0: {}
 
   pump@3.0.4:
     dependencies:
@@ -3720,6 +4348,24 @@ snapshots:
     dependencies:
       react: 19.2.4
 
+  react-markdown@10.1.0(@types/react@19.2.14)(react@19.2.4):
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@types/react': 19.2.14
+      devlop: 1.1.0
+      hast-util-to-jsx-runtime: 2.3.6
+      html-url-attributes: 3.0.1
+      mdast-util-to-hast: 13.2.1
+      react: 19.2.4
+      remark-parse: 11.0.0
+      remark-rehype: 11.1.2
+      unified: 11.0.5
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
   react-refresh@0.17.0: {}
 
   react@19.2.4: {}
@@ -3730,20 +4376,59 @@ snapshots:
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
 
+  rehype-slug@6.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      github-slugger: 2.0.0
+      hast-util-heading-rank: 3.0.0
+      hast-util-to-string: 3.0.1
+      unist-util-visit: 5.1.0
+
+  remark-breaks@4.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-newline-to-break: 2.0.0
+      unified: 11.0.5
+
+  remark-gfm@4.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-gfm: 3.1.0
+      micromark-extension-gfm: 3.0.0
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-parse@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      micromark-util-types: 2.0.2
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-rehype@11.1.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      mdast-util-to-hast: 13.2.1
+      unified: 11.0.5
+      vfile: 6.0.3
+
+  remark-stringify@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-to-markdown: 2.1.2
+      unified: 11.0.5
+
   require-from-string@2.0.2: {}
 
   resolve-pkg-maps@1.0.0: {}
 
   robust-predicates@3.0.3: {}
-
-  rollup-plugin-visualizer@7.0.1(rollup@4.60.1):
-    dependencies:
-      open: 11.0.0
-      picomatch: 4.0.4
-      source-map: 0.7.6
-      yargs: 18.0.0
-    optionalDependencies:
-      rollup: 4.60.1
 
   rollup@4.60.1:
     dependencies:
@@ -3783,8 +4468,6 @@ snapshots:
       points-on-curve: 0.2.0
       points-on-path: 0.2.1
 
-  run-applescript@7.1.0: {}
-
   rw@1.3.3: {}
 
   safe-buffer@5.2.1: {}
@@ -3819,27 +4502,30 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
-  source-map@0.7.6: {}
+  space-separated-tokens@2.0.2: {}
 
   stackback@0.0.2: {}
 
   std-env@4.0.0: {}
 
-  string-width@7.2.0:
-    dependencies:
-      emoji-regex: 10.6.0
-      get-east-asian-width: 1.5.0
-      strip-ansi: 7.2.0
-
   string_decoder@1.3.0:
     dependencies:
       safe-buffer: 5.2.1
 
-  strip-ansi@7.2.0:
+  stringify-entities@4.0.4:
     dependencies:
-      ansi-regex: 6.2.2
+      character-entities-html4: 2.1.0
+      character-entities-legacy: 3.0.0
 
   strip-json-comments@2.0.1: {}
+
+  style-to-js@1.1.21:
+    dependencies:
+      style-to-object: 1.0.14
+
+  style-to-object@1.0.14:
+    dependencies:
+      inline-style-parser: 0.2.7
 
   stylis@4.3.6: {}
 
@@ -3891,6 +4577,10 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  trim-lines@3.0.1: {}
+
+  trough@2.2.0: {}
+
   ts-dedent@2.2.0: {}
 
   tsx@4.21.0:
@@ -3921,6 +4611,39 @@ snapshots:
 
   undici@7.24.7: {}
 
+  unified@11.0.5:
+    dependencies:
+      '@types/unist': 3.0.3
+      bail: 2.0.2
+      devlop: 1.1.0
+      extend: 3.0.2
+      is-plain-obj: 4.1.0
+      trough: 2.2.0
+      vfile: 6.0.3
+
+  unist-util-is@6.0.1:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-position@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-stringify-position@4.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-visit-parents@6.0.2:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+
+  unist-util-visit@5.1.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
   update-browserslist-db@1.2.3(browserslist@4.28.2):
     dependencies:
       browserslist: 4.28.2
@@ -3930,6 +4653,16 @@ snapshots:
   util-deprecate@1.0.2: {}
 
   uuid@11.1.0: {}
+
+  vfile-message@4.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-stringify-position: 4.0.0
+
+  vfile@6.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile-message: 4.0.3
 
   vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0):
     dependencies:
@@ -4013,36 +4746,14 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
-  wrap-ansi@9.0.2:
-    dependencies:
-      ansi-styles: 6.2.3
-      string-width: 7.2.0
-      strip-ansi: 7.2.0
-
   wrappy@1.0.2: {}
 
   ws@8.20.0: {}
-
-  wsl-utils@0.3.1:
-    dependencies:
-      is-wsl: 3.1.1
-      powershell-utils: 0.1.0
 
   xml-name-validator@5.0.0: {}
 
   xmlchars@2.2.0: {}
 
-  y18n@5.0.8: {}
-
   yallist@3.1.1: {}
 
-  yargs-parser@22.0.0: {}
-
-  yargs@18.0.0:
-    dependencies:
-      cliui: 9.0.1
-      escalade: 3.2.0
-      get-caller-file: 2.0.5
-      string-width: 7.2.0
-      y18n: 5.0.8
-      yargs-parser: 22.0.0
+  zwitch@2.0.4: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,9 +60,6 @@ importers:
       '@xterm/xterm':
         specifier: ^5
         version: 5.5.0
-      marked:
-        specifier: ^17.0.5
-        version: 17.0.6
       mermaid:
         specifier: ^11.14.0
         version: 11.14.0
@@ -1720,11 +1717,6 @@ packages:
 
   marked@16.4.2:
     resolution: {integrity: sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==}
-    engines: {node: '>= 20'}
-    hasBin: true
-
-  marked@17.0.6:
-    resolution: {integrity: sha512-gB0gkNafnonOw0obSTEGZTT86IuhILt2Wfx0mWH/1Au83kybTayroZ/V6nS25mN7u8ASy+5fMhgB3XPNrOZdmA==}
     engines: {node: '>= 20'}
     hasBin: true
 
@@ -3844,8 +3836,6 @@ snapshots:
   markdown-table@3.0.4: {}
 
   marked@16.4.2: {}
-
-  marked@17.0.6: {}
 
   mdast-util-find-and-replace@3.0.2:
     dependencies:


### PR DESCRIPTION
## Summary

Migrate `MarkdownViewer` from `marked.parse` + `dangerouslySetInnerHTML` to `react-markdown` with `remark-gfm`, `remark-breaks`, and `rehype-slug`. Mermaid diagrams and table scrolling now flow through `components` overrides instead of DOM post-processing.

## What changed

- `components.code` detects `language-mermaid` and renders `MermaidDiagram` directly.
- `components.pre` unwraps mermaid blocks so diagrams do not inherit code-block chrome; regular fenced code still renders as `<pre><code>` for horizontal scroll.
- `components.table` wraps tables in `.md-table-scroll`.
- Existing `.md-content` CSS is preserved, with table-scroll CSS moved to the wrapper model.
- Snapshot suites now render fixtures through the same react-markdown config used by `MarkdownViewer`.
- Removed the direct `marked` dependency from `@cpc/web`; mermaid still brings its own transitive `marked@16.4.2`.
- Removed the stale `vendor-marked` Vite manual chunk entry.

## Intentional snapshot differences

- Snapshots now include the `.md-content` wrapper used by the actual viewer.
- `rehype-slug` adds heading `id` attributes, including duplicate suffixes.
- `remark-gfm` emits task-list classes and table alignment as inline `text-align` styles.
- Tables are wrapped in `.md-table-scroll`.
- Mermaid blocks snapshot as `.mermaid-mount` containing `MermaidDiagram` loading state.
- Raw HTML is escaped as text instead of injected as live HTML, closing the XSS path.

## Verification

- `pnpm --filter @cpc/web exec tsc -b`
- `pnpm --filter @cpc/web test`
- `pnpm --filter @cpc/web build`

Build passes with the existing large-chunk warning for mermaid/vendor assets; bundle mitigation remains a follow-up per the hardened plan.

HARDENED plan: `tmp/20260407-react-markdown-migration-plan-HARDENED.md`
DA: Gemini + Codex -> NEEDS WORK -> READY-WITH-CONDITIONS (all conditions met)