### PR TITLE
Follow-up: fix reading-list canonicalization, upsert title, and schema consistency

### DIFF
--- a/apps/server/src/__tests__/reading-list-migration.test.ts
+++ b/apps/server/src/__tests__/reading-list-migration.test.ts
@@ -35,32 +35,47 @@ function runMigration(db: Database.Database) {
     .all() as Array<{ name: string; type: string }>;
   const createdAtCol = cols.find((c) => c.name === "created_at");
   if (createdAtCol && createdAtCol.type.toUpperCase() !== "INTEGER") {
-    db.exec(`
-      BEGIN;
-      CREATE TABLE reading_list_new (
-        id INTEGER PRIMARY KEY AUTOINCREMENT,
-        user_id TEXT NOT NULL,
-        path TEXT NOT NULL,
-        title TEXT,
-        created_at INTEGER NOT NULL DEFAULT (unixepoch() * 1000),
-        UNIQUE(user_id, path)
-      );
-      INSERT INTO reading_list_new (id, user_id, path, title, created_at)
-      SELECT
-        id,
-        user_id,
-        path,
-        title,
-        CAST(strftime('%s', created_at) AS INTEGER) * 1000
-      FROM reading_list;
-      DROP INDEX IF EXISTS idx_reading_list_user;
-      DROP INDEX IF EXISTS idx_reading_list_user_path;
-      DROP TABLE reading_list;
-      ALTER TABLE reading_list_new RENAME TO reading_list;
-      CREATE INDEX IF NOT EXISTS idx_reading_list_user
-        ON reading_list(user_id, created_at DESC);
-      COMMIT;
-    `);
+    // Retry-safe: mirrors db.ts — clean up any leftover reading_list_new from
+    // a previous failed attempt, then wrap the rebuild in a try/catch that
+    // rolls back + drops the scratch table if anything throws.
+    db.exec("DROP TABLE IF EXISTS reading_list_new");
+
+    try {
+      db.exec(`
+        BEGIN;
+        CREATE TABLE reading_list_new (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          user_id TEXT NOT NULL,
+          path TEXT NOT NULL,
+          title TEXT,
+          created_at INTEGER NOT NULL DEFAULT (unixepoch() * 1000),
+          UNIQUE(user_id, path)
+        );
+        INSERT INTO reading_list_new (id, user_id, path, title, created_at)
+        SELECT
+          id,
+          user_id,
+          path,
+          title,
+          CAST(strftime('%s', created_at) AS INTEGER) * 1000
+        FROM reading_list;
+        DROP INDEX IF EXISTS idx_reading_list_user;
+        DROP INDEX IF EXISTS idx_reading_list_user_path;
+        DROP TABLE reading_list;
+        ALTER TABLE reading_list_new RENAME TO reading_list;
+        CREATE INDEX IF NOT EXISTS idx_reading_list_user
+          ON reading_list(user_id, created_at DESC);
+        COMMIT;
+      `);
+    } catch (error) {
+      try {
+        db.exec("ROLLBACK");
+      } catch {
+        // Ignore rollback errors if no transaction is active.
+      }
+      db.exec("DROP TABLE IF EXISTS reading_list_new");
+      throw error;
+    }
   }
 }
 
@@ -129,6 +144,59 @@ describe("reading_list TEXT → INTEGER migration", () => {
     const namedIndexes = indexes.map((i) => i.name);
     expect(namedIndexes).toContain("idx_reading_list_user");
     expect(namedIndexes).not.toContain("idx_reading_list_user_path");
+  });
+
+  it("cleans up a leftover reading_list_new from a previously aborted migration", () => {
+    const db = new Database(":memory:");
+    db.exec(`
+      CREATE TABLE reading_list (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        user_id TEXT NOT NULL,
+        path TEXT NOT NULL,
+        title TEXT,
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        UNIQUE(user_id, path)
+      );
+      INSERT INTO reading_list (user_id, path, title, created_at)
+      VALUES ('u1', '/home/claude/code/a.ts', 'A', '2025-01-01 00:00:00');
+
+      -- Simulate a half-finished previous migration attempt: the scratch
+      -- table exists with stale data but the real table was never swapped.
+      CREATE TABLE reading_list_new (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        user_id TEXT NOT NULL,
+        path TEXT NOT NULL,
+        title TEXT,
+        created_at INTEGER NOT NULL DEFAULT (unixepoch() * 1000),
+        UNIQUE(user_id, path)
+      );
+      INSERT INTO reading_list_new (user_id, path, title, created_at)
+      VALUES ('stale-user', '/stale/path', 'Stale', 999);
+    `);
+
+    // Should not throw — the retry-safe migration must drop the stale
+    // reading_list_new before recreating it fresh.
+    expect(() => runMigration(db)).not.toThrow();
+
+    // Real data is preserved.
+    const rows = db
+      .prepare("SELECT user_id, path, title FROM reading_list")
+      .all() as Array<{ user_id: string; path: string; title: string }>;
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      user_id: "u1",
+      path: "/home/claude/code/a.ts",
+      title: "A",
+    });
+
+    // The stale scratch-table data did NOT leak through.
+    expect(rows.find((r) => r.user_id === "stale-user")).toBeUndefined();
+
+    // And the scratch table itself is gone after a successful rebuild.
+    const tables = db
+      .prepare("SELECT name FROM sqlite_master WHERE type = 'table'")
+      .all() as Array<{ name: string }>;
+    expect(tables.map((t) => t.name)).not.toContain("reading_list_new");
   });
 
   it("is a no-op when created_at is already INTEGER", () => {

--- a/apps/server/src/__tests__/reading-list-migration.test.ts
+++ b/apps/server/src/__tests__/reading-list-migration.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from "vitest";
+import Database from "better-sqlite3";
+
+/**
+ * Regression test for the reading_list TEXT → INTEGER migration.
+ *
+ * Early builds of reading_list shipped with `created_at TEXT DEFAULT
+ * (datetime('now'))`. The current route layer assumes epoch-ms INTEGER.
+ * `CREATE TABLE IF NOT EXISTS` never rewrites an existing schema, so the
+ * bootstrap in db.ts must detect the legacy column type and rebuild the
+ * table in place.
+ *
+ * This test replays that bootstrap logic against an in-memory DB pre-seeded
+ * with the legacy schema + a couple rows, and asserts that the rebuild
+ * preserves data while converting timestamps.
+ */
+
+function runMigration(db: Database.Database) {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS reading_list (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      user_id TEXT NOT NULL,
+      path TEXT NOT NULL,
+      title TEXT,
+      created_at INTEGER NOT NULL DEFAULT (unixepoch() * 1000),
+      UNIQUE(user_id, path)
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_reading_list_user
+      ON reading_list(user_id, created_at DESC);
+  `);
+
+  const cols = db
+    .prepare("PRAGMA table_info(reading_list)")
+    .all() as Array<{ name: string; type: string }>;
+  const createdAtCol = cols.find((c) => c.name === "created_at");
+  if (createdAtCol && createdAtCol.type.toUpperCase() !== "INTEGER") {
+    db.exec(`
+      BEGIN;
+      CREATE TABLE reading_list_new (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        user_id TEXT NOT NULL,
+        path TEXT NOT NULL,
+        title TEXT,
+        created_at INTEGER NOT NULL DEFAULT (unixepoch() * 1000),
+        UNIQUE(user_id, path)
+      );
+      INSERT INTO reading_list_new (id, user_id, path, title, created_at)
+      SELECT
+        id,
+        user_id,
+        path,
+        title,
+        CAST(strftime('%s', created_at) AS INTEGER) * 1000
+      FROM reading_list;
+      DROP INDEX IF EXISTS idx_reading_list_user;
+      DROP INDEX IF EXISTS idx_reading_list_user_path;
+      DROP TABLE reading_list;
+      ALTER TABLE reading_list_new RENAME TO reading_list;
+      CREATE INDEX IF NOT EXISTS idx_reading_list_user
+        ON reading_list(user_id, created_at DESC);
+      COMMIT;
+    `);
+  }
+}
+
+describe("reading_list TEXT → INTEGER migration", () => {
+  it("rebuilds the table and converts ISO timestamps to epoch-ms", () => {
+    const db = new Database(":memory:");
+    // Seed with the legacy schema (from #134).
+    db.exec(`
+      CREATE TABLE reading_list (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        user_id TEXT NOT NULL,
+        path TEXT NOT NULL,
+        title TEXT,
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        UNIQUE(user_id, path)
+      );
+
+      CREATE INDEX idx_reading_list_user
+        ON reading_list(user_id, created_at DESC);
+
+      CREATE INDEX idx_reading_list_user_path
+        ON reading_list(user_id, path);
+
+      INSERT INTO reading_list (user_id, path, title, created_at)
+      VALUES
+        ('u1', '/home/claude/code/a.ts', 'A', '2025-01-01 00:00:00'),
+        ('u1', '/home/claude/code/b.ts', 'B', '2025-06-15 12:30:00');
+    `);
+
+    runMigration(db);
+
+    // Schema should now have INTEGER created_at.
+    const cols = db
+      .prepare("PRAGMA table_info(reading_list)")
+      .all() as Array<{ name: string; type: string }>;
+    const createdAtCol = cols.find((c) => c.name === "created_at")!;
+    expect(createdAtCol.type.toUpperCase()).toBe("INTEGER");
+
+    // Row data preserved.
+    const rows = db
+      .prepare("SELECT user_id, path, title, created_at FROM reading_list ORDER BY path")
+      .all() as Array<{ user_id: string; path: string; title: string; created_at: number }>;
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toMatchObject({
+      user_id: "u1",
+      path: "/home/claude/code/a.ts",
+      title: "A",
+    });
+    expect(typeof rows[0].created_at).toBe("number");
+    // 2025-01-01 00:00:00 UTC in epoch-ms
+    expect(rows[0].created_at).toBe(Date.UTC(2025, 0, 1, 0, 0, 0));
+    expect(rows[1].created_at).toBe(Date.UTC(2025, 5, 15, 12, 30, 0));
+
+    // UNIQUE(user_id, path) still enforced.
+    expect(() =>
+      db
+        .prepare("INSERT INTO reading_list (user_id, path, title) VALUES (?, ?, ?)")
+        .run("u1", "/home/claude/code/a.ts", "dup"),
+    ).toThrow();
+
+    // Redundant (user_id, path) index should have been dropped (the one
+    // duplicated by UNIQUE). The user-ordering index should remain.
+    const indexes = db
+      .prepare("PRAGMA index_list(reading_list)")
+      .all() as Array<{ name: string }>;
+    const namedIndexes = indexes.map((i) => i.name);
+    expect(namedIndexes).toContain("idx_reading_list_user");
+    expect(namedIndexes).not.toContain("idx_reading_list_user_path");
+  });
+
+  it("is a no-op when created_at is already INTEGER", () => {
+    const db = new Database(":memory:");
+    db.exec(`
+      CREATE TABLE reading_list (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        user_id TEXT NOT NULL,
+        path TEXT NOT NULL,
+        title TEXT,
+        created_at INTEGER NOT NULL DEFAULT (unixepoch() * 1000),
+        UNIQUE(user_id, path)
+      );
+      INSERT INTO reading_list (user_id, path, title, created_at)
+      VALUES ('u1', '/home/claude/code/a.ts', 'A', 1700000000000);
+    `);
+
+    runMigration(db);
+
+    const row = db
+      .prepare("SELECT created_at FROM reading_list WHERE path = ?")
+      .get("/home/claude/code/a.ts") as { created_at: number };
+    expect(row.created_at).toBe(1700000000000);
+  });
+});

--- a/apps/server/src/db.ts
+++ b/apps/server/src/db.ts
@@ -72,32 +72,48 @@ db.exec(`
     .all() as Array<{ name: string; type: string }>;
   const createdAtCol = cols.find((c) => c.name === "created_at");
   if (createdAtCol && createdAtCol.type.toUpperCase() !== "INTEGER") {
-    db.exec(`
-      BEGIN;
-      CREATE TABLE reading_list_new (
-        id INTEGER PRIMARY KEY AUTOINCREMENT,
-        user_id TEXT NOT NULL,
-        path TEXT NOT NULL,
-        title TEXT,
-        created_at INTEGER NOT NULL DEFAULT (unixepoch() * 1000),
-        UNIQUE(user_id, path)
-      );
-      INSERT INTO reading_list_new (id, user_id, path, title, created_at)
-      SELECT
-        id,
-        user_id,
-        path,
-        title,
-        CAST(strftime('%s', created_at) AS INTEGER) * 1000
-      FROM reading_list;
-      DROP INDEX IF EXISTS idx_reading_list_user;
-      DROP INDEX IF EXISTS idx_reading_list_user_path;
-      DROP TABLE reading_list;
-      ALTER TABLE reading_list_new RENAME TO reading_list;
-      CREATE INDEX IF NOT EXISTS idx_reading_list_user
-        ON reading_list(user_id, created_at DESC);
-      COMMIT;
-    `);
+    // Retry-safe: drop any leftover `reading_list_new` from a previous failed
+    // migration attempt before creating it fresh, and wrap the rebuild in a
+    // try/catch with explicit ROLLBACK + cleanup so the next startup isn't
+    // poisoned by a stale `reading_list_new` table.
+    db.exec("DROP TABLE IF EXISTS reading_list_new");
+
+    try {
+      db.exec(`
+        BEGIN;
+        CREATE TABLE reading_list_new (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          user_id TEXT NOT NULL,
+          path TEXT NOT NULL,
+          title TEXT,
+          created_at INTEGER NOT NULL DEFAULT (unixepoch() * 1000),
+          UNIQUE(user_id, path)
+        );
+        INSERT INTO reading_list_new (id, user_id, path, title, created_at)
+        SELECT
+          id,
+          user_id,
+          path,
+          title,
+          CAST(strftime('%s', created_at) AS INTEGER) * 1000
+        FROM reading_list;
+        DROP INDEX IF EXISTS idx_reading_list_user;
+        DROP INDEX IF EXISTS idx_reading_list_user_path;
+        DROP TABLE reading_list;
+        ALTER TABLE reading_list_new RENAME TO reading_list;
+        CREATE INDEX IF NOT EXISTS idx_reading_list_user
+          ON reading_list(user_id, created_at DESC);
+        COMMIT;
+      `);
+    } catch (error) {
+      try {
+        db.exec("ROLLBACK");
+      } catch {
+        // Ignore rollback errors if no transaction is active.
+      }
+      db.exec("DROP TABLE IF EXISTS reading_list_new");
+      throw error;
+    }
   }
 }
 

--- a/apps/server/src/db.ts
+++ b/apps/server/src/db.ts
@@ -56,10 +56,50 @@ db.exec(`
 
   CREATE INDEX IF NOT EXISTS idx_reading_list_user
     ON reading_list(user_id, created_at DESC);
-
-  CREATE INDEX IF NOT EXISTS idx_reading_list_user_path
-    ON reading_list(user_id, path);
+  -- Note: no explicit (user_id, path) index — the UNIQUE(user_id, path)
+  -- constraint already creates an identical implicit index.
 `);
+
+// Migration: early builds of reading_list shipped `created_at TEXT DEFAULT
+// (datetime('now'))`. The route layer (and tests) now assume epoch-ms
+// INTEGER. `CREATE TABLE IF NOT EXISTS` never rewrites an existing schema,
+// so any deployment that ran #134 before this fix still has TEXT values.
+// Detect it and rebuild the table in place (copy → drop → rename), converting
+// ISO timestamps to epoch-ms.
+{
+  const cols = db
+    .prepare("PRAGMA table_info(reading_list)")
+    .all() as Array<{ name: string; type: string }>;
+  const createdAtCol = cols.find((c) => c.name === "created_at");
+  if (createdAtCol && createdAtCol.type.toUpperCase() !== "INTEGER") {
+    db.exec(`
+      BEGIN;
+      CREATE TABLE reading_list_new (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        user_id TEXT NOT NULL,
+        path TEXT NOT NULL,
+        title TEXT,
+        created_at INTEGER NOT NULL DEFAULT (unixepoch() * 1000),
+        UNIQUE(user_id, path)
+      );
+      INSERT INTO reading_list_new (id, user_id, path, title, created_at)
+      SELECT
+        id,
+        user_id,
+        path,
+        title,
+        CAST(strftime('%s', created_at) AS INTEGER) * 1000
+      FROM reading_list;
+      DROP INDEX IF EXISTS idx_reading_list_user;
+      DROP INDEX IF EXISTS idx_reading_list_user_path;
+      DROP TABLE reading_list;
+      ALTER TABLE reading_list_new RENAME TO reading_list;
+      CREATE INDEX IF NOT EXISTS idx_reading_list_user
+        ON reading_list(user_id, created_at DESC);
+      COMMIT;
+    `);
+  }
+}
 
 export { db };
 export type { DatabaseType };

--- a/apps/server/src/db.ts
+++ b/apps/server/src/db.ts
@@ -44,6 +44,21 @@ db.exec(`
     PRIMARY KEY (content_hash, prompt_version, model)
   );
   CREATE INDEX IF NOT EXISTS idx_tldr_created ON tldr_cache(created_at DESC);
+
+  CREATE TABLE IF NOT EXISTS reading_list (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id TEXT NOT NULL,
+    path TEXT NOT NULL,
+    title TEXT,
+    created_at INTEGER NOT NULL DEFAULT (unixepoch() * 1000),
+    UNIQUE(user_id, path)
+  );
+
+  CREATE INDEX IF NOT EXISTS idx_reading_list_user
+    ON reading_list(user_id, created_at DESC);
+
+  CREATE INDEX IF NOT EXISTS idx_reading_list_user_path
+    ON reading_list(user_id, path);
 `);
 
 export { db };

--- a/apps/server/src/lib/get-user-id.ts
+++ b/apps/server/src/lib/get-user-id.ts
@@ -6,9 +6,8 @@ import type { TelegramUser } from "../auth.js";
  * Returns null if no user is authenticated.
  *
  * Shared helper used by voice.ts and reading-list.ts.
- * The caller decides the fallback behavior:
- *   - voice.ts falls back to "default" for backward compat
- *   - reading-list.ts returns 401 on null
+ * Callers decide auth behavior when this returns null
+ * (both voice.ts and reading-list.ts return 401).
  */
 export function getUserId(c: Context): string | null {
   const user = c.get("telegramUser") as TelegramUser | undefined;

--- a/apps/server/src/lib/path-allowed.ts
+++ b/apps/server/src/lib/path-allowed.ts
@@ -31,6 +31,15 @@ import { resolve, sep } from "node:path";
 // rejection from evicting a newer entry added after a cache clear.
 const realRootCache = new Map<string, Promise<string>>();
 
+export const ALLOWED_FILE_ROOTS = [
+  "/home/claude/claudes-world",
+  "/home/claude/code",
+  "/home/claude/bin",
+  "/home/claude/.claude",
+  "/home/claude/claudes-world/.claude",
+] as const;
+
+
 function getRealRoot(root: string): Promise<string> {
   const key = resolve(root);
   const cached = realRootCache.get(key);

--- a/apps/server/src/routes/__tests__/reading-list.test.ts
+++ b/apps/server/src/routes/__tests__/reading-list.test.ts
@@ -140,6 +140,29 @@ describe("POST /save", () => {
     expect((rows[0] as any).title).toBe("Second");
   });
 
+  it("bumps created_at on re-save so the item moves to the top of /list", async () => {
+    // Seed two items with controlled timestamps.
+    testDb.prepare(
+      "INSERT INTO reading_list (user_id, path, title, created_at) VALUES (?, ?, ?, ?)"
+    ).run("test-user-123", "/home/claude/code/old.ts", "Old", 1000);
+    testDb.prepare(
+      "INSERT INTO reading_list (user_id, path, title, created_at) VALUES (?, ?, ?, ?)"
+    ).run("test-user-123", "/home/claude/code/newer.ts", "Newer", 2000);
+
+    // Before: "Newer" is first in /list.
+    let res = await req("GET", "/list");
+    let body = await res.json();
+    expect(body.items[0].title).toBe("Newer");
+
+    // Re-save the older item without a title — should bump created_at.
+    await req("POST", "/save", { path: "/home/claude/code/old.ts" });
+
+    res = await req("GET", "/list");
+    body = await res.json();
+    expect(body.items[0].title).toBe("Old");
+    expect(body.items[0].created_at).toBeGreaterThan(2000);
+  });
+
   it("preserves custom title when re-saving without title", async () => {
     await req("POST", "/save", {
       path: "/home/claude/code/custom.ts",
@@ -247,7 +270,7 @@ describe("GET /check", () => {
 
 
 
-  it("normalizes incoming paths before checking", async () => {
+  it("normalizes incoming paths before checking (response keyed by original input)", async () => {
     testDb.prepare(
       "INSERT INTO reading_list (user_id, path, title) VALUES (?, ?, ?)"
     ).run("test-user-123", "/home/claude/code/saved.ts", "Saved");
@@ -258,7 +281,32 @@ describe("GET /check", () => {
     );
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body.saved["/home/claude/code/saved.ts"]).toBe(true);
+    // Response is keyed by the EXACT input string, not the normalized form,
+    // so clients can look up results using the paths they sent.
+    expect(body.saved["/home/claude/code/dir/../saved.ts"]).toBe(true);
+    expect(body.saved["/home/claude/code/saved.ts"]).toBeUndefined();
+  });
+
+  it("trims whitespace from comma-separated paths before normalization", async () => {
+    testDb.prepare(
+      "INSERT INTO reading_list (user_id, path, title) VALUES (?, ?, ?)"
+    ).run("test-user-123", "/home/claude/code/a.ts", "A");
+    testDb.prepare(
+      "INSERT INTO reading_list (user_id, path, title) VALUES (?, ?, ?)"
+    ).run("test-user-123", "/home/claude/code/b.ts", "B");
+
+    // Note the leading spaces after the commas — these must be trimmed
+    // before path.resolve() runs, or they'd become CWD-relative paths.
+    const res = await req(
+      "GET",
+      "/check?paths=/home/claude/code/a.ts, /home/claude/code/b.ts",
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.saved["/home/claude/code/a.ts"]).toBe(true);
+    // Response key is the trimmed form (trim is universal cleanup, not a
+    // path-semantic normalization), so clients see the clean string.
+    expect(body.saved["/home/claude/code/b.ts"]).toBe(true);
   });
   it("returns empty map when no paths param", async () => {
     const res = await req("GET", "/check");

--- a/apps/server/src/routes/__tests__/reading-list.test.ts
+++ b/apps/server/src/routes/__tests__/reading-list.test.ts
@@ -11,39 +11,17 @@ import Database from "better-sqlite3";
  *   - Drive the route via Hono's `app.request()` — no listening server, no ports.
  */
 
-// In-memory database for tests
+// In-memory database for tests, injected via the mocked db module.
 const testDb = new Database(":memory:");
 testDb.pragma("journal_mode = WAL");
-
-// Create the transcripts tables that db.ts normally creates, so the
-// module-level db.exec in reading-list.ts doesn't fail on missing tables.
 testDb.exec(`
-  CREATE TABLE IF NOT EXISTS transcripts (
-    id TEXT PRIMARY KEY,
+  CREATE TABLE IF NOT EXISTS reading_list (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
     user_id TEXT NOT NULL,
-    title TEXT NOT NULL DEFAULT 'Untitled',
-    description TEXT,
-    body TEXT NOT NULL DEFAULT '',
-    word_count INTEGER DEFAULT 0,
-    created_at INTEGER NOT NULL,
-    updated_at INTEGER NOT NULL,
-    deleted_at INTEGER
-  );
-  CREATE TABLE IF NOT EXISTS transcript_tags (
-    transcript_id TEXT NOT NULL REFERENCES transcripts(id),
-    tag TEXT NOT NULL,
-    PRIMARY KEY (transcript_id, tag)
-  );
-  CREATE TABLE IF NOT EXISTS tldr_cache (
-    content_hash TEXT NOT NULL,
-    prompt_version INTEGER NOT NULL DEFAULT 1,
-    model TEXT NOT NULL,
-    summary TEXT NOT NULL,
-    source_path TEXT,
-    input_tokens INTEGER,
-    output_tokens INTEGER,
-    created_at INTEGER NOT NULL,
-    PRIMARY KEY (content_hash, prompt_version, model)
+    path TEXT NOT NULL,
+    title TEXT,
+    created_at INTEGER NOT NULL DEFAULT (unixepoch() * 1000),
+    UNIQUE(user_id, path)
   );
 `);
 
@@ -59,8 +37,14 @@ vi.mock("../../lib/get-user-id.js", () => ({
 }));
 
 vi.mock("../../lib/path-allowed.js", () => ({
+  ALLOWED_FILE_ROOTS: [
+    "/home/claude/claudes-world",
+    "/home/claude/code",
+    "/home/claude/bin",
+    "/home/claude/.claude",
+    "/home/claude/claudes-world/.claude",
+  ],
   isPathAllowed: async (candidate: string, _roots: string[]) => {
-    // Allow paths under /home/claude/code and /home/claude/claudes-world
     return (
       candidate.startsWith("/home/claude/code/") ||
       candidate.startsWith("/home/claude/claudes-world/") ||
@@ -135,6 +119,43 @@ describe("POST /save", () => {
     expect(row.title).toBe("file.ts");
   });
 
+
+
+  it("normalizes equivalent path variants to one record", async () => {
+    await req("POST", "/save", {
+      path: "/home/claude/code/folder/../file.ts",
+      title: "First",
+    });
+
+    await req("POST", "/save", {
+      path: "/home/claude/code/file.ts",
+      title: "Second",
+    });
+
+    const rows = testDb.prepare(
+      "SELECT * FROM reading_list WHERE user_id = ? AND path = ?"
+    ).all("test-user-123", "/home/claude/code/file.ts");
+
+    expect(rows.length).toBe(1);
+    expect((rows[0] as any).title).toBe("Second");
+  });
+
+  it("preserves custom title when re-saving without title", async () => {
+    await req("POST", "/save", {
+      path: "/home/claude/code/custom.ts",
+      title: "Custom Title",
+    });
+
+    await req("POST", "/save", {
+      path: "/home/claude/code/custom.ts",
+    });
+
+    const row = testDb.prepare(
+      "SELECT title FROM reading_list WHERE user_id = ? AND path = ?"
+    ).get("test-user-123", "/home/claude/code/custom.ts") as any;
+
+    expect(row.title).toBe("Custom Title");
+  });
   it("rejects unauthenticated requests with 401", async () => {
     mockUserId = null;
     const res = await req("POST", "/save", {
@@ -161,10 +182,10 @@ describe("GET /list", () => {
     // Insert two items with controlled timestamps
     testDb.prepare(
       "INSERT INTO reading_list (user_id, path, title, created_at) VALUES (?, ?, ?, ?)"
-    ).run("test-user-123", "/home/claude/code/a.ts", "A", "2026-01-01 00:00:00");
+    ).run("test-user-123", "/home/claude/code/a.ts", "A", 1000);
     testDb.prepare(
       "INSERT INTO reading_list (user_id, path, title, created_at) VALUES (?, ?, ?, ?)"
-    ).run("test-user-123", "/home/claude/code/b.ts", "B", "2026-01-02 00:00:00");
+    ).run("test-user-123", "/home/claude/code/b.ts", "B", 2000);
 
     const res = await req("GET", "/list");
     expect(res.status).toBe(200);
@@ -224,6 +245,21 @@ describe("GET /check", () => {
     expect(body.saved["/home/claude/code/not-saved.ts"]).toBe(false);
   });
 
+
+
+  it("normalizes incoming paths before checking", async () => {
+    testDb.prepare(
+      "INSERT INTO reading_list (user_id, path, title) VALUES (?, ?, ?)"
+    ).run("test-user-123", "/home/claude/code/saved.ts", "Saved");
+
+    const res = await req(
+      "GET",
+      "/check?paths=/home/claude/code/dir/../saved.ts"
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.saved["/home/claude/code/saved.ts"]).toBe(true);
+  });
   it("returns empty map when no paths param", async () => {
     const res = await req("GET", "/check");
     expect(res.status).toBe(200);
@@ -276,6 +312,18 @@ describe("POST /delete", () => {
     expect(body.ok).toBe(true);
   });
 
+
+
+  it("normalizes path before deleting", async () => {
+    testDb.prepare(
+      "INSERT INTO reading_list (user_id, path, title) VALUES (?, ?, ?)"
+    ).run("test-user-123", "/home/claude/code/norm.ts", "Norm");
+
+    const res = await req("POST", "/delete", { path: "/home/claude/code/dir/../norm.ts" });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+  });
   it("returns 404 when deleting someone else's item (by id)", async () => {
     testDb.prepare(
       "INSERT INTO reading_list (user_id, path, title) VALUES (?, ?, ?)"

--- a/apps/server/src/routes/__tests__/reading-list.test.ts
+++ b/apps/server/src/routes/__tests__/reading-list.test.ts
@@ -163,6 +163,23 @@ describe("POST /save", () => {
     expect(body.items[0].created_at).toBeGreaterThan(2000);
   });
 
+  it("trims whitespace from path on /save (prevents false 403)", async () => {
+    // Leading/trailing whitespace on copy-pasted paths must not turn a valid
+    // absolute path into a CWD-relative one (which would then fall outside
+    // any allowed root and 403).
+    const res = await req("POST", "/save", {
+      path: "  /home/claude/code/trimmed.ts  ",
+      title: "Trimmed",
+    });
+    expect(res.status).toBe(200);
+    const row = testDb.prepare(
+      "SELECT path, title FROM reading_list WHERE user_id = ?"
+    ).get("test-user-123") as any;
+    // Row was written under the cleanly-resolved path, not a CWD-relative one.
+    expect(row.path).toBe("/home/claude/code/trimmed.ts");
+    expect(row.title).toBe("Trimmed");
+  });
+
   it("preserves custom title when re-saving without title", async () => {
     await req("POST", "/save", {
       path: "/home/claude/code/custom.ts",
@@ -371,6 +388,25 @@ describe("POST /delete", () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.ok).toBe(true);
+  });
+
+  it("trims whitespace from path on /delete (prevents false 404)", async () => {
+    testDb.prepare(
+      "INSERT INTO reading_list (user_id, path, title) VALUES (?, ?, ?)"
+    ).run("test-user-123", "/home/claude/code/trim-del.ts", "TrimDel");
+
+    const res = await req("POST", "/delete", {
+      path: "  /home/claude/code/trim-del.ts  ",
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+
+    // Row is gone, not a stale match under a CWD-relative path.
+    const check = testDb.prepare(
+      "SELECT id FROM reading_list WHERE user_id = ? AND path = ?"
+    ).get("test-user-123", "/home/claude/code/trim-del.ts");
+    expect(check).toBeUndefined();
   });
   it("returns 404 when deleting someone else's item (by id)", async () => {
     testDb.prepare(

--- a/apps/server/src/routes/files.ts
+++ b/apps/server/src/routes/files.ts
@@ -13,7 +13,10 @@ import { createReadStream } from "node:fs";
 import { basename, join, resolve, sep } from "node:path";
 import { constants as fsConstants } from "node:fs";
 import { Readable } from "node:stream";
-import { isPathAllowed as isPathAllowedShared } from "../lib/path-allowed.js";
+import {
+  ALLOWED_FILE_ROOTS,
+  isPathAllowed as isPathAllowedShared,
+} from "../lib/path-allowed.js";
 
 const app = new Hono();
 
@@ -30,13 +33,7 @@ type DownloadTicket = {
 const downloadTickets = new Map<string, DownloadTicket>();
 
 // Allowed root directories the file viewer can access
-const ALLOWED_ROOTS = [
-  "/home/claude/claudes-world",
-  "/home/claude/code",
-  "/home/claude/bin",
-  "/home/claude/.claude",
-  "/home/claude/claudes-world/.claude",
-];
+const ALLOWED_ROOTS = [...ALLOWED_FILE_ROOTS];
 
 function isPathAllowed(absPath: string): Promise<boolean> {
   return isPathAllowedShared(absPath, ALLOWED_ROOTS);

--- a/apps/server/src/routes/reading-list.ts
+++ b/apps/server/src/routes/reading-list.ts
@@ -37,7 +37,10 @@ app.post("/save", async (c) => {
     return c.json({ error: "Access denied" }, 403);
   }
 
-  // Upsert: insert or update title on conflict, returning the id in one query
+  // Upsert: insert or update title on conflict, returning the id in one query.
+  // `created_at` is always bumped to "now" on conflict so that re-saving an
+  // existing item moves it to the top of the list (which is ordered by
+  // created_at DESC).
   const stmt = db.prepare(`
     INSERT INTO reading_list (user_id, path, title)
     VALUES (?, ?, COALESCE(?, ?))
@@ -45,7 +48,8 @@ app.post("/save", async (c) => {
       title = CASE
         WHEN ? IS NULL THEN reading_list.title
         ELSE excluded.title
-      END
+      END,
+      created_at = (unixepoch() * 1000)
     RETURNING id
   `);
 
@@ -90,27 +94,42 @@ app.get("/check", (c) => {
     return c.json({ saved: {} });
   }
 
-  const paths = [...new Set(pathsParam.split(",").filter(Boolean).map((p) => normalizePath(p)))];
-  if (paths.length === 0) {
+  // Preserve the original input strings as response keys so clients can look
+  // up results using the exact paths they sent, while still normalizing for
+  // the DB lookup. Trim each segment first so `?paths=a, b` doesn't produce
+  // a path relative to CWD after normalization.
+  const originalInputs = [
+    ...new Set(
+      pathsParam.split(",").map((p) => p.trim()).filter(Boolean),
+    ),
+  ];
+  if (originalInputs.length === 0) {
     return c.json({ saved: {} });
   }
 
   // Cap at 256 paths per request
-  if (paths.length > 256) {
+  if (originalInputs.length > 256) {
     return c.json({ error: "Too many paths (max 256)" }, 413);
   }
 
+  const normalizedByOriginal = new Map<string, string>();
+  for (const original of originalInputs) {
+    normalizedByOriginal.set(original, normalizePath(original));
+  }
+  const uniqueNormalized = [...new Set(normalizedByOriginal.values())];
+
   // Query all matching paths for this user in one go
-  const placeholders = paths.map(() => "?").join(",");
+  const placeholders = uniqueNormalized.map(() => "?").join(",");
   const rows = db.prepare(`
     SELECT path FROM reading_list
     WHERE user_id = ? AND path IN (${placeholders})
-  `).all(userId, ...paths) as Array<{ path: string }>;
+  `).all(userId, ...uniqueNormalized) as Array<{ path: string }>;
 
   const savedSet = new Set(rows.map((r) => r.path));
   const saved: Record<string, boolean> = {};
-  for (const p of paths) {
-    saved[p] = savedSet.has(p);
+  for (const original of originalInputs) {
+    const normalized = normalizedByOriginal.get(original)!;
+    saved[original] = savedSet.has(normalized);
   }
 
   return c.json({ saved });

--- a/apps/server/src/routes/reading-list.ts
+++ b/apps/server/src/routes/reading-list.ts
@@ -1,37 +1,16 @@
 import { Hono } from "hono";
-import { basename } from "node:path";
+import { basename, resolve } from "node:path";
 import { db } from "../db.js";
 import { getUserId } from "../lib/get-user-id.js";
-import { isPathAllowed } from "../lib/path-allowed.js";
+import { ALLOWED_FILE_ROOTS, isPathAllowed } from "../lib/path-allowed.js";
 
 const app = new Hono();
 
-// Allowed root directories — same set as files.ts
-const ALLOWED_ROOTS = [
-  "/home/claude/claudes-world",
-  "/home/claude/code",
-  "/home/claude/bin",
-  "/home/claude/.claude",
-  "/home/claude/claudes-world/.claude",
-];
+const ALLOWED_ROOTS = [...ALLOWED_FILE_ROOTS];
 
-// Create reading_list table at module load (same pattern as db.ts for transcripts)
-db.exec(`
-  CREATE TABLE IF NOT EXISTS reading_list (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    user_id TEXT NOT NULL,
-    path TEXT NOT NULL,
-    title TEXT,
-    created_at TEXT NOT NULL DEFAULT (datetime('now')),
-    UNIQUE(user_id, path)
-  );
-
-  CREATE INDEX IF NOT EXISTS idx_reading_list_user
-    ON reading_list(user_id, created_at DESC);
-
-  CREATE INDEX IF NOT EXISTS idx_reading_list_user_path
-    ON reading_list(user_id, path);
-`);
+function normalizePath(path: string): string {
+  return resolve(path);
+}
 
 // POST /save — save a file to reading list (upsert)
 app.post("/save", async (c) => {
@@ -52,20 +31,32 @@ app.post("/save", async (c) => {
     return c.json({ error: "path is required" }, 400);
   }
 
-  if (!(await isPathAllowed(path, ALLOWED_ROOTS))) {
+  const normalizedPath = normalizePath(path);
+
+  if (!(await isPathAllowed(normalizedPath, ALLOWED_ROOTS))) {
     return c.json({ error: "Access denied" }, 403);
   }
 
   // Upsert: insert or update title on conflict, returning the id in one query
   const stmt = db.prepare(`
     INSERT INTO reading_list (user_id, path, title)
-    VALUES (?, ?, ?)
+    VALUES (?, ?, COALESCE(?, ?))
     ON CONFLICT(user_id, path) DO UPDATE SET
-      title = COALESCE(excluded.title, reading_list.title)
+      title = CASE
+        WHEN ? IS NULL THEN reading_list.title
+        ELSE excluded.title
+      END
     RETURNING id
   `);
 
-  const row = stmt.get(userId, path, title ?? basename(path)) as { id: number };
+  const titleOrNull = title ?? null;
+  const row = stmt.get(
+    userId,
+    normalizedPath,
+    titleOrNull,
+    basename(normalizedPath),
+    titleOrNull,
+  ) as { id: number };
 
   return c.json({ ok: true, id: row.id });
 });
@@ -82,7 +73,7 @@ app.get("/list", (c) => {
     FROM reading_list
     WHERE user_id = ?
     ORDER BY created_at DESC
-  `).all(userId) as Array<{ id: number; path: string; title: string | null; created_at: string }>;
+  `).all(userId) as Array<{ id: number; path: string; title: string | null; created_at: number }>;
 
   return c.json({ items: rows });
 });
@@ -99,7 +90,7 @@ app.get("/check", (c) => {
     return c.json({ saved: {} });
   }
 
-  const paths = [...new Set(pathsParam.split(",").filter(Boolean))];
+  const paths = [...new Set(pathsParam.split(",").filter(Boolean).map((p) => normalizePath(p)))];
   if (paths.length === 0) {
     return c.json({ saved: {} });
   }
@@ -125,7 +116,7 @@ app.get("/check", (c) => {
   return c.json({ saved });
 });
 
-// DELETE /delete — hard delete a reading list item
+// POST /delete — hard delete a reading list item
 app.post("/delete", async (c) => {
   const userId = getUserId(c);
   if (!userId) {
@@ -156,9 +147,10 @@ app.post("/delete", async (c) => {
 
   if (path && typeof path === "string") {
     // Delete by path — ownership enforced in WHERE clause
+    const normalizedPath = normalizePath(path);
     const result = db.prepare(
       "DELETE FROM reading_list WHERE path = ? AND user_id = ?"
-    ).run(path, userId);
+    ).run(normalizedPath, userId);
 
     if (result.changes === 0) {
       return c.json({ error: "Not found" }, 404);

--- a/apps/server/src/routes/reading-list.ts
+++ b/apps/server/src/routes/reading-list.ts
@@ -9,7 +9,12 @@ const app = new Hono();
 const ALLOWED_ROOTS = [...ALLOWED_FILE_ROOTS];
 
 function normalizePath(path: string): string {
-  return resolve(path);
+  // Trim before resolve() — otherwise leading/trailing whitespace (e.g. from
+  // copy/paste) would make resolve() treat the input as a CWD-relative path
+  // segment, causing false 403s on /save and false 404s on /delete. /check
+  // also trims each segment upstream; doing it here is idempotent and keeps
+  // all endpoints consistent.
+  return resolve(path.trim());
 }
 
 // POST /save — save a file to reading list (upsert)
@@ -94,10 +99,11 @@ app.get("/check", (c) => {
     return c.json({ saved: {} });
   }
 
-  // Preserve the original input strings as response keys so clients can look
-  // up results using the exact paths they sent, while still normalizing for
-  // the DB lookup. Trim each segment first so `?paths=a, b` doesn't produce
-  // a path relative to CWD after normalization.
+  // Trim each segment first so `?paths=a, b` doesn't produce a path relative
+  // to CWD after normalization. The response is keyed by the *trimmed* input
+  // (universal cleanup, not a path-semantic normalization), so clients can
+  // look up results using essentially the paths they sent — just without the
+  // accidental whitespace.
   const originalInputs = [
     ...new Set(
       pathsParam.split(",").map((p) => p.trim()).filter(Boolean),


### PR DESCRIPTION
### Motivation

- Address reviewer findings that equivalent path spellings produced duplicate reading-list records and caused false negatives for `check`/`delete` by normalizing paths before storage and queries.
- Prevent accidental overwrites of a user's custom `title` when re-saving without a `title` in the request. 
- Consolidate schema and configuration to avoid duplication and mismatch of timestamp types across the server.

### Description

- Canonicalize reading-list paths end-to-end by resolving incoming paths with `resolve()` before `POST /save`, `GET /check`, and path-based `POST /delete` in `apps/server/src/routes/reading-list.ts`. 
- Adjust upsert semantics so new inserts default to `basename(path)` while updates preserve an existing custom title when `title` is omitted, implemented via a revised `INSERT ... ON CONFLICT` statement. 
- Move `reading_list` table and its indexes into the central `apps/server/src/db.ts` bootstrap and switch `created_at` to an `INTEGER` epoch-ms default (`unixepoch() * 1000`).
- Introduce `ALLOWED_FILE_ROOTS` exported from `apps/server/src/lib/path-allowed.ts` and reuse it in `files.ts` and `reading-list.ts` to remove duplicated allowed-roots constants. 
- Update `get-user-id.ts` docs to reflect current behavior (no default-user fallback) and correct the route comment to `POST /delete`. 
- Simplify and harden tests in `apps/server/src/routes/__tests__/reading-list.test.ts` by injecting an in-memory DB schema for `reading_list` and adding regression tests for canonicalization and title-preservation.

### Testing

- Ran the server test suite with `pnpm --filter @cpc/server test` and all tests passed (`6 files`, `77 tests`).
- Ran type checking with `pnpm --filter @cpc/server typecheck` and it succeeded with no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dab1233bc88327b4d1ecd6feb02913)