### PR TITLE
chore(perf): parse Vite manifest.json for Early Hints

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -103,7 +103,9 @@ try {
   const entry = Object.values(manifest).find((e: any) => e.isEntry) as any;
   if (entry) {
     if (entry.file) earlyHintsLinks.push(`</${entry.file}>; rel=preload; as=script; crossorigin`);
-    if (entry.css?.[0]) earlyHintsLinks.push(`</${entry.css[0]}>; rel=preload; as=style`);
+    for (const css of entry.css ?? []) {
+      earlyHintsLinks.push(`</${css}>; rel=preload; as=style`);
+    }
   }
   earlyHintsLinks.push("<https://telegram.org>; rel=preconnect");
 } catch (e: any) {

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -96,15 +96,18 @@ const webDistRoot = join(__dirname, "../../web/dist");
 
 const earlyHintsLinks: string[] = [];
 try {
-  const indexHtml = readFileSync(join(webDistRoot, "index.html"), "utf-8");
-  const js = indexHtml.match(/<script[^>]+src="(\/assets\/index-[^"]+\.js)"/);
-  const css = indexHtml.match(/<link[^>]+href="(\/assets\/index-[^"]+\.css)"/);
-
-  if (js) earlyHintsLinks.push(`<${js[1]}>; rel=preload; as=script; crossorigin`);
-  if (css) earlyHintsLinks.push(`<${css[1]}>; rel=preload; as=style`);
+  const manifestPath = join(webDistRoot, ".vite/manifest.json");
+  const manifest = JSON.parse(readFileSync(manifestPath, "utf-8"));
+  // Find the entry point (has isEntry: true)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const entry = Object.values(manifest).find((e: any) => e.isEntry) as any;
+  if (entry) {
+    if (entry.file) earlyHintsLinks.push(`</${entry.file}>; rel=preload; as=script; crossorigin`);
+    if (entry.css?.[0]) earlyHintsLinks.push(`</${entry.css[0]}>; rel=preload; as=style`);
+  }
   earlyHintsLinks.push("<https://telegram.org>; rel=preconnect");
 } catch (e: any) {
-  console.warn(`[earlyHints] Unable to read ${join(webDistRoot, "index.html")}: ${e.message}`);
+  console.warn(`[earlyHints] Unable to read manifest: ${e.message}`);
 }
 
 app.use("/*", async (c, next) => {

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -24,6 +24,7 @@ export default defineConfig(({ command }) => ({
     __APP_VERSION__: JSON.stringify(gitVersion),
   },
   build: {
+    manifest: true,
     // Kill the eager `<link rel="modulepreload">` hint Vite emits for the
     // mermaid chunk. Mermaid is dynamically imported inside MermaidDiagram.tsx
     // and only needed when a markdown file actually contains a diagram, but


### PR DESCRIPTION
## Summary
- Enable `manifest: true` in Vite build config to emit `.vite/manifest.json`
- Replace fragile regex parsing of `index.html` with structured manifest.json parsing for Early Hints asset extraction
- Server now reads the entry point's `file` and `css` fields from the manifest, which is stable across Vite versions and doesn't break if HTML structure changes

Closes #142

## Test plan
- [x] `pnpm run build` generates `.vite/manifest.json` with `isEntry: true` entry
- [x] `pnpm run typecheck` passes in `apps/server`
- [x] `pnpm run test:unit` passes (199/199 tests green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)