### PR TITLE
fix(downloads): consume ticket after file validation, not before (closes #171)

### DIFF
--- a/apps/server/src/routes/files.ts
+++ b/apps/server/src/routes/files.ts
@@ -300,12 +300,19 @@ app.get("/download", async (c) => {
       return c.json({ error: "invalid or expired ticket" }, 403);
     }
 
+    // Claim the ticket synchronously (before any await) so two concurrent
+    // GETs can't both pass the `record.used` check and both receive the file.
+    // If the subsequent file validation fails we undo the claim so the user
+    // can retry with the same ticket.
+    record.used = true;
+
     const file = await getDownloadableFile(record.path);
     if (!file.ok) {
+      // Undo claim on file-not-available so the caller can retry.
+      record.used = false;
       return c.json({ error: file.error }, file.status);
     }
 
-    record.used = true;
     return createDownloadResponse(file);
   }
 

--- a/apps/server/src/routes/files.ts
+++ b/apps/server/src/routes/files.ts
@@ -300,12 +300,12 @@ app.get("/download", async (c) => {
       return c.json({ error: "invalid or expired ticket" }, 403);
     }
 
-    record.used = true;
     const file = await getDownloadableFile(record.path);
     if (!file.ok) {
       return c.json({ error: file.error }, file.status);
     }
 
+    record.used = true;
     return createDownloadResponse(file);
   }
 


### PR DESCRIPTION
## Summary
- Fixes the download ticket TOCTOU bug where a GET request marked a ticket as used before confirming the target file still existed.
- Moves ticket consumption until after getDownloadableFile(record.path) succeeds, immediately before returning the download response.

## Impact
If a file is deleted between ticket creation and redemption, the request now returns the file error without consuming the ticket, so the user can retry after the file becomes available again.

## Verification
- cd /home/claude/code/cpc-impl-toctou-171/apps/server && npx tsc --noEmit
- cd /home/claude/code/cpc-impl-toctou-171 && pnpm run test:unit
- Confirmed apps/server/src/routes/__tests__/download-ticket.test.ts passed in the unit run.