### PR TITLE
feat(file-viewer): reuse file-type icons in the main file list (#143)

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -3,6 +3,7 @@ import { FiDownload } from "react-icons/fi";
 import { getAuthHeaders } from "../lib/telegram";
 import { MarkdownViewer } from "./MarkdownViewer";
 import { BottomSheet } from "./BottomSheet";
+import { getFileIcon } from "./file-icons";
 
 const PASTE_MAX_BYTES = 1024 * 1024;
 
@@ -842,13 +843,14 @@ export function FileViewer({ onClose, initialFile, showHidden = false, sortMode 
             >
               <span
                 style={{
-                  color: entry.type === "dir" ? "#7aa2f7" : "#c0caf5",
-                  fontSize: 14,
                   width: 20,
-                  textAlign: "center",
+                  display: "inline-flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  flexShrink: 0,
                 }}
               >
-                {entry.type === "dir" ? "📁" : "📄"}
+                {getFileIcon(entry.name, entry.type === "dir")}
               </span>
               <span
                 style={{


### PR DESCRIPTION
## Summary
- Import `getFileIcon` from `./file-icons` in `FileViewer.tsx`
- Replace the `📁`/`📄` emoji span in the directory listing with the SVG icon (folders via `isFolder: true`, files by extension, unknown → generic doc outline)
- Keep the 20px-wide wrapper so row alignment matches the pre-change layout; the icons are 16x16 and inherit the existing flex gap

Closes #143

## Verification
- [x] `pnpm --filter @cpc/web exec tsc -b --noEmit` clean
- [x] `pnpm --filter @cpc/web test` pass (72 tests in 4 files)
- [x] `pnpm run build` pass

## Out of scope (per issue non-goals)
- Icon set unchanged
- `FileSearchSheet` untouched (reference pattern preserved)
- No new dependencies
