### PR TITLE
fix(file-viewer): ref-based download race guard (#173)

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -153,13 +153,16 @@ export function FileViewer({ onClose, initialFile, showHidden = false, sortMode 
   // changes don't clobber their edits once they've taken control.
   const pasteFilenameEditedRef = useRef(false);
   const pasteTextareaRef = useRef<HTMLTextAreaElement>(null);
+  const downloadInFlightRef = useRef(false);
 
   const handleDownload = async () => {
-    if (!filePath || !fileName || downloading) return;
+    if (!filePath || !fileName || downloadInFlightRef.current) return;
+    downloadInFlightRef.current = true;
     setError(null);
 
     const downloadWindow = window.open("about:blank", "_blank");
     if (!downloadWindow) {
+      downloadInFlightRef.current = false;
       setError("Download blocked by browser. Allow popups for this site.");
       return;
     }
@@ -201,6 +204,7 @@ export function FileViewer({ onClose, initialFile, showHidden = false, sortMode 
       downloadWindow.close();
       setError(err instanceof Error ? err.message : "Download failed");
     } finally {
+      downloadInFlightRef.current = false;
       setDownloading(false);
     }
   };


### PR DESCRIPTION
## Summary

- Adds `downloadInFlightRef` (synchronous `useRef` guard) to `handleDownload` in `FileViewer.tsx`, preventing duplicate download requests from rapid double-taps
- Matches the proven `inFlightRef` pattern already used in `TldrModal.tsx`
- Keeps `setDownloading` state for UI spinner — the ref is purely the synchronous race lock
- Also resets the ref on the early-return popup-blocked path to avoid permanently locking out downloads

Closes #173

## Test plan

- [x] `pnpm run test:unit` — 199 tests pass (127 server + 72 web)
- [x] TypeScript typecheck clean (`tsc --noEmit`)
- [ ] Manual: open FileViewer, rapid-tap download button — only one popup + ticket request should fire

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>