### PR TITLE
fix: pre-v1.10.0 security + quality fixes (closes #162, #165, #166, #168, #169, #170, #171)

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -9,6 +9,7 @@ import { serve } from "@hono/node-server";
 import { createNodeWebSocket } from "@hono/node-ws";
 import { telegramAuth } from "./middleware.js";
 import { validateTelegramLoginWidget, createSession, getAllowedUsers } from "./auth.js";
+import { ALLOWED_ORIGINS } from "./lib/allowed-origins.js";
 import { terminalRoute } from "./routes/terminal/index.js";
 import { sessionRoute } from "./routes/session.js";
 import { todoRoute } from "./routes/todo.js";
@@ -46,12 +47,7 @@ const app = new Hono<{ Bindings: HttpBindings }>();
 const { injectWebSocket, upgradeWebSocket } = createNodeWebSocket({ app });
 
 app.use("*", cors({
-  origin: [
-    "https://web.telegram.org",
-    "https://cpc.claude.do",
-    "http://localhost:5173",
-    "http://localhost:58830",
-  ],
+  origin: [...ALLOWED_ORIGINS],
 }));
 
 // Public routes (no auth)

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -45,7 +45,14 @@ loadEnv(`${process.env.HOME}/.secrets/cpc.env`);
 const app = new Hono<{ Bindings: HttpBindings }>();
 const { injectWebSocket, upgradeWebSocket } = createNodeWebSocket({ app });
 
-app.use("*", cors());
+app.use("*", cors({
+  origin: [
+    "https://web.telegram.org",
+    "https://cpc.claude.do",
+    "http://localhost:5173",
+    "http://localhost:58830",
+  ],
+}));
 
 // Public routes (no auth)
 app.get("/api/public/health", (c) => c.json({ status: "ok" }));

--- a/apps/server/src/lib/allowed-origins.ts
+++ b/apps/server/src/lib/allowed-origins.ts
@@ -1,0 +1,17 @@
+/**
+ * Canonical list of origins allowed to connect to the CPC server.
+ *
+ * Used by:
+ *  - Hono cors() middleware (HTTP requests)
+ *  - WebSocket upgrade Origin validation (terminal-ws.ts)
+ *
+ * Keep in sync: both consumers import this constant so there is a single
+ * source of truth. Adding an origin here covers both HTTP CORS and WS.
+ */
+export const ALLOWED_ORIGINS: readonly string[] = [
+  "https://web.telegram.org",
+  "https://cpc.claude.do",
+  "https://cpc-dev.claude.do",
+  "http://localhost:5173",
+  "http://localhost:58830",
+];

--- a/apps/server/src/routes/__tests__/audio.test.ts
+++ b/apps/server/src/routes/__tests__/audio.test.ts
@@ -225,4 +225,19 @@ describe("/check path allowlist (M-5 adjacent)", () => {
     expect(res.status).toBe(200);
     expect(body.exists).toBe(true);
   });
+
+  it("returns exists=false (not 403) for an allowlisted .md whose .mp3 does not exist (#170)", async () => {
+    // This is the exact bug scenario: the source .md is allowlisted and exists,
+    // but the .mp3 hasn't been generated yet. Before the fix, isPathAllowed
+    // was called on the non-existent .mp3, and realpath() would fail, causing
+    // a false 403. The fix validates the source .md path instead.
+    const noAudioMd = join(sandbox, "no-audio-yet.md");
+    writeFileSync(noAudioMd, "# Pending\n\nAudio not generated yet.\n");
+    const params = new URLSearchParams({ path: noAudioMd });
+    const res = await audioRoute.request(`/check?${params.toString()}`);
+    const body = (await res.json()) as { ok: boolean; exists?: boolean; path?: string | null };
+    expect(res.status).toBe(200);
+    expect(body.exists).toBe(false);
+    expect(body.path).toBeNull();
+  });
 });

--- a/apps/server/src/routes/__tests__/audio.test.ts
+++ b/apps/server/src/routes/__tests__/audio.test.ts
@@ -218,6 +218,44 @@ describe("/check path allowlist (M-5 adjacent)", () => {
     expect(body.error).toBe("path not allowed");
   });
 
+  it("rejects a non-.md extension with 400", async () => {
+    // Without the extension gate, note.txt would pass through the .md→.mp3
+    // replace as a no-op, leaking existence of arbitrary non-markdown files.
+    const params = new URLSearchParams({ path: join(sandbox, "note.txt") });
+    const res = await audioRoute.request(`/check?${params.toString()}`);
+    const body = (await res.json()) as { ok: boolean; error?: string };
+    expect(res.status).toBe(400);
+    expect(body.error).toMatch(/only \.md files allowed/);
+  });
+
+  it("returns exists=false (not 403) when derived .mp3 path fails isPathAllowed", async () => {
+    // Covers the symlink-escape edge case: if the .mp3 path resolves outside
+    // allowed roots (e.g. a planted symlink), we silently return exists=false
+    // rather than 403, so the caller can't probe out-of-bounds file existence
+    // via timing or error-code differences.
+    // We simulate this by using a sandbox .md that is allowed, but we redirect
+    // the audioPath isPathAllowed check by using a path whose .mp3 resolves
+    // outside the sandbox — in practice this is a symlink attack vector.
+    // For the unit test, we use a .md under evilSibling-named dir which the
+    // sandbox allowlist doesn't cover, but the .md check passes because we
+    // temporarily add the source dir. Instead, we confirm that our existing
+    // "outside-allowlist .mp3" branch is handled by testing the 200+exists=false
+    // response shape stays consistent (the actual symlink test is an integration
+    // concern; unit coverage proves the code path exists).
+    // NOTE: The primary regression (#170 scenario) is covered by the test below.
+    const noAudioMd = join(sandbox, "no-audio-for-symlink-test.md");
+    writeFileSync(noAudioMd, "# Symlink edge case\n");
+    const params = new URLSearchParams({ path: noAudioMd });
+    const res = await audioRoute.request(`/check?${params.toString()}`);
+    const body = (await res.json()) as { ok: boolean; exists?: boolean; path?: string | null };
+    // The .mp3 does not exist — isPathAllowed on a non-existent path returns
+    // false (realpath fails), so we get exists=false via the guard branch.
+    expect(res.status).toBe(200);
+    expect(body.ok).toBe(true);
+    expect(body.exists).toBe(false);
+    expect(body.path).toBeNull();
+  });
+
   it("returns exists=true for an allowlisted .md whose .mp3 sibling exists", async () => {
     const params = new URLSearchParams({ path: join(sandbox, "note.md") });
     const res = await audioRoute.request(`/check?${params.toString()}`);

--- a/apps/server/src/routes/__tests__/terminal-ws-auth.test.ts
+++ b/apps/server/src/routes/__tests__/terminal-ws-auth.test.ts
@@ -30,8 +30,16 @@ beforeAll(() => {
 });
 
 afterAll(() => {
-  process.env.TELEGRAM_BOT_TOKEN = savedBotToken;
-  process.env.ALLOWED_TELEGRAM_USERS = savedAllowed;
+  if (savedBotToken === undefined) {
+    delete process.env.TELEGRAM_BOT_TOKEN;
+  } else {
+    process.env.TELEGRAM_BOT_TOKEN = savedBotToken;
+  }
+  if (savedAllowed === undefined) {
+    delete process.env.ALLOWED_TELEGRAM_USERS;
+  } else {
+    process.env.ALLOWED_TELEGRAM_USERS = savedAllowed;
+  }
 });
 
 // Mock child_process so tmux spawn/exec doesn't actually run.
@@ -93,6 +101,9 @@ describe("terminalWsRoute session-token allowlist (issue #162)", () => {
       try { return JSON.parse(s).type === "error"; } catch { return false; }
     });
     expect(errorMessages).toHaveLength(0);
+
+    // Clean up the setInterval started by onOpen to prevent timer leaks
+    (ws as any)._cleanup?.();
   });
 
   it("rejects a session token for a non-allowed user", () => {

--- a/apps/server/src/routes/__tests__/terminal-ws-auth.test.ts
+++ b/apps/server/src/routes/__tests__/terminal-ws-auth.test.ts
@@ -65,10 +65,11 @@ vi.mock("../utils.js", async () => {
 
 const { terminalWsRoute } = await import("../terminal-ws.js");
 
-function makeMockContext(query: Record<string, string>) {
+function makeMockContext(query: Record<string, string>, headers: Record<string, string> = {}) {
   return {
     req: {
       query: (key: string) => query[key] || "",
+      header: (key: string) => headers[key.toLowerCase()],
     },
   };
 }
@@ -89,7 +90,7 @@ describe("terminalWsRoute session-token allowlist (issue #162)", () => {
 
   it("accepts a session token for an allowed user", () => {
     const token = createSession({ id: Number(TEST_USER_ID), first_name: "Allowed" });
-    const c = makeMockContext({ token });
+    const c = makeMockContext({ token }, { origin: "https://cpc.claude.do" });
     const handlers = terminalWsRoute(c);
     const ws = makeMockWs();
 
@@ -108,7 +109,7 @@ describe("terminalWsRoute session-token allowlist (issue #162)", () => {
 
   it("rejects a session token for a non-allowed user", () => {
     const token = createSession({ id: Number(INTRUDER_ID), first_name: "Intruder" });
-    const c = makeMockContext({ token });
+    const c = makeMockContext({ token }, { origin: "https://cpc.claude.do" });
     const handlers = terminalWsRoute(c);
     const ws = makeMockWs();
 

--- a/apps/server/src/routes/__tests__/terminal-ws-auth.test.ts
+++ b/apps/server/src/routes/__tests__/terminal-ws-auth.test.ts
@@ -1,0 +1,113 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { createSession } from "../../auth.js";
+
+/**
+ * terminal-ws session-token allowlist enforcement tests (issue #162).
+ *
+ * The WebSocket route `terminalWsRoute` has three auth paths:
+ *   1. initData (mini app) — already checks allowlist via `checkAuth`
+ *   2. session token        — was MISSING allowlist check (the bug)
+ *   3. JWT token            — already checks allowlist
+ *
+ * Strategy: call `terminalWsRoute(mockContext)` with a valid session token,
+ * then invoke the returned `onOpen` with a mock WebSocket. If auth failed,
+ * `onOpen` sends `{ type: "error" }` and closes with code 4001. If auth
+ * succeeded, it attempts to spawn tmux (which will fail in CI, but we only
+ * care about whether it *tried* — meaning auth passed).
+ */
+
+const TEST_USER_ID = "999111";
+const INTRUDER_ID = "777888";
+
+let savedBotToken: string | undefined;
+let savedAllowed: string | undefined;
+
+beforeAll(() => {
+  savedBotToken = process.env.TELEGRAM_BOT_TOKEN;
+  savedAllowed = process.env.ALLOWED_TELEGRAM_USERS;
+  process.env.TELEGRAM_BOT_TOKEN = "123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11";
+  process.env.ALLOWED_TELEGRAM_USERS = TEST_USER_ID;
+});
+
+afterAll(() => {
+  process.env.TELEGRAM_BOT_TOKEN = savedBotToken;
+  process.env.ALLOWED_TELEGRAM_USERS = savedAllowed;
+});
+
+// Mock child_process so tmux spawn/exec doesn't actually run.
+// Must spread the real module so `exec`, `execFile`, etc. are still available
+// for transitive imports (e.g. utils.ts uses `exec`/`execFile`).
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:child_process")>();
+  return {
+    ...actual,
+    spawn: vi.fn(() => ({
+      stdout: { on: vi.fn() },
+      on: vi.fn(),
+    })),
+    execSync: vi.fn(() => "80x24"),
+  };
+});
+
+// Mock utils to avoid tmux session validation at import time
+vi.mock("../utils.js", async () => {
+  const actual = await vi.importActual<typeof import("../utils.js")>("../utils.js");
+  return { ...actual, TMUX_SESSION: "test-session" };
+});
+
+const { terminalWsRoute } = await import("../terminal-ws.js");
+
+function makeMockContext(query: Record<string, string>) {
+  return {
+    req: {
+      query: (key: string) => query[key] || "",
+    },
+  };
+}
+
+function makeMockWs() {
+  const sent: string[] = [];
+  return {
+    send: vi.fn((data: string) => sent.push(data)),
+    close: vi.fn(),
+    _sent: sent,
+  };
+}
+
+describe("terminalWsRoute session-token allowlist (issue #162)", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("accepts a session token for an allowed user", () => {
+    const token = createSession({ id: Number(TEST_USER_ID), first_name: "Allowed" });
+    const c = makeMockContext({ token });
+    const handlers = terminalWsRoute(c);
+    const ws = makeMockWs();
+
+    handlers.onOpen(new Event("open"), ws as any);
+
+    // Should NOT have sent an error or closed with 4001
+    expect(ws.close).not.toHaveBeenCalledWith(4001, "Unauthorized");
+    const errorMessages = ws._sent.filter((s) => {
+      try { return JSON.parse(s).type === "error"; } catch { return false; }
+    });
+    expect(errorMessages).toHaveLength(0);
+  });
+
+  it("rejects a session token for a non-allowed user", () => {
+    const token = createSession({ id: Number(INTRUDER_ID), first_name: "Intruder" });
+    const c = makeMockContext({ token });
+    const handlers = terminalWsRoute(c);
+    const ws = makeMockWs();
+
+    handlers.onOpen(new Event("open"), ws as any);
+
+    // Should have sent error and closed
+    expect(ws.close).toHaveBeenCalledWith(4001, "Unauthorized");
+    expect(ws._sent.length).toBeGreaterThan(0);
+    const errorMsg = JSON.parse(ws._sent[0]);
+    expect(errorMsg.type).toBe("error");
+    expect(errorMsg.message).toBe("Unauthorized");
+  });
+});

--- a/apps/server/src/routes/audio.ts
+++ b/apps/server/src/routes/audio.ts
@@ -33,14 +33,16 @@ app.get("/check", async (c) => {
     const filePath = c.req.query("path");
     if (!filePath) return c.json({ ok: false, error: "path required" }, 400);
 
-    // Audio file is the same path but with .mp3 extension
-    const audioPath = filePath.replace(/\.md$/, ".mp3");
-    // Allowlist-guard the resolved path so the endpoint cannot be used to
-    // stat arbitrary filesystem locations. Reject with 403 on mismatch;
-    // `existsSync` is cheap but still an information leak without the guard.
-    if (!(await isPathAllowed(resolve(audioPath)))) {
+    // Allowlist-guard the SOURCE markdown path, not the derived .mp3 path.
+    // The .mp3 may not exist yet (client is asking "does audio exist?"), and
+    // isPathAllowed uses realpath() which fails on non-existent files,
+    // returning a false 403. The source .md file is what the client has, so
+    // validate that instead. (Fixes #170)
+    if (!(await isPathAllowed(resolve(filePath)))) {
       return c.json({ ok: false, error: "path not allowed" }, 403);
     }
+    // Audio file is the same path but with .mp3 extension
+    const audioPath = filePath.replace(/\.md$/, ".mp3");
     const exists = existsSync(audioPath);
     return c.json({ ok: true, exists, path: exists ? audioPath : null });
   } catch (err: any) {

--- a/apps/server/src/routes/audio.ts
+++ b/apps/server/src/routes/audio.ts
@@ -33,16 +33,34 @@ app.get("/check", async (c) => {
     const filePath = c.req.query("path");
     if (!filePath) return c.json({ ok: false, error: "path required" }, 400);
 
+    // Require an explicit `.md` extension so a non-markdown path (e.g. note.txt)
+    // doesn't silently skip the .mp3 replacement and leak file existence of
+    // arbitrary paths. Mirrors the same gate in /generate.
+    const resolvedFilePath = resolve(filePath);
+    if (!resolvedFilePath.toLowerCase().endsWith(".md")) {
+      return c.json({ ok: false, error: "only .md files allowed" }, 400);
+    }
+
     // Allowlist-guard the SOURCE markdown path, not the derived .mp3 path.
     // The .mp3 may not exist yet (client is asking "does audio exist?"), and
     // isPathAllowed uses realpath() which fails on non-existent files,
     // returning a false 403. The source .md file is what the client has, so
     // validate that instead. (Fixes #170)
-    if (!(await isPathAllowed(resolve(filePath)))) {
+    if (!(await isPathAllowed(resolvedFilePath))) {
       return c.json({ ok: false, error: "path not allowed" }, 403);
     }
-    // Audio file is the same path but with .mp3 extension
-    const audioPath = filePath.replace(/\.md$/, ".mp3");
+
+    // Audio file is the same path but with .mp3 extension.
+    const audioPath = resolvedFilePath.replace(/\.md$/i, ".mp3");
+
+    // Guard the derived .mp3 path too: a symlink planted under an allowed root
+    // that points outside allowed roots would otherwise let existsSync() reveal
+    // whether an out-of-bounds file exists. If the check fails (symlink escape
+    // or the path resolves outside roots), treat the audio as non-existent.
+    if (!(await isPathAllowed(resolve(audioPath)))) {
+      return c.json({ ok: true, exists: false, path: null });
+    }
+
     const exists = existsSync(audioPath);
     return c.json({ ok: true, exists, path: exists ? audioPath : null });
   } catch (err: any) {

--- a/apps/server/src/routes/files.ts
+++ b/apps/server/src/routes/files.ts
@@ -300,12 +300,19 @@ app.get("/download", async (c) => {
       return c.json({ error: "invalid or expired ticket" }, 403);
     }
 
+    // Claim the ticket synchronously (before any await) so two concurrent
+    // GETs can't both pass the `record.used` check and both receive the file.
+    // If the subsequent file validation fails we undo the claim so the user
+    // can retry with the same ticket.
+    record.used = true;
+
     const file = await getDownloadableFile(record.path);
     if (!file.ok) {
+      // Undo claim on file-not-available so the caller can retry.
+      record.used = false;
       return c.json({ error: file.error }, file.status);
     }
 
-    record.used = true;
     return createDownloadResponse(file);
   }
 

--- a/apps/server/src/routes/files.ts
+++ b/apps/server/src/routes/files.ts
@@ -22,6 +22,7 @@ const app = new Hono();
 const BASE_DIR = process.env.FILES_BASE_DIR || "/home/claude/claudes-world";
 const DOWNLOAD_MAX_BYTES = 50 * 1024 * 1024;
 const UPLOAD_BODY_LIMIT = 50 * 1024 * 1024;
+const UPLOAD_BODY_LIMIT_MB = UPLOAD_BODY_LIMIT / (1024 * 1024);
 const DOWNLOAD_TICKET_TTL_MS = 60 * 1000;
 
 type DownloadTicket = {
@@ -404,7 +405,7 @@ app.post(
     maxSize: UPLOAD_BODY_LIMIT,
     onError: (c) =>
       c.json(
-        { error: "Request body too large (max 50MB)" },
+        { error: `Request body too large (max ${UPLOAD_BODY_LIMIT_MB}MB)` },
         413,
       ),
   }),
@@ -423,17 +424,13 @@ app.post(
   }
 
   try {
-    // Strip any directory components from the user-supplied filename so a
-    // value like "../../etc/passwd" cannot escape the validated `resolved`
-    // directory via path.join. basename() returns just the trailing segment.
-    let fileName = basename((file as File).name || "uploaded-file");
-    // basename() returns `.`, `..`, or `""` unchanged, which path.join would
-    // then normalize into the parent/current directory. Reject those and
-    // fall back to the default name so the upload always writes a new file
-    // inside the validated root.
-    if (fileName === "" || fileName === "." || fileName === "..") {
-      fileName = "uploaded-file";
-    }
+    // Strip directory components then run through sanitizeFilename() which
+    // additionally rejects control characters, null bytes, reserved Windows
+    // names, and other dangerous patterns. basename() is applied first so
+    // sanitizeFilename() never sees a slash-separated path.
+    const rawName = basename((file as File).name || "uploaded-file");
+    const sanitized = sanitizeFilename(rawName);
+    let fileName = sanitized ?? "uploaded-file";
     const arrayBuffer = await (file as File).arrayBuffer();
     const data = Buffer.from(arrayBuffer);
 
@@ -444,6 +441,20 @@ app.post(
     //     outside the allowed root would trick the write into landing outside
     //     ALLOWED_ROOTS).
     //
+    // Verify the target directory exists before attempting writes. If it
+    // doesn't, open() would throw ENOENT which would surface as a generic 500.
+    try {
+      const dirStat = await stat(resolved);
+      if (!dirStat.isDirectory()) {
+        return c.json({ error: "Target path is not a directory" }, 400);
+      }
+    } catch (err: any) {
+      if (err && err.code === "ENOENT") {
+        return c.json({ error: "Target directory does not exist" }, 404);
+      }
+      throw err;
+    }
+
     // Try the chosen filename, then incrementing suffixes until O_EXCL
     // succeeds or we give up.
     const dotIdx = fileName.lastIndexOf(".");

--- a/apps/server/src/routes/files.ts
+++ b/apps/server/src/routes/files.ts
@@ -7,7 +7,6 @@ import {
   readFile,
   stat,
   unlink,
-  writeFile,
 } from "node:fs/promises";
 import { createReadStream } from "node:fs";
 import { basename, join, resolve, sep } from "node:path";
@@ -22,6 +21,7 @@ const app = new Hono();
 
 const BASE_DIR = process.env.FILES_BASE_DIR || "/home/claude/claudes-world";
 const DOWNLOAD_MAX_BYTES = 50 * 1024 * 1024;
+const UPLOAD_BODY_LIMIT = 50 * 1024 * 1024;
 const DOWNLOAD_TICKET_TTL_MS = 60 * 1000;
 
 type DownloadTicket = {
@@ -398,7 +398,17 @@ app.get("/search", async (c) => {
 });
 
 // Upload file to current directory
-app.post("/upload", async (c) => {
+app.post(
+  "/upload",
+  bodyLimit({
+    maxSize: UPLOAD_BODY_LIMIT,
+    onError: (c) =>
+      c.json(
+        { error: "Request body too large (max 50MB)" },
+        413,
+      ),
+  }),
+  async (c) => {
   const body = await c.req.parseBody();
   const file = body["file"];
   const dir = (body["dir"] as string) || BASE_DIR;
@@ -424,35 +434,80 @@ app.post("/upload", async (c) => {
     if (fileName === "" || fileName === "." || fileName === "..") {
       fileName = "uploaded-file";
     }
-    const destPath = join(resolved, fileName);
-
-    // Don't overwrite existing files — add suffix
-    let finalPath = destPath;
-    let counter = 1;
-    try {
-      while (await stat(finalPath)) {
-        const ext = fileName.includes(".") ? "." + fileName.split(".").pop() : "";
-        const base = fileName.includes(".") ? fileName.slice(0, fileName.lastIndexOf(".")) : fileName;
-        finalPath = join(resolved, `${base}-${counter}${ext}`);
-        counter++;
-      }
-    } catch {
-      // File doesn't exist — good, use this path
-    }
-
     const arrayBuffer = await (file as File).arrayBuffer();
-    await writeFile(finalPath, Buffer.from(arrayBuffer));
+    const data = Buffer.from(arrayBuffer);
+
+    // Atomic exclusive create with O_NOFOLLOW to defeat both:
+    // (a) TOCTOU race (stat-then-write where two concurrent uploads pick the
+    //     same suffix), and
+    // (b) symlink-redirected writes (a symlink inside an allowed dir pointing
+    //     outside the allowed root would trick the write into landing outside
+    //     ALLOWED_ROOTS).
+    //
+    // Try the chosen filename, then incrementing suffixes until O_EXCL
+    // succeeds or we give up.
+    const dotIdx = fileName.lastIndexOf(".");
+    const hasExt = dotIdx > 0;
+    const base = hasExt ? fileName.slice(0, dotIdx) : fileName;
+    const ext = hasExt ? fileName.slice(dotIdx) : "";
+
+    let finalPath = "";
+    for (let counter = 0; counter <= 9999; counter++) {
+      const candidate =
+        counter === 0
+          ? join(resolved, fileName)
+          : join(resolved, `${base}-${counter}${ext}`);
+      let opened = false;
+      try {
+        const handle = await open(
+          candidate,
+          fsConstants.O_WRONLY |
+            fsConstants.O_CREAT |
+            fsConstants.O_EXCL |
+            fsConstants.O_NOFOLLOW,
+          0o644,
+        );
+        opened = true;
+        try {
+          await handle.writeFile(data);
+        } finally {
+          await handle.close();
+        }
+        finalPath = candidate;
+        break;
+      } catch (err: any) {
+        if (err && err.code === "EEXIST") continue;
+        if (err && (err.code === "ELOOP" || err.code === "EMLINK")) {
+          return c.json(
+            { error: "Refusing to write through symlink" },
+            403,
+          );
+        }
+        if (opened) {
+          try {
+            await unlink(candidate);
+          } catch {
+            // ignore — already gone or unlink not allowed
+          }
+        }
+        throw err;
+      }
+    }
+    if (!finalPath) {
+      throw new Error("Could not find available filename");
+    }
 
     return c.json({
       ok: true,
-      path: finalPath,
-      name: finalPath.split("/").pop(),
+      name: basename(finalPath),
       size: arrayBuffer.byteLength,
     });
   } catch (err: any) {
-    return c.json({ error: err.message }, 500);
+    console.error("[files/upload] write error:", err);
+    return c.json({ error: "Failed to write file" }, 500);
   }
-});
+  },
+);
 
 // Paste text content into the current directory as a new file.
 // JSON body: { filename: string, content: string, dir: string }

--- a/apps/server/src/routes/files.ts
+++ b/apps/server/src/routes/files.ts
@@ -300,12 +300,12 @@ app.get("/download", async (c) => {
       return c.json({ error: "invalid or expired ticket" }, 403);
     }
 
-    record.used = true;
     const file = await getDownloadableFile(record.path);
     if (!file.ok) {
       return c.json({ error: file.error }, file.status);
     }
 
+    record.used = true;
     return createDownloadResponse(file);
   }
 

--- a/apps/server/src/routes/terminal-ws.ts
+++ b/apps/server/src/routes/terminal-ws.ts
@@ -40,6 +40,8 @@ export function terminalWsRoute(c: any) {
         const allowed = getAllowedUsers();
         if (allowed.size === 0 || allowed.has(String(user.id))) {
           authResult = { ok: true, user };
+        } else {
+          authResult = { ok: false, error: "User not in allowlist" };
         }
       }
 

--- a/apps/server/src/routes/terminal-ws.ts
+++ b/apps/server/src/routes/terminal-ws.ts
@@ -37,7 +37,10 @@ export function terminalWsRoute(c: any) {
     if (token) {
       const { valid, user } = validateSession(token);
       if (valid && user) {
-        authResult = { ok: true, user };
+        const allowed = getAllowedUsers();
+        if (allowed.size === 0 || allowed.has(String(user.id))) {
+          authResult = { ok: true, user };
+        }
       }
 
       // Fallback: JWT token validation (keyboard button auth)

--- a/apps/server/src/routes/terminal-ws.ts
+++ b/apps/server/src/routes/terminal-ws.ts
@@ -7,6 +7,7 @@ import { checkAuth, validateSession, validateJwtToken, getAllowedUsers } from ".
 // execSync call below vulnerable to env-var shell injection. Flagged
 // security-high by cloud Gemini Code Assist on round-2 review of PR #85.
 import { TMUX_SESSION } from "./utils.js";
+import { ALLOWED_ORIGINS } from "../lib/allowed-origins.js";
 
 function getPaneDimensions(): { cols: number; rows: number } {
   try {
@@ -27,6 +28,20 @@ function getPaneDimensions(): { cols: number; rows: number } {
 // The mini app adapts to whatever tmux size exists via -J (join wrapped lines).
 
 export function terminalWsRoute(c: any) {
+  // Origin check: WebSocket upgrades bypass Hono's cors() middleware, so we
+  // validate the Origin header explicitly here. Close with 4003 (policy
+  // violation) if the origin is not in the allowlist.
+  // NOTE: c.req.header() may return undefined for missing headers.
+  const origin = c.req.header("origin") ?? "";
+  if (!ALLOWED_ORIGINS.includes(origin)) {
+    console.log(`[ws] rejected: disallowed origin "${origin}"`);
+    return {
+      onOpen(_event: Event, ws: WSContext) {
+        ws.close(4003, "Forbidden origin");
+      },
+    };
+  }
+
   // Auth check: initData or session token passed as query param
   const initData = c.req.query("auth") || "";
   let authResult = checkAuth(initData);

--- a/apps/web/src/components/Terminal.tsx
+++ b/apps/web/src/components/Terminal.tsx
@@ -159,9 +159,8 @@ export function Terminal({ onConnectionChange }: TerminalProps) {
           position: "absolute",
           inset: 0,
           zIndex: 10,
+          pointerEvents: "none",
         }}
-        onTouchStart={(e) => e.preventDefault()}
-        onClick={(e) => e.preventDefault()}
       />
       <style>{`
         .xterm textarea { pointer-events: none !important; }

--- a/apps/web/src/components/Terminal.tsx
+++ b/apps/web/src/components/Terminal.tsx
@@ -159,7 +159,7 @@ export function Terminal({ onConnectionChange }: TerminalProps) {
           position: "absolute",
           inset: 0,
           zIndex: 10,
-          pointerEvents: "none",
+          touchAction: "none",
         }}
       />
       <style>{`

--- a/apps/web/src/debug/DebugOverlay.tsx
+++ b/apps/web/src/debug/DebugOverlay.tsx
@@ -122,6 +122,10 @@ export function DebugOverlay() {
   if (!isDevHost()) return null;
   if (!isCaptureInstalled()) return null;
 
+  return <DebugOverlayInner />;
+}
+
+function DebugOverlayInner() {
   const [isOpen, setIsOpen] = useState(false);
   const [filter, setFilter] = useState("");
 


### PR DESCRIPTION
## Summary

Consolidated fix PR for 7 issues identified by the Opus 6-agent swarm review (PR #164) and cloud reviewer feedback on PR #159. Each fix went through the local 3-tier review swarm (Claude + Codex + Gemini) with fix rounds until clean.

### Fixes included
- **#162** — WS terminal session-token auth now enforces allowlist
- **#165** — Terminal overlay uses `touch-action: none` instead of `preventDefault` on touchstart
- **#168** — DebugOverlay split into wrapper + inner to fix Rules of Hooks violation
- **#170** — Audio `/check` validates source `.md` path + adds extension gate + symlink oracle guard
- **#171** — Download ticket uses compare-and-swap (claim before async, undo on failure)
- **#169** — CORS restricted to known origins + WS Origin validation + shared `ALLOWED_ORIGINS` constant
- **#166** — Upload route: bodyLimit(50MB) + O_EXCL/O_NOFOLLOW atomic writes + sanitizeFilename

### Integration fix
- **terminal-ws-auth.test.ts** — Added `header()` mock to test context so the WS allowlist test (PR #163) works alongside the CORS origin check (PR #179). The two PRs were developed independently on `dev` and the mock needed updating for the merged code.

### Review process
All fixes reviewed by local Codex + Gemini flash. Cloud reviewers (Copilot + Gemini Code Assist) triggered on individual PRs; findings addressed in fix rounds.

## Test plan
- [ ] All 199 unit tests pass (127 server + 72 web)
- [ ] Server typecheck clean
- [ ] Manual smoke test of CPC in Telegram WebView
- [ ] Verify terminal overlay blocks keyboard without breaking swipe
- [ ] Verify file upload with bodyLimit
- [ ] Verify CORS headers on cross-origin requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)