### PR TITLE
fix(security): add bodyLimit + symlink-safe writes to /upload (closes #166)

### DIFF
--- a/apps/server/src/routes/files.ts
+++ b/apps/server/src/routes/files.ts
@@ -22,6 +22,7 @@ const app = new Hono();
 const BASE_DIR = process.env.FILES_BASE_DIR || "/home/claude/claudes-world";
 const DOWNLOAD_MAX_BYTES = 50 * 1024 * 1024;
 const UPLOAD_BODY_LIMIT = 50 * 1024 * 1024;
+const UPLOAD_BODY_LIMIT_MB = UPLOAD_BODY_LIMIT / (1024 * 1024);
 const DOWNLOAD_TICKET_TTL_MS = 60 * 1000;
 
 type DownloadTicket = {
@@ -404,7 +405,7 @@ app.post(
     maxSize: UPLOAD_BODY_LIMIT,
     onError: (c) =>
       c.json(
-        { error: "Request body too large (max 50MB)" },
+        { error: `Request body too large (max ${UPLOAD_BODY_LIMIT_MB}MB)` },
         413,
       ),
   }),
@@ -423,17 +424,13 @@ app.post(
   }
 
   try {
-    // Strip any directory components from the user-supplied filename so a
-    // value like "../../etc/passwd" cannot escape the validated `resolved`
-    // directory via path.join. basename() returns just the trailing segment.
-    let fileName = basename((file as File).name || "uploaded-file");
-    // basename() returns `.`, `..`, or `""` unchanged, which path.join would
-    // then normalize into the parent/current directory. Reject those and
-    // fall back to the default name so the upload always writes a new file
-    // inside the validated root.
-    if (fileName === "" || fileName === "." || fileName === "..") {
-      fileName = "uploaded-file";
-    }
+    // Strip directory components then run through sanitizeFilename() which
+    // additionally rejects control characters, null bytes, reserved Windows
+    // names, and other dangerous patterns. basename() is applied first so
+    // sanitizeFilename() never sees a slash-separated path.
+    const rawName = basename((file as File).name || "uploaded-file");
+    const sanitized = sanitizeFilename(rawName);
+    let fileName = sanitized ?? "uploaded-file";
     const arrayBuffer = await (file as File).arrayBuffer();
     const data = Buffer.from(arrayBuffer);
 
@@ -444,6 +441,20 @@ app.post(
     //     outside the allowed root would trick the write into landing outside
     //     ALLOWED_ROOTS).
     //
+    // Verify the target directory exists before attempting writes. If it
+    // doesn't, open() would throw ENOENT which would surface as a generic 500.
+    try {
+      const dirStat = await stat(resolved);
+      if (!dirStat.isDirectory()) {
+        return c.json({ error: "Target path is not a directory" }, 400);
+      }
+    } catch (err: any) {
+      if (err && err.code === "ENOENT") {
+        return c.json({ error: "Target directory does not exist" }, 404);
+      }
+      throw err;
+    }
+
     // Try the chosen filename, then incrementing suffixes until O_EXCL
     // succeeds or we give up.
     const dotIdx = fileName.lastIndexOf(".");

--- a/apps/server/src/routes/files.ts
+++ b/apps/server/src/routes/files.ts
@@ -7,7 +7,6 @@ import {
   readFile,
   stat,
   unlink,
-  writeFile,
 } from "node:fs/promises";
 import { createReadStream } from "node:fs";
 import { basename, join, resolve, sep } from "node:path";
@@ -22,6 +21,7 @@ const app = new Hono();
 
 const BASE_DIR = process.env.FILES_BASE_DIR || "/home/claude/claudes-world";
 const DOWNLOAD_MAX_BYTES = 50 * 1024 * 1024;
+const UPLOAD_BODY_LIMIT = 50 * 1024 * 1024;
 const DOWNLOAD_TICKET_TTL_MS = 60 * 1000;
 
 type DownloadTicket = {
@@ -398,7 +398,17 @@ app.get("/search", async (c) => {
 });
 
 // Upload file to current directory
-app.post("/upload", async (c) => {
+app.post(
+  "/upload",
+  bodyLimit({
+    maxSize: UPLOAD_BODY_LIMIT,
+    onError: (c) =>
+      c.json(
+        { error: "Request body too large (max 50MB)" },
+        413,
+      ),
+  }),
+  async (c) => {
   const body = await c.req.parseBody();
   const file = body["file"];
   const dir = (body["dir"] as string) || BASE_DIR;
@@ -424,35 +434,80 @@ app.post("/upload", async (c) => {
     if (fileName === "" || fileName === "." || fileName === "..") {
       fileName = "uploaded-file";
     }
-    const destPath = join(resolved, fileName);
-
-    // Don't overwrite existing files — add suffix
-    let finalPath = destPath;
-    let counter = 1;
-    try {
-      while (await stat(finalPath)) {
-        const ext = fileName.includes(".") ? "." + fileName.split(".").pop() : "";
-        const base = fileName.includes(".") ? fileName.slice(0, fileName.lastIndexOf(".")) : fileName;
-        finalPath = join(resolved, `${base}-${counter}${ext}`);
-        counter++;
-      }
-    } catch {
-      // File doesn't exist — good, use this path
-    }
-
     const arrayBuffer = await (file as File).arrayBuffer();
-    await writeFile(finalPath, Buffer.from(arrayBuffer));
+    const data = Buffer.from(arrayBuffer);
+
+    // Atomic exclusive create with O_NOFOLLOW to defeat both:
+    // (a) TOCTOU race (stat-then-write where two concurrent uploads pick the
+    //     same suffix), and
+    // (b) symlink-redirected writes (a symlink inside an allowed dir pointing
+    //     outside the allowed root would trick the write into landing outside
+    //     ALLOWED_ROOTS).
+    //
+    // Try the chosen filename, then incrementing suffixes until O_EXCL
+    // succeeds or we give up.
+    const dotIdx = fileName.lastIndexOf(".");
+    const hasExt = dotIdx > 0;
+    const base = hasExt ? fileName.slice(0, dotIdx) : fileName;
+    const ext = hasExt ? fileName.slice(dotIdx) : "";
+
+    let finalPath = "";
+    for (let counter = 0; counter <= 9999; counter++) {
+      const candidate =
+        counter === 0
+          ? join(resolved, fileName)
+          : join(resolved, `${base}-${counter}${ext}`);
+      let opened = false;
+      try {
+        const handle = await open(
+          candidate,
+          fsConstants.O_WRONLY |
+            fsConstants.O_CREAT |
+            fsConstants.O_EXCL |
+            fsConstants.O_NOFOLLOW,
+          0o644,
+        );
+        opened = true;
+        try {
+          await handle.writeFile(data);
+        } finally {
+          await handle.close();
+        }
+        finalPath = candidate;
+        break;
+      } catch (err: any) {
+        if (err && err.code === "EEXIST") continue;
+        if (err && (err.code === "ELOOP" || err.code === "EMLINK")) {
+          return c.json(
+            { error: "Refusing to write through symlink" },
+            403,
+          );
+        }
+        if (opened) {
+          try {
+            await unlink(candidate);
+          } catch {
+            // ignore — already gone or unlink not allowed
+          }
+        }
+        throw err;
+      }
+    }
+    if (!finalPath) {
+      throw new Error("Could not find available filename");
+    }
 
     return c.json({
       ok: true,
-      path: finalPath,
-      name: finalPath.split("/").pop(),
+      name: basename(finalPath),
       size: arrayBuffer.byteLength,
     });
   } catch (err: any) {
-    return c.json({ error: err.message }, 500);
+    console.error("[files/upload] write error:", err);
+    return c.json({ error: "Failed to write file" }, 500);
   }
-});
+  },
+);
 
 // Paste text content into the current directory as a new file.
 // JSON body: { filename: string, content: string, dir: string }


### PR DESCRIPTION
## Summary

- Add `bodyLimit()` middleware (50 MB cap) to the `/upload` route, matching the existing pattern on `/paste`. Without this, an authenticated user could exhaust server memory with an oversized upload.
- Replace the TOCTOU-vulnerable `stat()` loop + `writeFile()` with the atomic `O_CREAT|O_EXCL|O_NOFOLLOW` pattern already used by `/paste`, preventing both symlink-escape writes and concurrent-upload race conditions.
- Stop leaking absolute filesystem paths and raw error messages in the upload response (security hardening matching `/paste`).
- Remove unused `writeFile` import from `node:fs/promises`.

## Test plan

- [x] `pnpm run typecheck` passes in `apps/server`
- [x] `pnpm run test:unit` passes (122 server + 72 web tests)
- [ ] Manual: upload a file via CPC and verify it lands correctly
- [ ] Manual: verify uploads >50 MB are rejected with 413

🤖 Generated with [Claude Code](https://claude.com/claude-code)