### PR TITLE
docs: v0.10.0 pre-release code review report

### DIFF
--- a/docs/reviews/v0.10.0-pre-release-review.md
+++ b/docs/reviews/v0.10.0-pre-release-review.md
@@ -1,0 +1,203 @@
+# v0.10.0 Pre-Release Code Review Report
+
+> **Date:** 2026-04-12
+> **Branch:** `dev` (target merge to `main`)
+> **Scope:** 95 files changed, +9,509 / -1,964 lines since v1.9.0
+> **Method:** 6 parallel specialized review agents, findings cross-referenced and verified
+
+---
+
+## Table of Contents
+
+1. [Review Methodology](#1-review-methodology)
+2. [Agent Summary & Quality Assessment](#2-agent-summary--quality-assessment)
+3. [Overlap & Divergence Analysis](#3-overlap--divergence-analysis)
+4. [Classified Findings](#4-classified-findings)
+   - [MUST FIX (release blockers)](#must-fix-release-blockers)
+   - [SHOULD FIX (high-value, low-risk)](#should-fix-high-value-low-risk)
+   - [DEFER (file as new issues)](#defer-file-as-new-issues)
+   - [SKIP / False Positive](#skip--false-positive)
+5. [Recommended Next Steps](#5-recommended-next-steps)
+
+---
+
+## 1. Review Methodology
+
+Six specialized review agents ran in parallel, each with a distinct focus area:
+
+| Agent | Focus | Raw Findings |
+|-------|-------|--------------|
+| **A1 — Security** | Auth, path traversal, input validation, data exposure, DB, WS | 4 HIGH, 8 MEDIUM, ~10 LOW |
+| **A2 — Frontend Architecture** | Component design, state, types, CSS, build config | 1 HIGH, 8 MEDIUM, ~15 LOW |
+| **A3 — Backend Correctness** | Error handling, HTTP status codes, race conditions, API contract | 2 HIGH, 14 MEDIUM, 19 LOW |
+| **A4 — Test Coverage** | Test quality, coverage gaps, CI, fixtures | 3 HIGH, 8 MEDIUM, ~15 LOW |
+| **A5 — Performance** | Bundle size, lazy loading, React rendering, server perf | 4 HIGH, 6 MEDIUM, ~10 LOW |
+| **A6 — Telegram WebView** | Touch handling, vertical swipe, platform APIs, media | 2 CRITICAL, 3 HIGH, 8 MEDIUM, 4 LOW |
+
+**Total unique findings after deduplication:** ~48 actionable items
+
+---
+
+## 2. Agent Summary & Quality Assessment
+
+### A1 — Security Audit
+**Quality: 9/10** — Thorough, well-structured. Correctly identified the `/upload` symlink write gap (confirmed: `/paste` uses `O_NOFOLLOW` + `O_EXCL`, `/upload` uses `writeFile`). CORS finding was accurate. WebSocket allowlist bypass is a real edge case. One minor overstatement: initData replay risk is lower in practice given the single-user model.
+
+### A2 — Frontend Architecture
+**Quality: 8/10** — Good architectural observations. Correctly flagged Rules of Hooks violation in `DebugOverlay` (confirmed: early returns before `useState` calls). Identified dead `_fileName` prop and ActionBarProps type looseness. Slightly generous in LOW ratings for things that deserve MEDIUM (e.g., all tabs mounted simultaneously).
+
+### A3 — Backend Correctness
+**Quality: 9/10** — Excellent coverage of error handling gaps. The 500-instead-of-404 pattern and session file overwrite on parse failure are both correctness bugs. The download ticket race condition is a real TOCTOU. Very thorough on git routes returning 200 for failures. Minor overlap with A1 on file upload issues.
+
+### A4 — Test Coverage
+**Quality: 8/10** — Comprehensive gap analysis. Correctly identified that reading-list tests fully mock `isPathAllowed`, defeating the purpose of security testing. E2E-not-in-CI finding is important for release gating. The duplicate markdown fixture finding is actionable. Slightly over-counted: some "missing tests" are for routes that are thin wrappers.
+
+### A5 — Performance
+**Quality: 7/10** — Good identification of the terminal WS 500ms polling issue and all-tabs-mounted pattern. Lazy loading recommendation is sound. The compression finding depends on whether Caddy/nginx sits in front (likely does in prod). Some findings are optimization suggestions rather than bugs.
+
+### A6 — Telegram WebView
+**Quality: 9/10** — Most unique and platform-specific perspective. The `preventDefault` on `touchstart` in Terminal.tsx finding is **confirmed real** (line 163). The `getUserMedia` finding is **confirmed real** — contradicts documented platform constraints. Vertical swipe gap for non-BottomSheet modals is an excellent catch. The `location.reload()` on file search is also confirmed.
+
+---
+
+## 3. Overlap & Divergence Analysis
+
+### High Overlap (3+ agents flagged)
+| Finding | Agents | Agreement |
+|---------|--------|-----------|
+| `/upload` missing body limit + symlink protection | A1, A3, A5 | Full — all agree this is HIGH |
+| Permissive CORS (`cors()` with no origin) | A1, A3, A5 | Full — all agree MEDIUM-HIGH |
+| All tabs mounted, no lazy loading | A2, A5, A6 | Full — perf + UX concern |
+| Error messages leaking internal details | A1, A3 | Full — multiple routes affected |
+| Download ticket in URL (log/Referer leak) | A1, A3 | Full — both note same threat vector |
+
+### Moderate Overlap (2 agents flagged)
+| Finding | Agents | Notes |
+|---------|--------|-------|
+| Session file overwrite on parse error | A3, A4 | A3 found bug, A4 noted no tests for it |
+| Git routes return 200 on failure | A3, A4 | A3 found pattern, A4 noted no coverage |
+| `DebugOverlay` Rules of Hooks violation | A2, A6 | Both flagged early return before hooks |
+| Reading-list tests mock `isPathAllowed` | A1, A4 | A1 reviewed real code, A4 found test gap |
+
+### Unique Findings (single agent)
+| Finding | Agent | Notes |
+|---------|-------|-------|
+| `preventDefault` on `touchstart` in Terminal.tsx | A6 | Platform-critical, confirmed |
+| `getUserMedia` in VoiceRecorder.tsx | A6 | Contradicts documented constraints |
+| `location.reload()` in file search | A6 + A2 | WebView-hostile pattern |
+| Vertical swipe not disabled for centered modals | A6 | Only BottomSheet does this |
+| voice CRUD has zero test coverage | A4 | Only `/transcribe` tested |
+| Terminal WS `execSync` overlap risk at 500ms | A5 | Server stability concern |
+| `db.ts` migration `strftime` on bad legacy data | A3 | Data corruption edge case |
+
+---
+
+## 4. Classified Findings
+
+### MUST FIX (Release Blockers)
+
+These have confirmed security impact, violate documented platform rules, or break core UX.
+
+| # | Finding | File(s) | Agents | Justification |
+|---|---------|---------|--------|---------------|
+| **M-1** | `preventDefault()` on `touchstart` in Terminal overlay | `apps/web/src/components/Terminal.tsx:163` | A6 | **Directly violates** documented CPC rule: "Never `preventDefault()` on `touchstart`". Breaks Telegram swipe-to-close and scroll. Use `pointer-events: none` on the overlay div instead — the adjacent CSS `<style>` block already disables xterm's textarea with `pointer-events: none !important`. |
+| **M-2** | `/upload` route has no body size limit | `apps/server/src/routes/files.ts:401-455` | A1, A3, A5 | `/paste` correctly uses `bodyLimit()` middleware. `/upload` loads the entire multipart body into memory via `arrayBuffer()` with no cap. An authenticated user (or leaked token) can exhaust server memory. Add `bodyLimit` matching `/paste`. |
+| **M-3** | `/upload` uses `writeFile` without `O_NOFOLLOW` / `O_EXCL` | `apps/server/src/routes/files.ts:427-444` | A1, A3 | `/paste` (line 570-576) correctly uses `O_CREAT|O_EXCL|O_NOFOLLOW` for atomic writes. `/upload` uses `stat` loop + `writeFile`, vulnerable to symlink escape and TOCTOU race. Align with `/paste` pattern. |
+| **M-4** | `getUserMedia` in VoiceRecorder contradicts platform docs | `apps/web/src/components/VoiceRecorder.tsx:78` | A6 | Project docs state: "`getUserMedia` does NOT work in Telegram WebView. Use `<input type="file" capture>`." The implementation uses `getUserMedia({ audio: true })`. Voice recording is broken for in-Telegram users. Switch to file-capture approach. |
+| **M-5** | `DebugOverlay` violates Rules of Hooks | `apps/web/src/debug/DebugOverlay.tsx:120-130` | A2, A6 | Early returns (`if (!isDevHost()) return null`) appear before `useState`/`useSyncExternalStore` calls. React requires hooks to be called unconditionally in the same order. Today it works because hostname is stable, but this is undefined behavior. Move hooks above the gate or extract to a wrapper component. |
+| **M-6** | Permissive CORS with no origin restriction | `apps/server/src/index.ts:48` | A1, A3 | `app.use("*", cors())` allows any origin. Combined with bearer token auth, this enables cross-origin abuse if a token leaks. Restrict to `web.telegram.org`, `cpc.claude.do`, `cpc-dev.claude.do`, and `localhost`. |
+
+### SHOULD FIX (High Value, Low Risk to Implement)
+
+Important for quality, but unlikely to cause user-visible breakage.
+
+| # | Finding | File(s) | Agents | Justification |
+|---|---------|---------|--------|---------------|
+| **S-1** | `location.reload()` in file search selection | `apps/web/src/components/action-bar/ActionBar.tsx:287` | A2, A6 | Full page reload loses in-memory state, flashes, re-inits WebApp. Set React state + hash without reload. |
+| **S-2** | Vertical swipes not disabled for centered modals | Centered modals in `action-bar/` (RenameModal, ForkNameModal, NewConfirmModal, CompactModals) | A6 | Only `BottomSheet` calls `disableVerticalSwipes`. Centered modals use fixed overlays but don't prevent Telegram from minimizing on swipe-down. Add a shared hook or wrap in a common modal component. |
+| **S-3** | `/files/read` and `/files/list` return 500 for missing paths | `apps/server/src/routes/files.ts:131-260` | A3 | `ENOENT` errors from `stat`/`readFile`/`readdir` fall into generic catch returning 500. Should return 404 for missing paths, 500 for unexpected errors. |
+| **S-4** | Session file overwrite on JSON parse failure | `apps/server/src/routes/session.ts:14-19, 60-65` | A3 | If session-names file is corrupted, parse failure sets `names = []`, then the write path overwrites with empty data. Should return 500 on parse failure without writing. |
+| **S-5** | Git routes return HTTP 200 for failures | `apps/server/src/routes/terminal/git.ts:36-43, 70-73, 169-171` | A3 | `git-status`, `git-command`, `dir-branch` all return 200 with `ok: false`. Clients must inspect body. Use 500 or 502 for command failures. |
+| **S-6** | Error messages leak internal paths/details | Multiple: `files.ts:193,258,452`, `session.ts:46-50`, `audio.ts:97-99` | A1, A3 | `err.message` in responses can expose filesystem paths, errno, or provider error details. Return generic messages; log details server-side. |
+| **S-7** | `voice` POST/PATCH routes don't catch bad JSON | `apps/server/src/routes/voice.ts:99-121, 181-222` | A3 | `await c.req.json()` without try/catch. Malformed JSON surfaces as unhandled exception. Wrap in try/catch, return 400. |
+| **S-8** | E2E tests not running in CI | `.github/workflows/test.yml` | A4 | CI runs `test:unit` only. Playwright E2E is excluded. For a release, at minimum run E2E once locally, or wire a CI job with build + serve. |
+| **S-9** | `voice` transcript CRUD has zero test coverage | `apps/server/src/routes/__tests__/voice.test.ts` | A4 | Only `/transcribe` is tested. GET/POST/PATCH/DELETE for transcripts have no automated tests. Add CRUD tests with in-memory SQLite. |
+| **S-10** | `ErrorBoundary` doesn't handle non-Error throwables | `apps/web/src/components/ErrorBoundary.tsx:22-24` | A2 | `getDerivedStateFromError` assumes `Error` type. String throws produce confusing UI. Normalize with `error instanceof Error ? error : new Error(String(error))`. |
+
+### DEFER (File as New Issues)
+
+Valid improvements that should not block v0.10.0 but are worth tracking.
+
+| # | Finding | File(s) | Agents | Justification |
+|---|---------|---------|--------|---------------|
+| **D-1** | All tabs mounted simultaneously, no lazy loading | `apps/web/src/App.tsx:368-399` | A2, A5 | All four tab panels render at once via CSS transform. Heavy: xterm WS + FileViewer + VoiceRecorder run in background. Use `React.lazy` + render only active tab. Significant refactor — file as perf issue for next cycle. |
+| **D-2** | Terminal WS polls tmux every 500ms with `execSync`/`spawn` | `apps/server/src/routes/terminal-ws.ts:73-109` | A5 | `spawn("tmux", ...)` + sync dimension check every 500ms. If capture exceeds interval, processes pile up. Add single-flight guard and idle-state backoff. |
+| **D-3** | `ActionBarProps` marks nearly all fields optional | `apps/web/src/components/action-bar/types.ts:4-14` | A2 | TypeScript won't catch missing props. Split into required vs truly-optional. |
+| **D-4** | `any` types in markdown/heading components | `MarkdownViewer.tsx`, `CollapsibleHeading.tsx` | A2 | Multiple `node?: any` and `[key: string]: any`. Use `react-markdown` v9 types. |
+| **D-5** | API response shape inconsistency | Multiple server routes | A3 | Mix of `{ error }`, `{ ok, error }`, `{ ok: false, error }`. Standardize envelope for v0.11. |
+| **D-6** | initData `auth_date` freshness not checked | `apps/server/src/auth.ts:7-40` | A1, A6 | HMAC verified but no staleness check. Login Widget path checks 24h. Add TTL for initData too. Low urgency given single-user model + allowlist. |
+| **D-7** | Static assets served without `Cache-Control: immutable` | `apps/server/src/index.ts:90-121` | A5 | Hashed assets (`*.js`, `*.css` in `dist/assets/`) should get long cache. Depends on whether Caddy handles this in prod. |
+| **D-8** | WS auth via session token skips allowlist re-check | `apps/server/src/routes/terminal-ws.ts:34-41` | A1 | A user removed from allowlist can still open terminal WS until session expires. Edge case for single-user system. |
+| **D-9** | Duplicate markdown test fixtures and snapshot harnesses | `apps/web/src/__tests__/` vs `apps/web/src/components/__tests__/markdown-fixtures/` | A4 | Two fixture sets with overlapping purpose. Consolidate to one canonical set. |
+| **D-10** | Reading-list tests mock `isPathAllowed` entirely | `apps/server/src/routes/__tests__/reading-list.test.ts` | A4 | Hand-written `startsWith` mock defeats security testing purpose. Use real `isPathAllowed` with test roots. |
+| **D-11** | Missing `safe-area-inset-*` on root layout | `apps/web/index.html`, `App.tsx` root div | A6 | `viewport-fit=cover` set but no CSS `env(safe-area-inset-*)` padding on main container. Tab bar can overlap home indicator on notched devices. |
+| **D-12** | Links/Markdown don't use `Telegram.WebApp.openLink` | `apps/web/src/components/Links.tsx`, `MarkdownViewer.tsx` | A6 | External links use plain `<a href>` / `target="_blank"`. In Telegram WebView, `openLink` provides more consistent behavior. |
+| **D-13** | No `React.memo` on any component | Repo-wide | A2, A5 | App-level state changes re-render all children. Add `memo` selectively after profiling. |
+| **D-14** | Missing coverage thresholds in Vitest config | `apps/server/vitest.config.ts`, `apps/web/vitest.config.ts` | A4 | No `coverage` block or thresholds. Add for critical paths. |
+| **D-15** | `db.ts` migration `strftime` may produce NULL on bad legacy data | `apps/server/src/db.ts:92-99` | A3 | If old `created_at` TEXT is unparseable, `CAST` may yield NULL vs NOT NULL. Use `COALESCE` fallback. |
+
+### SKIP / False Positive
+
+| # | Finding | Agent | Reason to Skip |
+|---|---------|-------|----------------|
+| **FP-1** | "Terminal overlay `preventDefault` on `touchstart`" (A6 rated CRITICAL) — the `touchstart` handler was attributed to an absent pattern | A6 | **Actually confirmed real** after verification — reclassified as M-1 above. Initially appeared ambiguous but code at line 163 confirmed. |
+| **FP-2** | "Empty allowlist = open API access" | A1 | In production, `ALLOWED_TELEGRAM_USERS` is always set via `~/.secrets/cpc.env`. Empty allowlist is a valid dev-mode convenience. The deploy script and env setup docs cover this. Low-risk misconfiguration vector on a single-user system. |
+| **FP-3** | "JWT token in URL query parameter" security concern | A1 | The `?token=` pattern is used only for download tickets (one-time, 60s TTL, random 128-bit). Acceptable for the specific use case of browser-initiated downloads where headers can't be set. |
+| **FP-4** | "Download ticket race: two concurrent GETs" | A3 | Real TOCTOU but extremely narrow window, single-user system, tickets are 128-bit random. Not exploitable in practice. |
+| **FP-5** | "`slash-commands` non-raw path uses `JSON.stringify` in shell" | A3 | `JSON.stringify` produces properly quoted strings for `tmux send-keys -l`. The token allowlist on raw mode is the real security boundary. Consistent with project patterns. |
+| **FP-6** | "`TMUX_SESSION` invalid crashes server at import" | A3 | Fail-fast is correct behavior. An invalid tmux session means the core feature (terminal) won't work. Better to crash early than serve a broken app. |
+| **FP-7** | "ActionBar legacy shim file is redundant" | A2 | `components/ActionBar.tsx` may be kept for backward compatibility with external references or deep imports. Minimal maintenance cost. |
+| **FP-8** | "Playwright `screenshot: 'on'` is slow" | A4 | Screenshots on all tests aids debugging in this project. Storage cost is acceptable for E2E suite of ~10 specs. |
+
+---
+
+## 5. Recommended Next Steps
+
+### Before Merge (address M-1 through M-6)
+
+1. **M-1: Terminal touch handler** — Replace `onTouchStart={(e) => e.preventDefault()}` with `style={{ pointerEvents: 'none' }}` on the overlay div. The xterm textarea is already disabled via CSS. ~5 min fix.
+
+2. **M-2 + M-3: Upload route hardening** — Add `bodyLimit()` middleware to the `/upload` route and rewrite the file write to use `O_CREAT|O_EXCL|O_NOFOLLOW` matching `/paste`. ~30 min fix, port the pattern.
+
+3. **M-4: VoiceRecorder media** — Replace `getUserMedia` with `<input type="file" accept="audio/*" capture="user">` + upload flow. This is a meaningful refactor of the recording UI but is necessary for the feature to work in Telegram. ~1-2 hours.
+
+4. **M-5: DebugOverlay hooks** — Move early-return guard below all hook calls, or split into a `<DebugOverlayGate>` wrapper. ~10 min fix.
+
+5. **M-6: CORS restriction** — Change `cors()` to `cors({ origin: [...allowedOrigins] })`. ~10 min fix.
+
+### After Merge (S-1 through S-10 as fast-follows)
+
+Prioritize S-1 (file search reload), S-2 (vertical swipes), S-3 (404 mapping), and S-4 (session overwrite) for a v0.10.1 patch. S-8 (E2E in CI) should be wired before v0.11.
+
+### Deferred (D-1 through D-15 as backlog issues)
+
+File as GitHub issues. D-1 (lazy tab loading) and D-2 (terminal WS polling) are the highest-impact performance items for the next cycle. D-3/D-4 (type safety) can be addressed incrementally.
+
+---
+
+## Appendix: Agent Agreement Matrix
+
+Findings where multiple agents independently flagged the same issue carry higher confidence:
+
+| Finding | A1 | A2 | A3 | A4 | A5 | A6 | Count |
+|---------|----|----|----|----|----|----|-------|
+| Upload body limit + symlink | x | | x | | x | | 3 |
+| Permissive CORS | x | | x | | x | | 3 |
+| All tabs mounted (perf) | | x | | | x | x | 3 |
+| Error message leakage | x | | x | | | | 2 |
+| DebugOverlay hooks | | x | | | | x | 2 |
+| Session file overwrite | | | x | x | | | 2 |
+| Git 200-on-failure | | | x | x | | | 2 |
+| Terminal touchstart | | | | | | x | 1 |
+| getUserMedia | | | | | | x | 1 |
+| Voice CRUD untested | | | | x | | | 1 |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Comprehensive pre-release code review for v0.10.0, performed by 6 parallel specialized review agents covering security, frontend architecture, backend correctness, test coverage, performance, and Telegram WebView compatibility.

## Key Findings

**6 MUST FIX (release blockers):**
- **M-1:** `preventDefault()` on `touchstart` in Terminal.tsx — violates documented Telegram rule
- **M-2:** `/upload` route has no body size limit (memory exhaustion risk)
- **M-3:** `/upload` uses `writeFile` without `O_NOFOLLOW`/`O_EXCL` (symlink escape)
- **M-4:** `getUserMedia` in VoiceRecorder contradicts platform docs (broken in WebView)
- **M-5:** `DebugOverlay` violates React Rules of Hooks (early return before hooks)
- **M-6:** Permissive CORS with no origin restriction

**10 SHOULD FIX, 15 DEFER, 8 SKIP/false-positive** — all classified with justifications.

## Report Location

Full report: `docs/reviews/v0.10.0-pre-release-review.md`

## Agent Quality Assessment

| Agent | Focus | Quality |
|-------|-------|---------|
| Security | Auth, traversal, injection | 9/10 |
| Frontend Architecture | Components, state, types | 8/10 |
| Backend Correctness | Error handling, races, API | 9/10 |
| Test Coverage | Gaps, CI, fixtures | 8/10 |
| Performance | Bundle, lazy loading, WS | 7/10 |
| Telegram WebView | Touch, swipe, media | 9/10 |

## Next Steps

1. Fix M-1 through M-6 before merging `dev` → `main`
2. Ship S-1 through S-10 as fast-follow in v0.10.1
3. File D-1 through D-15 as GitHub issues for backlog
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c3552a12-7a77-4b1c-b358-02b26b1012b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c3552a12-7a77-4b1c-b358-02b26b1012b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

