### PR TITLE
fix(reading-list): use queries() for multi-path params + reject relative paths

### DIFF
--- a/apps/server/src/routes/__tests__/reading-list.test.ts
+++ b/apps/server/src/routes/__tests__/reading-list.test.ts
@@ -121,23 +121,17 @@ describe("POST /save", () => {
 
 
 
-  it("normalizes equivalent path variants to one record", async () => {
-    await req("POST", "/save", {
+  it("stores paths with ../ literally (no resolve)", async () => {
+    const res = await req("POST", "/save", {
       path: "/home/claude/code/folder/../file.ts",
-      title: "First",
+      title: "With dot-dot",
     });
-
-    await req("POST", "/save", {
-      path: "/home/claude/code/file.ts",
-      title: "Second",
-    });
-
-    const rows = testDb.prepare(
-      "SELECT * FROM reading_list WHERE user_id = ? AND path = ?"
-    ).all("test-user-123", "/home/claude/code/file.ts");
-
-    expect(rows.length).toBe(1);
-    expect((rows[0] as any).title).toBe("Second");
+    expect(res.status).toBe(200);
+    const row = testDb.prepare(
+      "SELECT path, title FROM reading_list WHERE user_id = ?"
+    ).get("test-user-123") as any;
+    expect(row.path).toBe("/home/claude/code/folder/../file.ts");
+    expect(row.title).toBe("With dot-dot");
   });
 
   it("bumps created_at on re-save so the item moves to the top of /list", async () => {
@@ -277,7 +271,7 @@ describe("GET /check", () => {
 
     const res = await req(
       "GET",
-      "/check?paths=/home/claude/code/saved.ts,/home/claude/code/not-saved.ts"
+      "/check?paths=/home/claude/code/saved.ts&paths=/home/claude/code/not-saved.ts"
     );
     expect(res.status).toBe(200);
     const body = await res.json();
@@ -287,42 +281,33 @@ describe("GET /check", () => {
 
 
 
-  it("normalizes incoming paths before checking (response keyed by original input)", async () => {
+  it("does not resolve ../ segments (paths are literal after trim)", async () => {
     testDb.prepare(
       "INSERT INTO reading_list (user_id, path, title) VALUES (?, ?, ?)"
     ).run("test-user-123", "/home/claude/code/saved.ts", "Saved");
-
     const res = await req(
       "GET",
       "/check?paths=/home/claude/code/dir/../saved.ts"
     );
     expect(res.status).toBe(200);
     const body = await res.json();
-    // Response is keyed by the EXACT input string, not the normalized form,
-    // so clients can look up results using the paths they sent.
-    expect(body.saved["/home/claude/code/dir/../saved.ts"]).toBe(true);
-    expect(body.saved["/home/claude/code/saved.ts"]).toBeUndefined();
+    expect(body.saved["/home/claude/code/dir/../saved.ts"]).toBe(false);
   });
 
-  it("trims whitespace from comma-separated paths before normalization", async () => {
+  it("trims whitespace from repeated paths params", async () => {
     testDb.prepare(
       "INSERT INTO reading_list (user_id, path, title) VALUES (?, ?, ?)"
     ).run("test-user-123", "/home/claude/code/a.ts", "A");
     testDb.prepare(
       "INSERT INTO reading_list (user_id, path, title) VALUES (?, ?, ?)"
     ).run("test-user-123", "/home/claude/code/b.ts", "B");
-
-    // Note the leading spaces after the commas — these must be trimmed
-    // before path.resolve() runs, or they'd become CWD-relative paths.
     const res = await req(
       "GET",
-      "/check?paths=/home/claude/code/a.ts, /home/claude/code/b.ts",
+      "/check?paths= /home/claude/code/a.ts &paths= /home/claude/code/b.ts ",
     );
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.saved["/home/claude/code/a.ts"]).toBe(true);
-    // Response key is the trimmed form (trim is universal cleanup, not a
-    // path-semantic normalization), so clients see the clean string.
     expect(body.saved["/home/claude/code/b.ts"]).toBe(true);
   });
   it("returns empty map when no paths param", async () => {
@@ -333,8 +318,8 @@ describe("GET /check", () => {
   });
 
   it("rejects more than 256 paths with 413", async () => {
-    const paths = Array.from({ length: 257 }, (_, i) => `/home/claude/code/f${i}.ts`).join(",");
-    const res = await req("GET", `/check?paths=${paths}`);
+    const pathParams = Array.from({ length: 257 }, (_, i) => `paths=/home/claude/code/f${i}.ts`).join("&");
+    const res = await req("GET", `/check?${pathParams}`);
     expect(res.status).toBe(413);
   });
 
@@ -379,15 +364,12 @@ describe("POST /delete", () => {
 
 
 
-  it("normalizes path before deleting", async () => {
+  it("does not resolve ../ on delete (path is literal after trim)", async () => {
     testDb.prepare(
       "INSERT INTO reading_list (user_id, path, title) VALUES (?, ?, ?)"
     ).run("test-user-123", "/home/claude/code/norm.ts", "Norm");
-
     const res = await req("POST", "/delete", { path: "/home/claude/code/dir/../norm.ts" });
-    expect(res.status).toBe(200);
-    const body = await res.json();
-    expect(body.ok).toBe(true);
+    expect(res.status).toBe(404);
   });
 
   it("trims whitespace from path on /delete (prevents false 404)", async () => {

--- a/apps/server/src/routes/reading-list.ts
+++ b/apps/server/src/routes/reading-list.ts
@@ -1,5 +1,5 @@
 import { Hono } from "hono";
-import { basename, resolve } from "node:path";
+import { basename } from "node:path";
 import { db } from "../db.js";
 import { getUserId } from "../lib/get-user-id.js";
 import { ALLOWED_FILE_ROOTS, isPathAllowed } from "../lib/path-allowed.js";
@@ -8,13 +8,12 @@ const app = new Hono();
 
 const ALLOWED_ROOTS = [...ALLOWED_FILE_ROOTS];
 
-function normalizePath(path: string): string {
-  // Trim before resolve() — otherwise leading/trailing whitespace (e.g. from
-  // copy/paste) would make resolve() treat the input as a CWD-relative path
-  // segment, causing false 403s on /save and false 404s on /delete. /check
-  // also trims each segment upstream; doing it here is idempotent and keeps
-  // all endpoints consistent.
-  return resolve(path.trim());
+function normalizePath(input: string): string {
+  const trimmed = input.trim();
+  if (!trimmed.startsWith("/")) {
+    throw new Error(`Path must be absolute: ${trimmed}`);
+  }
+  return trimmed;
 }
 
 // POST /save — save a file to reading list (upsert)
@@ -94,20 +93,9 @@ app.get("/check", (c) => {
     return c.json({ error: "auth required" }, 401);
   }
 
-  const pathsParam = c.req.query("paths");
-  if (!pathsParam) {
-    return c.json({ saved: {} });
-  }
-
-  // Trim each segment first so `?paths=a, b` doesn't produce a path relative
-  // to CWD after normalization. The response is keyed by the *trimmed* input
-  // (universal cleanup, not a path-semantic normalization), so clients can
-  // look up results using essentially the paths they sent — just without the
-  // accidental whitespace.
+  const rawPaths = c.req.queries("paths") ?? [];
   const originalInputs = [
-    ...new Set(
-      pathsParam.split(",").map((p) => p.trim()).filter(Boolean),
-    ),
+    ...new Set(rawPaths.map((p) => p.trim()).filter(Boolean)),
   ];
   if (originalInputs.length === 0) {
     return c.json({ saved: {} });


### PR DESCRIPTION
Closes #174

## Summary
- **Comma-split fix:** `GET /check` now uses `c.req.queries("paths")` (repeated `?paths=a&paths=b` params) instead of splitting a single `paths` value on commas. Paths containing commas no longer break the batched-check endpoint.
- **CWD-dependent resolve fix:** `normalizePath()` no longer calls `path.resolve()`, which silently resolved relative paths against the server's CWD. It now rejects non-absolute paths with an error and returns the trimmed input as-is. The unused `resolve` import is removed.
- **Tests updated:** 6 tests adapted to match the new behavior (literal `../` storage, repeated query params, 404 on unresolved `../` delete).

## Test plan
- [x] `pnpm run typecheck` — clean
- [x] `pnpm run test:unit` — 127/127 server tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)