### PR TITLE
chore(types): replace any prop signatures with ExtraProps in markdown components

### DIFF
--- a/apps/web/src/components/MarkdownViewer.tsx
+++ b/apps/web/src/components/MarkdownViewer.tsx
@@ -1,5 +1,5 @@
 import React, { Children, isValidElement, useState, useCallback, useMemo, useRef, type ReactNode } from "react";
-import ReactMarkdown, { type Components } from "react-markdown";
+import ReactMarkdown, { type Components, type ExtraProps } from "react-markdown";
 import remarkGfm from "remark-gfm";
 import remarkBreaks from "remark-breaks";
 import rehypeSlug from "rehype-slug";
@@ -40,7 +40,7 @@ function getTextContent(children: ReactNode): string {
     .join("");
 }
 
-function CodeBlock({ className, children, node: _node, ...props }: React.ComponentPropsWithoutRef<'code'> & { node?: any; className?: string }) {
+function CodeBlock({ className, children, node: _node, ...props }: React.ComponentPropsWithoutRef<'code'> & ExtraProps) {
   const language = getLanguage(className);
 
   if (language === "mermaid") {
@@ -58,7 +58,7 @@ function CodeBlock({ className, children, node: _node, ...props }: React.Compone
   );
 }
 
-function ScrollableTable({ children, node: _node, ...props }: React.ComponentPropsWithoutRef<'table'> & { node?: any }) {
+function ScrollableTable({ children, node: _node, ...props }: React.ComponentPropsWithoutRef<'table'> & ExtraProps) {
   return (
     <div className="md-table-scroll">
       <table {...props}>{children}</table>
@@ -73,7 +73,7 @@ function isMermaidCodeChild(child: ReactNode): boolean {
   );
 }
 
-function PreBlock({ children, node: _node, ...props }: React.ComponentPropsWithoutRef<'pre'> & { node?: any }) {
+function PreBlock({ children, node: _node, ...props }: React.ComponentPropsWithoutRef<'pre'> & ExtraProps) {
   const childArray = Children.toArray(children);
 
   if (childArray.length === 1 && isMermaidCodeChild(childArray[0])) {
@@ -176,7 +176,7 @@ export function MarkdownViewer({ content, fileName: _fileName }: MarkdownViewerP
     return {
       ...baseComponents,
       ...headingComponents,
-      section: ({ node: _node, children, ...props }: any) => {
+      section: ({ node: _node, children, ...props }: React.ComponentPropsWithoutRef<'section'> & ExtraProps & { "data-fold-slug"?: string }) => {
         const slug = props["data-fold-slug"] as string | undefined;
         if (!slug) return <section {...props}>{children}</section>;
         // Compute effective-hidden inline using collected headings.

--- a/apps/web/src/components/markdown/CollapsibleHeading.tsx
+++ b/apps/web/src/components/markdown/CollapsibleHeading.tsx
@@ -18,7 +18,8 @@
  *  - aria-controls points to the section element's id
  *  - Enter/Space activate the button natively
  */
-import { type ReactNode, type MutableRefObject, useCallback } from "react";
+import React, { type MutableRefObject, useCallback } from "react";
+import type { ExtraProps } from "react-markdown";
 
 export interface HeadingEntry {
   slug: string;
@@ -34,12 +35,7 @@ export interface FoldControls {
   registerHeading: (entry: HeadingEntry) => void;
 }
 
-interface HeadingProps {
-  node?: any;
-  children?: ReactNode;
-  id?: string;
-  [key: string]: any;
-}
+type HeadingProps = React.ComponentPropsWithoutRef<'h1'> & ExtraProps & { "data-has-section"?: string };
 
 // Heading level from tag name (e.g. "h2" → 2)
 function tagLevel(tag: string): number {


### PR DESCRIPTION
## Summary
- Replace `{ node?: any }` and `{ node?: any; [key: string]: any }` prop signatures with `react-markdown`'s `ExtraProps` type across `MarkdownViewer.tsx` and `CollapsibleHeading.tsx`
- Add explicit data-attribute types (`data-fold-slug`, `data-has-section`) where components access custom rehype-injected attributes
- Remove unused `ReactNode` import from `CollapsibleHeading.tsx`

Closes #139

## Test plan
- [x] `pnpm run test:unit` — all 199 tests pass (72 web + 127 server)
- [x] `tsc --noEmit` — zero type errors in both apps/web and apps/server

🤖 Generated with [Claude Code](https://claude.com/claude-code)