### PR TITLE
release: v1.10.1 quality + security fixes

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -8,7 +8,8 @@ import { serveStatic } from "@hono/node-server/serve-static";
 import { serve } from "@hono/node-server";
 import { createNodeWebSocket } from "@hono/node-ws";
 import { telegramAuth } from "./middleware.js";
-import { validateTelegramLoginWidget, createSession, getAllowedUsers } from "./auth.js";
+import { validateTelegramLoginWidget, createSession } from "./auth.js";
+import { isAllowedUser } from "./lib/allowed-users.js";
 import { ALLOWED_ORIGINS } from "./lib/allowed-origins.js";
 import { terminalRoute } from "./routes/terminal/index.js";
 import { sessionRoute } from "./routes/session.js";
@@ -64,8 +65,7 @@ app.post("/api/auth/telegram-widget", async (c) => {
   if (!valid || !user) return c.json({ error: "Invalid login" }, 401);
 
   // Check allowlist
-  const allowed = getAllowedUsers();
-  if (allowed.size > 0 && !allowed.has(String(user.id))) {
+  if (!isAllowedUser(user.id)) {
     return c.json({ error: "User not authorized" }, 403);
   }
 

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -96,15 +96,20 @@ const webDistRoot = join(__dirname, "../../web/dist");
 
 const earlyHintsLinks: string[] = [];
 try {
-  const indexHtml = readFileSync(join(webDistRoot, "index.html"), "utf-8");
-  const js = indexHtml.match(/<script[^>]+src="(\/assets\/index-[^"]+\.js)"/);
-  const css = indexHtml.match(/<link[^>]+href="(\/assets\/index-[^"]+\.css)"/);
-
-  if (js) earlyHintsLinks.push(`<${js[1]}>; rel=preload; as=script; crossorigin`);
-  if (css) earlyHintsLinks.push(`<${css[1]}>; rel=preload; as=style`);
+  const manifestPath = join(webDistRoot, ".vite/manifest.json");
+  const manifest = JSON.parse(readFileSync(manifestPath, "utf-8"));
+  // Find the entry point (has isEntry: true)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const entry = Object.values(manifest).find((e: any) => e.isEntry) as any;
+  if (entry) {
+    if (entry.file) earlyHintsLinks.push(`</${entry.file}>; rel=preload; as=script; crossorigin`);
+    for (const css of entry.css ?? []) {
+      earlyHintsLinks.push(`</${css}>; rel=preload; as=style`);
+    }
+  }
   earlyHintsLinks.push("<https://telegram.org>; rel=preconnect");
 } catch (e: any) {
-  console.warn(`[earlyHints] Unable to read ${join(webDistRoot, "index.html")}: ${e.message}`);
+  console.warn(`[earlyHints] Unable to read manifest: ${e.message}`);
 }
 
 app.use("/*", async (c, next) => {

--- a/apps/server/src/lib/allowed-users.ts
+++ b/apps/server/src/lib/allowed-users.ts
@@ -1,0 +1,13 @@
+import { getAllowedUsers } from "../auth.js";
+
+/**
+ * Check if a user ID is in the allowlist.
+ * Re-reads env on each call (matches existing getAllowedUsers behavior).
+ * Empty allowlist = all users allowed (dev convenience).
+ */
+export function isAllowedUser(userId: string | number | undefined | null): boolean {
+  const allowed = getAllowedUsers();
+  if (allowed.size === 0) return true; // dev convenience: empty allowlist = open
+  if (userId == null) return false;    // no identity → block when allowlist is active
+  return allowed.has(String(userId));
+}

--- a/apps/server/src/lib/path-allowed.ts
+++ b/apps/server/src/lib/path-allowed.ts
@@ -70,7 +70,7 @@ export function __resetRealRootCacheForTests(): void {
 
 export async function isPathAllowed(
   absPath: string,
-  allowedRoots: string[],
+  allowedRoots: readonly string[],
 ): Promise<boolean> {
   let realCandidate: string;
   try {

--- a/apps/server/src/middleware.ts
+++ b/apps/server/src/middleware.ts
@@ -1,5 +1,6 @@
 import type { Context, Next } from "hono";
-import { validateTelegramInitData, getAllowedUsers, validateSession, validateJwtToken } from "./auth.js";
+import { validateTelegramInitData, validateSession, validateJwtToken } from "./auth.js";
+import { isAllowedUser } from "./lib/allowed-users.js";
 
 /**
  * Middleware that validates Telegram Mini App auth.
@@ -31,14 +32,8 @@ export async function telegramAuth(c: Context, next: Next) {
       return c.json({ error: "Invalid Telegram auth" }, 401);
     }
 
-    const allowed = getAllowedUsers();
-    if (allowed.size > 0) {
-      if (!user) {
-        return c.json({ error: "User identification is required" }, 403);
-      }
-      if (!allowed.has(String(user.id))) {
-        return c.json({ error: "User not authorized" }, 403);
-      }
+    if (!isAllowedUser(user?.id)) {
+      return c.json({ error: "User not authorized" }, 403);
     }
 
     if (user) {
@@ -56,14 +51,8 @@ export async function telegramAuth(c: Context, next: Next) {
     // Try session token first
     const sessionResult = validateSession(token);
     if (sessionResult.valid) {
-      const allowed = getAllowedUsers();
-      if (allowed.size > 0) {
-        if (!sessionResult.user) {
-          return c.json({ error: "User identification is required" }, 403);
-        }
-        if (!allowed.has(String(sessionResult.user.id))) {
-          return c.json({ error: "User not authorized" }, 403);
-        }
+      if (!isAllowedUser(sessionResult.user?.id)) {
+        return c.json({ error: "User not authorized" }, 403);
       }
 
       if (sessionResult.user) {
@@ -77,11 +66,8 @@ export async function telegramAuth(c: Context, next: Next) {
     // Try JWT token validation (keyboard button auth)
     const jwtResult = validateJwtToken(token, botToken);
     if (jwtResult.valid) {
-      const allowed = getAllowedUsers();
-      if (allowed.size > 0) {
-        if (!jwtResult.user || !allowed.has(String(jwtResult.user.id))) {
-          return c.json({ error: "User not authorized" }, 403);
-        }
+      if (!isAllowedUser(jwtResult.user?.id)) {
+        return c.json({ error: "User not authorized" }, 403);
       }
 
       if (jwtResult.user) {
@@ -100,11 +86,8 @@ export async function telegramAuth(c: Context, next: Next) {
   if (urlToken) {
     const { valid, user } = validateJwtToken(urlToken, botToken);
     if (valid) {
-      const allowed = getAllowedUsers();
-      if (allowed.size > 0) {
-        if (!user || !allowed.has(String(user.id))) {
-          return c.json({ error: "User not authorized" }, 403);
-        }
+      if (!isAllowedUser(user?.id)) {
+        return c.json({ error: "User not authorized" }, 403);
       }
 
       if (user) {

--- a/apps/server/src/routes/__tests__/reading-list.test.ts
+++ b/apps/server/src/routes/__tests__/reading-list.test.ts
@@ -121,23 +121,17 @@ describe("POST /save", () => {
 
 
 
-  it("normalizes equivalent path variants to one record", async () => {
-    await req("POST", "/save", {
+  it("stores paths with ../ literally (no resolve)", async () => {
+    const res = await req("POST", "/save", {
       path: "/home/claude/code/folder/../file.ts",
-      title: "First",
+      title: "With dot-dot",
     });
-
-    await req("POST", "/save", {
-      path: "/home/claude/code/file.ts",
-      title: "Second",
-    });
-
-    const rows = testDb.prepare(
-      "SELECT * FROM reading_list WHERE user_id = ? AND path = ?"
-    ).all("test-user-123", "/home/claude/code/file.ts");
-
-    expect(rows.length).toBe(1);
-    expect((rows[0] as any).title).toBe("Second");
+    expect(res.status).toBe(200);
+    const row = testDb.prepare(
+      "SELECT path, title FROM reading_list WHERE user_id = ?"
+    ).get("test-user-123") as any;
+    expect(row.path).toBe("/home/claude/code/folder/../file.ts");
+    expect(row.title).toBe("With dot-dot");
   });
 
   it("bumps created_at on re-save so the item moves to the top of /list", async () => {
@@ -277,7 +271,7 @@ describe("GET /check", () => {
 
     const res = await req(
       "GET",
-      "/check?paths=/home/claude/code/saved.ts,/home/claude/code/not-saved.ts"
+      "/check?paths=/home/claude/code/saved.ts&paths=/home/claude/code/not-saved.ts"
     );
     expect(res.status).toBe(200);
     const body = await res.json();
@@ -287,42 +281,33 @@ describe("GET /check", () => {
 
 
 
-  it("normalizes incoming paths before checking (response keyed by original input)", async () => {
+  it("does not resolve ../ segments (paths are literal after trim)", async () => {
     testDb.prepare(
       "INSERT INTO reading_list (user_id, path, title) VALUES (?, ?, ?)"
     ).run("test-user-123", "/home/claude/code/saved.ts", "Saved");
-
     const res = await req(
       "GET",
       "/check?paths=/home/claude/code/dir/../saved.ts"
     );
     expect(res.status).toBe(200);
     const body = await res.json();
-    // Response is keyed by the EXACT input string, not the normalized form,
-    // so clients can look up results using the paths they sent.
-    expect(body.saved["/home/claude/code/dir/../saved.ts"]).toBe(true);
-    expect(body.saved["/home/claude/code/saved.ts"]).toBeUndefined();
+    expect(body.saved["/home/claude/code/dir/../saved.ts"]).toBe(false);
   });
 
-  it("trims whitespace from comma-separated paths before normalization", async () => {
+  it("trims whitespace from repeated paths params", async () => {
     testDb.prepare(
       "INSERT INTO reading_list (user_id, path, title) VALUES (?, ?, ?)"
     ).run("test-user-123", "/home/claude/code/a.ts", "A");
     testDb.prepare(
       "INSERT INTO reading_list (user_id, path, title) VALUES (?, ?, ?)"
     ).run("test-user-123", "/home/claude/code/b.ts", "B");
-
-    // Note the leading spaces after the commas — these must be trimmed
-    // before path.resolve() runs, or they'd become CWD-relative paths.
     const res = await req(
       "GET",
-      "/check?paths=/home/claude/code/a.ts, /home/claude/code/b.ts",
+      "/check?paths= /home/claude/code/a.ts &paths= /home/claude/code/b.ts ",
     );
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.saved["/home/claude/code/a.ts"]).toBe(true);
-    // Response key is the trimmed form (trim is universal cleanup, not a
-    // path-semantic normalization), so clients see the clean string.
     expect(body.saved["/home/claude/code/b.ts"]).toBe(true);
   });
   it("returns empty map when no paths param", async () => {
@@ -333,8 +318,8 @@ describe("GET /check", () => {
   });
 
   it("rejects more than 256 paths with 413", async () => {
-    const paths = Array.from({ length: 257 }, (_, i) => `/home/claude/code/f${i}.ts`).join(",");
-    const res = await req("GET", `/check?paths=${paths}`);
+    const pathParams = Array.from({ length: 257 }, (_, i) => `paths=/home/claude/code/f${i}.ts`).join("&");
+    const res = await req("GET", `/check?${pathParams}`);
     expect(res.status).toBe(413);
   });
 
@@ -379,15 +364,12 @@ describe("POST /delete", () => {
 
 
 
-  it("normalizes path before deleting", async () => {
+  it("does not resolve ../ on delete (path is literal after trim)", async () => {
     testDb.prepare(
       "INSERT INTO reading_list (user_id, path, title) VALUES (?, ?, ?)"
     ).run("test-user-123", "/home/claude/code/norm.ts", "Norm");
-
     const res = await req("POST", "/delete", { path: "/home/claude/code/dir/../norm.ts" });
-    expect(res.status).toBe(200);
-    const body = await res.json();
-    expect(body.ok).toBe(true);
+    expect(res.status).toBe(404);
   });
 
   it("trims whitespace from path on /delete (prevents false 404)", async () => {

--- a/apps/server/src/routes/audio.ts
+++ b/apps/server/src/routes/audio.ts
@@ -4,26 +4,18 @@ import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { resolve } from "node:path";
 import { loadOpenAIEnv, getTelegramCreds } from "./utils.js";
-import { isPathAllowed as isPathAllowedShared } from "../lib/path-allowed.js";
+import {
+  ALLOWED_FILE_ROOTS,
+  isPathAllowed as isPathAllowedShared,
+} from "../lib/path-allowed.js";
 
 const execFileAsync = promisify(execFile);
 
 // Load OpenAI env on module init
 loadOpenAIEnv();
 
-// Allowed root directories for any user-supplied path reaching this route.
-// Kept in sync with files.ts / markdown.ts / terminal/git.ts until S-1 lands a
-// shared `lib/allowed-roots.ts`. See `plans/review/20260411-cpc-presrelease-swarm-review.md`.
-const ALLOWED_ROOTS = [
-  "/home/claude/claudes-world",
-  "/home/claude/code",
-  "/home/claude/bin",
-  "/home/claude/.claude",
-  "/home/claude/claudes-world/.claude",
-];
-
 function isPathAllowed(absPath: string): Promise<boolean> {
-  return isPathAllowedShared(absPath, ALLOWED_ROOTS);
+  return isPathAllowedShared(absPath, ALLOWED_FILE_ROOTS);
 }
 
 const app = new Hono();

--- a/apps/server/src/routes/files.ts
+++ b/apps/server/src/routes/files.ts
@@ -33,8 +33,9 @@ type DownloadTicket = {
 
 const downloadTickets = new Map<string, DownloadTicket>();
 
-// Allowed root directories the file viewer can access
-const ALLOWED_ROOTS = [...ALLOWED_FILE_ROOTS];
+// Allowed root directories the file viewer can access — canonical list lives
+// in path-allowed.ts; used directly here (no spread copy needed).
+const ALLOWED_ROOTS = ALLOWED_FILE_ROOTS;
 
 function isPathAllowed(absPath: string): Promise<boolean> {
   return isPathAllowedShared(absPath, ALLOWED_ROOTS);
@@ -344,7 +345,7 @@ app.get("/search", async (c) => {
   const q = qRaw;
 
   const scopeRaw = c.req.query("scope");
-  let roots: string[] = ALLOWED_ROOTS;
+  let roots: readonly string[] = ALLOWED_ROOTS;
   if (scopeRaw) {
     const scopeResolved = resolve(scopeRaw);
     // Reject scopes that aren't inside an allowed root. Same check as every

--- a/apps/server/src/routes/markdown.ts
+++ b/apps/server/src/routes/markdown.ts
@@ -5,23 +5,15 @@ import { resolve } from "node:path";
 import { createHash, randomBytes } from "node:crypto";
 import { spawn } from "node:child_process";
 import { db } from "../db.js";
-import { isPathAllowed as isPathAllowedShared } from "../lib/path-allowed.js";
+import {
+  ALLOWED_FILE_ROOTS,
+  isPathAllowed as isPathAllowedShared,
+} from "../lib/path-allowed.js";
 
 const app = new Hono();
 
-// Allowed root directories — kept in sync with files.ts. Uses the shared
-// hardened helper from apps/server/src/lib/path-allowed.ts (added in PR #62)
-// which enforces a separator boundary and resolves symlinks via realpath.
-const ALLOWED_ROOTS = [
-  "/home/claude/claudes-world",
-  "/home/claude/code",
-  "/home/claude/bin",
-  "/home/claude/.claude",
-  "/home/claude/claudes-world/.claude",
-];
-
 function isPathAllowed(absPath: string): Promise<boolean> {
-  return isPathAllowedShared(absPath, ALLOWED_ROOTS);
+  return isPathAllowedShared(absPath, ALLOWED_FILE_ROOTS);
 }
 
 // Env vars are read LAZILY (via getters) instead of snapshotted at module

--- a/apps/server/src/routes/reading-list.ts
+++ b/apps/server/src/routes/reading-list.ts
@@ -6,8 +6,6 @@ import { ALLOWED_FILE_ROOTS, isPathAllowed } from "../lib/path-allowed.js";
 
 const app = new Hono();
 
-const ALLOWED_ROOTS = [...ALLOWED_FILE_ROOTS];
-
 function normalizePath(input: string): string {
   const trimmed = input.trim();
   if (!trimmed.startsWith("/")) {
@@ -37,7 +35,7 @@ app.post("/save", async (c) => {
 
   const normalizedPath = normalizePath(path);
 
-  if (!(await isPathAllowed(normalizedPath, ALLOWED_ROOTS))) {
+  if (!(await isPathAllowed(normalizedPath, ALLOWED_FILE_ROOTS))) {
     return c.json({ error: "Access denied" }, 403);
   }
 

--- a/apps/server/src/routes/reading-list.ts
+++ b/apps/server/src/routes/reading-list.ts
@@ -1,5 +1,5 @@
 import { Hono } from "hono";
-import { basename, resolve } from "node:path";
+import { basename } from "node:path";
 import { db } from "../db.js";
 import { getUserId } from "../lib/get-user-id.js";
 import { ALLOWED_FILE_ROOTS, isPathAllowed } from "../lib/path-allowed.js";
@@ -8,13 +8,12 @@ const app = new Hono();
 
 const ALLOWED_ROOTS = [...ALLOWED_FILE_ROOTS];
 
-function normalizePath(path: string): string {
-  // Trim before resolve() — otherwise leading/trailing whitespace (e.g. from
-  // copy/paste) would make resolve() treat the input as a CWD-relative path
-  // segment, causing false 403s on /save and false 404s on /delete. /check
-  // also trims each segment upstream; doing it here is idempotent and keeps
-  // all endpoints consistent.
-  return resolve(path.trim());
+function normalizePath(input: string): string {
+  const trimmed = input.trim();
+  if (!trimmed.startsWith("/")) {
+    throw new Error(`Path must be absolute: ${trimmed}`);
+  }
+  return trimmed;
 }
 
 // POST /save — save a file to reading list (upsert)
@@ -94,20 +93,9 @@ app.get("/check", (c) => {
     return c.json({ error: "auth required" }, 401);
   }
 
-  const pathsParam = c.req.query("paths");
-  if (!pathsParam) {
-    return c.json({ saved: {} });
-  }
-
-  // Trim each segment first so `?paths=a, b` doesn't produce a path relative
-  // to CWD after normalization. The response is keyed by the *trimmed* input
-  // (universal cleanup, not a path-semantic normalization), so clients can
-  // look up results using essentially the paths they sent — just without the
-  // accidental whitespace.
+  const rawPaths = c.req.queries("paths") ?? [];
   const originalInputs = [
-    ...new Set(
-      pathsParam.split(",").map((p) => p.trim()).filter(Boolean),
-    ),
+    ...new Set(rawPaths.map((p) => p.trim()).filter(Boolean)),
   ];
   if (originalInputs.length === 0) {
     return c.json({ saved: {} });

--- a/apps/server/src/routes/terminal-ws.ts
+++ b/apps/server/src/routes/terminal-ws.ts
@@ -1,6 +1,7 @@
 import { spawn, execSync } from "node:child_process";
 import type { WSContext } from "hono/ws";
-import { checkAuth, validateSession, validateJwtToken, getAllowedUsers } from "../auth.js";
+import { checkAuth, validateSession, validateJwtToken } from "../auth.js";
+import { isAllowedUser } from "../lib/allowed-users.js";
 // Import the validated TMUX_SESSION from routes/utils so we inherit the
 // `/^[A-Za-z0-9_.-]+$/` character-set check that runs once at module load.
 // Keeping a local unvalidated copy would bypass that fence and leave the
@@ -52,8 +53,7 @@ export function terminalWsRoute(c: any) {
     if (token) {
       const { valid, user } = validateSession(token);
       if (valid && user) {
-        const allowed = getAllowedUsers();
-        if (allowed.size === 0 || allowed.has(String(user.id))) {
+        if (isAllowedUser(user.id)) {
           authResult = { ok: true, user };
         } else {
           authResult = { ok: false, error: "User not in allowlist" };
@@ -66,8 +66,7 @@ export function terminalWsRoute(c: any) {
         if (botToken) {
           const { valid: jwtValid, user: jwtUser } = validateJwtToken(token, botToken);
           if (jwtValid && jwtUser) {
-            const allowed = getAllowedUsers();
-            if (allowed.size === 0 || allowed.has(String(jwtUser.id))) {
+            if (isAllowedUser(jwtUser.id)) {
               authResult = { ok: true, user: jwtUser };
             }
           }

--- a/apps/web/src/components/ErrorBoundary.tsx
+++ b/apps/web/src/components/ErrorBoundary.tsx
@@ -19,8 +19,8 @@ interface ErrorBoundaryState {
 export class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundaryState> {
   state: ErrorBoundaryState = { error: null, resetKey: 0 };
 
-  static getDerivedStateFromError(error: Error): Partial<ErrorBoundaryState> {
-    return { error };
+  static getDerivedStateFromError(error: unknown): Partial<ErrorBoundaryState> {
+    return { error: error instanceof Error ? error : new Error(String(error)) };
   }
 
   componentDidCatch(error: Error, info: React.ErrorInfo) {
@@ -66,6 +66,7 @@ export class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoun
       return (
         <ErrorFallback
           error={this.state.error}
+          level={this.props.level ?? "root"}
           onRetry={this.reset}
           onReload={() => window.location.reload()}
         />
@@ -78,18 +79,19 @@ export class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoun
 
 interface ErrorFallbackProps {
   error: Error;
+  level: ErrorBoundaryLevel;
   onRetry: () => void;
   onReload: () => void;
 }
 
-function ErrorFallback({ error, onRetry, onReload }: ErrorFallbackProps) {
+function ErrorFallback({ error, level, onRetry, onReload }: ErrorFallbackProps) {
   // Tokyo Night palette to match the rest of CPC.
   // bg #1a1b26, fg #c0caf5, error accent #f7768e, muted #565f89, action blue #7aa2f7
   return (
     <div
       role="alert"
       style={{
-        minHeight: "100dvh",
+        minHeight: level === "tab" ? "100%" : "100dvh",
         width: "100%",
         background: "#1a1b26",
         color: "#c0caf5",

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -153,13 +153,16 @@ export function FileViewer({ onClose, initialFile, showHidden = false, sortMode 
   // changes don't clobber their edits once they've taken control.
   const pasteFilenameEditedRef = useRef(false);
   const pasteTextareaRef = useRef<HTMLTextAreaElement>(null);
+  const downloadInFlightRef = useRef(false);
 
   const handleDownload = async () => {
-    if (!filePath || !fileName || downloading) return;
+    if (!filePath || !fileName || downloadInFlightRef.current) return;
+    downloadInFlightRef.current = true;
     setError(null);
 
     const downloadWindow = window.open("about:blank", "_blank");
     if (!downloadWindow) {
+      downloadInFlightRef.current = false;
       setError("Download blocked by browser. Allow popups for this site.");
       return;
     }
@@ -201,6 +204,7 @@ export function FileViewer({ onClose, initialFile, showHidden = false, sortMode 
       downloadWindow.close();
       setError(err instanceof Error ? err.message : "Download failed");
     } finally {
+      downloadInFlightRef.current = false;
       setDownloading(false);
     }
   };

--- a/apps/web/src/components/MarkdownViewer.tsx
+++ b/apps/web/src/components/MarkdownViewer.tsx
@@ -1,5 +1,5 @@
 import React, { Children, isValidElement, useState, useCallback, useMemo, useRef, type ReactNode } from "react";
-import ReactMarkdown, { type Components } from "react-markdown";
+import ReactMarkdown, { type Components, type ExtraProps } from "react-markdown";
 import remarkGfm from "remark-gfm";
 import remarkBreaks from "remark-breaks";
 import rehypeSlug from "rehype-slug";
@@ -40,7 +40,7 @@ function getTextContent(children: ReactNode): string {
     .join("");
 }
 
-function CodeBlock({ className, children, node: _node, ...props }: React.ComponentPropsWithoutRef<'code'> & { node?: any; className?: string }) {
+function CodeBlock({ className, children, node: _node, ...props }: React.ComponentPropsWithoutRef<'code'> & ExtraProps) {
   const language = getLanguage(className);
 
   if (language === "mermaid") {
@@ -58,7 +58,7 @@ function CodeBlock({ className, children, node: _node, ...props }: React.Compone
   );
 }
 
-function ScrollableTable({ children, node: _node, ...props }: React.ComponentPropsWithoutRef<'table'> & { node?: any }) {
+function ScrollableTable({ children, node: _node, ...props }: React.ComponentPropsWithoutRef<'table'> & ExtraProps) {
   return (
     <div className="md-table-scroll">
       <table {...props}>{children}</table>
@@ -73,7 +73,7 @@ function isMermaidCodeChild(child: ReactNode): boolean {
   );
 }
 
-function PreBlock({ children, node: _node, ...props }: React.ComponentPropsWithoutRef<'pre'> & { node?: any }) {
+function PreBlock({ children, node: _node, ...props }: React.ComponentPropsWithoutRef<'pre'> & ExtraProps) {
   const childArray = Children.toArray(children);
 
   if (childArray.length === 1 && isMermaidCodeChild(childArray[0])) {
@@ -176,7 +176,7 @@ export function MarkdownViewer({ content, fileName: _fileName }: MarkdownViewerP
     return {
       ...baseComponents,
       ...headingComponents,
-      section: ({ node: _node, children, ...props }: any) => {
+      section: ({ node: _node, children, ...props }: React.ComponentPropsWithoutRef<'section'> & ExtraProps & { "data-fold-slug"?: string }) => {
         const slug = props["data-fold-slug"] as string | undefined;
         if (!slug) return <section {...props}>{children}</section>;
         // Compute effective-hidden inline using collected headings.

--- a/apps/web/src/components/markdown/CollapsibleHeading.tsx
+++ b/apps/web/src/components/markdown/CollapsibleHeading.tsx
@@ -18,7 +18,8 @@
  *  - aria-controls points to the section element's id
  *  - Enter/Space activate the button natively
  */
-import { type ReactNode, type MutableRefObject, useCallback } from "react";
+import React, { type MutableRefObject, useCallback } from "react";
+import type { ExtraProps } from "react-markdown";
 
 export interface HeadingEntry {
   slug: string;
@@ -34,12 +35,7 @@ export interface FoldControls {
   registerHeading: (entry: HeadingEntry) => void;
 }
 
-interface HeadingProps {
-  node?: any;
-  children?: ReactNode;
-  id?: string;
-  [key: string]: any;
-}
+type HeadingProps = React.ComponentPropsWithoutRef<'h1'> & ExtraProps & { "data-has-section"?: string };
 
 // Heading level from tag name (e.g. "h2" → 2)
 function tagLevel(tag: string): number {

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -24,6 +24,7 @@ export default defineConfig(({ command }) => ({
     __APP_VERSION__: JSON.stringify(gitVersion),
   },
   build: {
+    manifest: true,
     // Kill the eager `<link rel="modulepreload">` hint Vite emits for the
     // mermaid chunk. Mermaid is dynamically imported inside MermaidDiagram.tsx
     // and only needed when a markdown file actually contains a diagram, but


### PR DESCRIPTION
## Summary

7 fixes merged since v1.10.0:

- **#173** — FileViewer double-tap download race (ref-based in-flight lock)
- **#29** — ErrorBoundary handles non-Error throws + level prop for tab-scoped fallback
- **#174** — Reading-list: queries() for multi-path params + reject relative paths
- **#142** — Early Hints: parse Vite manifest.json instead of regex on index.html
- **#139** — Replace `any` prop signatures with ExtraProps in markdown components
- **#155** — Consolidate ALLOWED_ROOTS to single source in path-allowed.ts
- **#156** — Centralize allowlist check into isAllowedUser helper (null-safe)

All fixes went through plan → DA review → implement → Codex swarm review → fix rounds until green.

## Test plan
- [x] 199 unit tests pass
- [x] Server typecheck clean
- [ ] Manual smoke test of CPC in Telegram WebView

🤖 Generated with [Claude Code](https://claude.com/claude-code)