### PR TITLE
chore(auth): centralize allowlist check into isAllowedUser helper

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -8,7 +8,8 @@ import { serveStatic } from "@hono/node-server/serve-static";
 import { serve } from "@hono/node-server";
 import { createNodeWebSocket } from "@hono/node-ws";
 import { telegramAuth } from "./middleware.js";
-import { validateTelegramLoginWidget, createSession, getAllowedUsers } from "./auth.js";
+import { validateTelegramLoginWidget, createSession } from "./auth.js";
+import { isAllowedUser } from "./lib/allowed-users.js";
 import { ALLOWED_ORIGINS } from "./lib/allowed-origins.js";
 import { terminalRoute } from "./routes/terminal/index.js";
 import { sessionRoute } from "./routes/session.js";
@@ -64,8 +65,7 @@ app.post("/api/auth/telegram-widget", async (c) => {
   if (!valid || !user) return c.json({ error: "Invalid login" }, 401);
 
   // Check allowlist
-  const allowed = getAllowedUsers();
-  if (allowed.size > 0 && !allowed.has(String(user.id))) {
+  if (!isAllowedUser(user.id)) {
     return c.json({ error: "User not authorized" }, 403);
   }
 

--- a/apps/server/src/lib/allowed-users.ts
+++ b/apps/server/src/lib/allowed-users.ts
@@ -1,0 +1,11 @@
+import { getAllowedUsers } from "../auth.js";
+
+/**
+ * Check if a user ID is in the allowlist.
+ * Re-reads env on each call (matches existing getAllowedUsers behavior).
+ * Empty allowlist = all users allowed (dev convenience).
+ */
+export function isAllowedUser(userId: string | number): boolean {
+  const allowed = getAllowedUsers();
+  return allowed.size === 0 || allowed.has(String(userId));
+}

--- a/apps/server/src/lib/allowed-users.ts
+++ b/apps/server/src/lib/allowed-users.ts
@@ -5,7 +5,9 @@ import { getAllowedUsers } from "../auth.js";
  * Re-reads env on each call (matches existing getAllowedUsers behavior).
  * Empty allowlist = all users allowed (dev convenience).
  */
-export function isAllowedUser(userId: string | number): boolean {
+export function isAllowedUser(userId: string | number | undefined | null): boolean {
   const allowed = getAllowedUsers();
-  return allowed.size === 0 || allowed.has(String(userId));
+  if (allowed.size === 0) return true; // dev convenience: empty allowlist = open
+  if (userId == null) return false;    // no identity → block when allowlist is active
+  return allowed.has(String(userId));
 }

--- a/apps/server/src/middleware.ts
+++ b/apps/server/src/middleware.ts
@@ -1,5 +1,6 @@
 import type { Context, Next } from "hono";
-import { validateTelegramInitData, getAllowedUsers, validateSession, validateJwtToken } from "./auth.js";
+import { validateTelegramInitData, validateSession, validateJwtToken } from "./auth.js";
+import { isAllowedUser } from "./lib/allowed-users.js";
 
 /**
  * Middleware that validates Telegram Mini App auth.
@@ -31,14 +32,8 @@ export async function telegramAuth(c: Context, next: Next) {
       return c.json({ error: "Invalid Telegram auth" }, 401);
     }
 
-    const allowed = getAllowedUsers();
-    if (allowed.size > 0) {
-      if (!user) {
-        return c.json({ error: "User identification is required" }, 403);
-      }
-      if (!allowed.has(String(user.id))) {
-        return c.json({ error: "User not authorized" }, 403);
-      }
+    if (user && !isAllowedUser(user.id)) {
+      return c.json({ error: "User not authorized" }, 403);
     }
 
     if (user) {
@@ -56,14 +51,8 @@ export async function telegramAuth(c: Context, next: Next) {
     // Try session token first
     const sessionResult = validateSession(token);
     if (sessionResult.valid) {
-      const allowed = getAllowedUsers();
-      if (allowed.size > 0) {
-        if (!sessionResult.user) {
-          return c.json({ error: "User identification is required" }, 403);
-        }
-        if (!allowed.has(String(sessionResult.user.id))) {
-          return c.json({ error: "User not authorized" }, 403);
-        }
+      if (sessionResult.user && !isAllowedUser(sessionResult.user.id)) {
+        return c.json({ error: "User not authorized" }, 403);
       }
 
       if (sessionResult.user) {
@@ -77,11 +66,8 @@ export async function telegramAuth(c: Context, next: Next) {
     // Try JWT token validation (keyboard button auth)
     const jwtResult = validateJwtToken(token, botToken);
     if (jwtResult.valid) {
-      const allowed = getAllowedUsers();
-      if (allowed.size > 0) {
-        if (!jwtResult.user || !allowed.has(String(jwtResult.user.id))) {
-          return c.json({ error: "User not authorized" }, 403);
-        }
+      if (jwtResult.user && !isAllowedUser(jwtResult.user.id)) {
+        return c.json({ error: "User not authorized" }, 403);
       }
 
       if (jwtResult.user) {
@@ -100,11 +86,8 @@ export async function telegramAuth(c: Context, next: Next) {
   if (urlToken) {
     const { valid, user } = validateJwtToken(urlToken, botToken);
     if (valid) {
-      const allowed = getAllowedUsers();
-      if (allowed.size > 0) {
-        if (!user || !allowed.has(String(user.id))) {
-          return c.json({ error: "User not authorized" }, 403);
-        }
+      if (user && !isAllowedUser(user.id)) {
+        return c.json({ error: "User not authorized" }, 403);
       }
 
       if (user) {

--- a/apps/server/src/middleware.ts
+++ b/apps/server/src/middleware.ts
@@ -32,7 +32,7 @@ export async function telegramAuth(c: Context, next: Next) {
       return c.json({ error: "Invalid Telegram auth" }, 401);
     }
 
-    if (user && !isAllowedUser(user.id)) {
+    if (!isAllowedUser(user?.id)) {
       return c.json({ error: "User not authorized" }, 403);
     }
 
@@ -51,7 +51,7 @@ export async function telegramAuth(c: Context, next: Next) {
     // Try session token first
     const sessionResult = validateSession(token);
     if (sessionResult.valid) {
-      if (sessionResult.user && !isAllowedUser(sessionResult.user.id)) {
+      if (!isAllowedUser(sessionResult.user?.id)) {
         return c.json({ error: "User not authorized" }, 403);
       }
 
@@ -66,7 +66,7 @@ export async function telegramAuth(c: Context, next: Next) {
     // Try JWT token validation (keyboard button auth)
     const jwtResult = validateJwtToken(token, botToken);
     if (jwtResult.valid) {
-      if (jwtResult.user && !isAllowedUser(jwtResult.user.id)) {
+      if (!isAllowedUser(jwtResult.user?.id)) {
         return c.json({ error: "User not authorized" }, 403);
       }
 
@@ -86,7 +86,7 @@ export async function telegramAuth(c: Context, next: Next) {
   if (urlToken) {
     const { valid, user } = validateJwtToken(urlToken, botToken);
     if (valid) {
-      if (user && !isAllowedUser(user.id)) {
+      if (!isAllowedUser(user?.id)) {
         return c.json({ error: "User not authorized" }, 403);
       }
 

--- a/apps/server/src/routes/terminal-ws.ts
+++ b/apps/server/src/routes/terminal-ws.ts
@@ -1,6 +1,7 @@
 import { spawn, execSync } from "node:child_process";
 import type { WSContext } from "hono/ws";
-import { checkAuth, validateSession, validateJwtToken, getAllowedUsers } from "../auth.js";
+import { checkAuth, validateSession, validateJwtToken } from "../auth.js";
+import { isAllowedUser } from "../lib/allowed-users.js";
 // Import the validated TMUX_SESSION from routes/utils so we inherit the
 // `/^[A-Za-z0-9_.-]+$/` character-set check that runs once at module load.
 // Keeping a local unvalidated copy would bypass that fence and leave the
@@ -52,8 +53,7 @@ export function terminalWsRoute(c: any) {
     if (token) {
       const { valid, user } = validateSession(token);
       if (valid && user) {
-        const allowed = getAllowedUsers();
-        if (allowed.size === 0 || allowed.has(String(user.id))) {
+        if (isAllowedUser(user.id)) {
           authResult = { ok: true, user };
         } else {
           authResult = { ok: false, error: "User not in allowlist" };
@@ -66,8 +66,7 @@ export function terminalWsRoute(c: any) {
         if (botToken) {
           const { valid: jwtValid, user: jwtUser } = validateJwtToken(token, botToken);
           if (jwtValid && jwtUser) {
-            const allowed = getAllowedUsers();
-            if (allowed.size === 0 || allowed.has(String(jwtUser.id))) {
+            if (isAllowedUser(jwtUser.id)) {
               authResult = { ok: true, user: jwtUser };
             }
           }


### PR DESCRIPTION
## Summary
- Creates `apps/server/src/lib/allowed-users.ts` with a lazy `isAllowedUser(userId)` predicate that wraps `getAllowedUsers()` from auth.ts
- Replaces 6 inline allowlist check blocks (3-5 lines each) across `middleware.ts`, `terminal-ws.ts`, and `index.ts` with single-line `isAllowedUser()` calls
- Preserves lazy per-call env reading (no import-time parsing) to respect `loadEnv()` lifecycle

Closes #156

## Test plan
- [x] `pnpm run typecheck` passes clean
- [x] All 127 server tests pass (including `terminal-ws-auth.test.ts` allowlist tests)
- [x] All 72 web tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)