### PR TITLE
chore(security): consolidate ALLOWED_ROOTS to single source (#155)

### DIFF
--- a/apps/server/src/lib/path-allowed.ts
+++ b/apps/server/src/lib/path-allowed.ts
@@ -70,7 +70,7 @@ export function __resetRealRootCacheForTests(): void {
 
 export async function isPathAllowed(
   absPath: string,
-  allowedRoots: string[],
+  allowedRoots: readonly string[],
 ): Promise<boolean> {
   let realCandidate: string;
   try {

--- a/apps/server/src/routes/audio.ts
+++ b/apps/server/src/routes/audio.ts
@@ -4,26 +4,18 @@ import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { resolve } from "node:path";
 import { loadOpenAIEnv, getTelegramCreds } from "./utils.js";
-import { isPathAllowed as isPathAllowedShared } from "../lib/path-allowed.js";
+import {
+  ALLOWED_FILE_ROOTS,
+  isPathAllowed as isPathAllowedShared,
+} from "../lib/path-allowed.js";
 
 const execFileAsync = promisify(execFile);
 
 // Load OpenAI env on module init
 loadOpenAIEnv();
 
-// Allowed root directories for any user-supplied path reaching this route.
-// Kept in sync with files.ts / markdown.ts / terminal/git.ts until S-1 lands a
-// shared `lib/allowed-roots.ts`. See `plans/review/20260411-cpc-presrelease-swarm-review.md`.
-const ALLOWED_ROOTS = [
-  "/home/claude/claudes-world",
-  "/home/claude/code",
-  "/home/claude/bin",
-  "/home/claude/.claude",
-  "/home/claude/claudes-world/.claude",
-];
-
 function isPathAllowed(absPath: string): Promise<boolean> {
-  return isPathAllowedShared(absPath, ALLOWED_ROOTS);
+  return isPathAllowedShared(absPath, ALLOWED_FILE_ROOTS);
 }
 
 const app = new Hono();

--- a/apps/server/src/routes/files.ts
+++ b/apps/server/src/routes/files.ts
@@ -33,8 +33,9 @@ type DownloadTicket = {
 
 const downloadTickets = new Map<string, DownloadTicket>();
 
-// Allowed root directories the file viewer can access
-const ALLOWED_ROOTS = [...ALLOWED_FILE_ROOTS];
+// Allowed root directories the file viewer can access — canonical list lives
+// in path-allowed.ts; used directly here (no spread copy needed).
+const ALLOWED_ROOTS = ALLOWED_FILE_ROOTS;
 
 function isPathAllowed(absPath: string): Promise<boolean> {
   return isPathAllowedShared(absPath, ALLOWED_ROOTS);
@@ -344,7 +345,7 @@ app.get("/search", async (c) => {
   const q = qRaw;
 
   const scopeRaw = c.req.query("scope");
-  let roots: string[] = ALLOWED_ROOTS;
+  let roots: readonly string[] = ALLOWED_ROOTS;
   if (scopeRaw) {
     const scopeResolved = resolve(scopeRaw);
     // Reject scopes that aren't inside an allowed root. Same check as every

--- a/apps/server/src/routes/markdown.ts
+++ b/apps/server/src/routes/markdown.ts
@@ -5,23 +5,15 @@ import { resolve } from "node:path";
 import { createHash, randomBytes } from "node:crypto";
 import { spawn } from "node:child_process";
 import { db } from "../db.js";
-import { isPathAllowed as isPathAllowedShared } from "../lib/path-allowed.js";
+import {
+  ALLOWED_FILE_ROOTS,
+  isPathAllowed as isPathAllowedShared,
+} from "../lib/path-allowed.js";
 
 const app = new Hono();
 
-// Allowed root directories — kept in sync with files.ts. Uses the shared
-// hardened helper from apps/server/src/lib/path-allowed.ts (added in PR #62)
-// which enforces a separator boundary and resolves symlinks via realpath.
-const ALLOWED_ROOTS = [
-  "/home/claude/claudes-world",
-  "/home/claude/code",
-  "/home/claude/bin",
-  "/home/claude/.claude",
-  "/home/claude/claudes-world/.claude",
-];
-
 function isPathAllowed(absPath: string): Promise<boolean> {
-  return isPathAllowedShared(absPath, ALLOWED_ROOTS);
+  return isPathAllowedShared(absPath, ALLOWED_FILE_ROOTS);
 }
 
 // Env vars are read LAZILY (via getters) instead of snapshotted at module

--- a/apps/server/src/routes/reading-list.ts
+++ b/apps/server/src/routes/reading-list.ts
@@ -6,8 +6,6 @@ import { ALLOWED_FILE_ROOTS, isPathAllowed } from "../lib/path-allowed.js";
 
 const app = new Hono();
 
-const ALLOWED_ROOTS = [...ALLOWED_FILE_ROOTS];
-
 function normalizePath(input: string): string {
   const trimmed = input.trim();
   if (!trimmed.startsWith("/")) {
@@ -37,7 +35,7 @@ app.post("/save", async (c) => {
 
   const normalizedPath = normalizePath(path);
 
-  if (!(await isPathAllowed(normalizedPath, ALLOWED_ROOTS))) {
+  if (!(await isPathAllowed(normalizedPath, ALLOWED_FILE_ROOTS))) {
     return c.json({ error: "Access denied" }, 403);
   }
 


### PR DESCRIPTION
## Summary

- Remove duplicate inline `ALLOWED_ROOTS` arrays from `markdown.ts` and `audio.ts`, replacing them with the canonical `ALLOWED_FILE_ROOTS` export from `path-allowed.ts`
- In `files.ts`, use `ALLOWED_FILE_ROOTS` directly instead of spreading into a mutable copy
- Widen `isPathAllowed`'s `allowedRoots` parameter from `string[]` to `readonly string[]` since it only iterates, never mutates

Closes #155

## Test plan

- [x] `pnpm run typecheck` passes clean
- [x] All 199 unit tests pass (127 server + 72 web)
- [ ] Verify file browser, markdown summarizer, and audio routes still work in the mini app

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>