### PR TITLE
fix(debug): move early-return guards above hooks in DebugOverlay

### DIFF
--- a/apps/web/src/debug/DebugOverlay.tsx
+++ b/apps/web/src/debug/DebugOverlay.tsx
@@ -122,6 +122,10 @@ export function DebugOverlay() {
   if (!isDevHost()) return null;
   if (!isCaptureInstalled()) return null;
 
+  return <DebugOverlayInner />;
+}
+
+function DebugOverlayInner() {
   const [isOpen, setIsOpen] = useState(false);
   const [filter, setFilter] = useState("");
 


### PR DESCRIPTION
## Summary

- Fixes Rules of Hooks violation in `DebugOverlay` where `useState` and `useSyncExternalStore` were called after conditional early returns
- Splits into wrapper (`DebugOverlay`) + inner component (`DebugOverlayInner`) pattern so guards run before any hooks

Closes #168

## Test plan

- [x] `pnpm run test:unit` — 194 tests pass (72 web + 122 server)
- [x] TypeScript typecheck (`tsc --noEmit`) — clean
- [ ] Manual: verify debug overlay still appears on dev hostnames and hides on prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>