### PR TITLE
fix(error-boundary): handle non-Error throws + wire level prop

### DIFF
--- a/apps/web/src/components/ErrorBoundary.tsx
+++ b/apps/web/src/components/ErrorBoundary.tsx
@@ -19,8 +19,8 @@ interface ErrorBoundaryState {
 export class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundaryState> {
   state: ErrorBoundaryState = { error: null, resetKey: 0 };
 
-  static getDerivedStateFromError(error: Error): Partial<ErrorBoundaryState> {
-    return { error };
+  static getDerivedStateFromError(error: unknown): Partial<ErrorBoundaryState> {
+    return { error: error instanceof Error ? error : new Error(String(error)) };
   }
 
   componentDidCatch(error: Error, info: React.ErrorInfo) {
@@ -66,6 +66,7 @@ export class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoun
       return (
         <ErrorFallback
           error={this.state.error}
+          level={this.props.level ?? "root"}
           onRetry={this.reset}
           onReload={() => window.location.reload()}
         />
@@ -78,18 +79,19 @@ export class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoun
 
 interface ErrorFallbackProps {
   error: Error;
+  level: ErrorBoundaryLevel;
   onRetry: () => void;
   onReload: () => void;
 }
 
-function ErrorFallback({ error, onRetry, onReload }: ErrorFallbackProps) {
+function ErrorFallback({ error, level, onRetry, onReload }: ErrorFallbackProps) {
   // Tokyo Night palette to match the rest of CPC.
   // bg #1a1b26, fg #c0caf5, error accent #f7768e, muted #565f89, action blue #7aa2f7
   return (
     <div
       role="alert"
       style={{
-        minHeight: "100dvh",
+        minHeight: level === "tab" ? "100%" : "100dvh",
         width: "100%",
         background: "#1a1b26",
         color: "#c0caf5",


### PR DESCRIPTION
## Summary

- `getDerivedStateFromError` now accepts `unknown` and normalizes non-Error throws (strings, numbers, objects) into proper `Error` instances, preventing crashes when third-party code throws primitives
- Wires the existing `level` prop through to `ErrorFallback`: `"root"` (default) renders full-screen `100dvh`, `"tab"` scopes to `100%` so the fallback fits inside tab containers

Closes #29

## Test plan

- [x] `pnpm run test:unit` passes (199 tests, 0 failures)
- [ ] Manual: wrap a component that throws a string in `<ErrorBoundary>` — should render fallback without console type errors
- [ ] Manual: `<ErrorBoundary level="tab">` renders fallback scoped to its container, not full viewport

Generated with [Claude Code](https://claude.com/claude-code)