### PR TITLE
chore(security): consolidate ALLOWED_ROOTS to single source (#155)

### DIFF
--- a/apps/server/src/lib/path-allowed.ts
+++ b/apps/server/src/lib/path-allowed.ts
@@ -70,7 +70,7 @@ export function __resetRealRootCacheForTests(): void {
 
 export async function isPathAllowed(
   absPath: string,
-  allowedRoots: string[],
+  allowedRoots: readonly string[],
 ): Promise<boolean> {
   let realCandidate: string;
   try {

--- a/apps/server/src/routes/audio.ts
+++ b/apps/server/src/routes/audio.ts
@@ -4,26 +4,19 @@ import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { resolve } from "node:path";
 import { loadOpenAIEnv, getTelegramCreds } from "./utils.js";
-import { isPathAllowed as isPathAllowedShared } from "../lib/path-allowed.js";
+import {
+  ALLOWED_FILE_ROOTS,
+  isPathAllowed as isPathAllowedShared,
+} from "../lib/path-allowed.js";
 
 const execFileAsync = promisify(execFile);
 
 // Load OpenAI env on module init
 loadOpenAIEnv();
 
-// Allowed root directories for any user-supplied path reaching this route.
-// Kept in sync with files.ts / markdown.ts / terminal/git.ts until S-1 lands a
-// shared `lib/allowed-roots.ts`. See `plans/review/20260411-cpc-presrelease-swarm-review.md`.
-const ALLOWED_ROOTS = [
-  "/home/claude/claudes-world",
-  "/home/claude/code",
-  "/home/claude/bin",
-  "/home/claude/.claude",
-  "/home/claude/claudes-world/.claude",
-];
 
 function isPathAllowed(absPath: string): Promise<boolean> {
-  return isPathAllowedShared(absPath, ALLOWED_ROOTS);
+  return isPathAllowedShared(absPath, ALLOWED_FILE_ROOTS);
 }
 
 const app = new Hono();

--- a/apps/server/src/routes/files.ts
+++ b/apps/server/src/routes/files.ts
@@ -33,11 +33,8 @@ type DownloadTicket = {
 
 const downloadTickets = new Map<string, DownloadTicket>();
 
-// Allowed root directories the file viewer can access
-const ALLOWED_ROOTS = [...ALLOWED_FILE_ROOTS];
-
 function isPathAllowed(absPath: string): Promise<boolean> {
-  return isPathAllowedShared(absPath, ALLOWED_ROOTS);
+  return isPathAllowedShared(absPath, ALLOWED_FILE_ROOTS);
 }
 
 function pruneExpiredDownloadTickets(now = Date.now()) {
@@ -122,7 +119,7 @@ function sanitizeFilename(raw: string): string | null {
 // List available root directories
 app.get("/roots", (c) => {
   return c.json({
-    roots: ALLOWED_ROOTS.map((r) => ({
+    roots: ALLOWED_FILE_ROOTS.map((r) => ({
       path: r,
       name: r.replace("/home/claude/", "~/"),
     })),
@@ -178,7 +175,7 @@ app.get("/list", async (c) => {
     });
 
     // Return parent: null ONLY if `resolve(resolved, "..")` is itself
-    // NOT allowed. Using `ALLOWED_ROOTS.includes(resolved)` would break
+    // NOT allowed. Using `ALLOWED_FILE_ROOTS.includes(resolved)` would break
     // nested allowed roots — e.g. if both /a/b and /a/b/c are in the
     // list, a user at /a/b/c could see `parent: null` and be unable to
     // navigate up to /a/b even though that path is allowed. Use the
@@ -344,7 +341,7 @@ app.get("/search", async (c) => {
   const q = qRaw;
 
   const scopeRaw = c.req.query("scope");
-  let roots: string[] = ALLOWED_ROOTS;
+  let roots: readonly string[] = ALLOWED_FILE_ROOTS;
   if (scopeRaw) {
     const scopeResolved = resolve(scopeRaw);
     // Reject scopes that aren't inside an allowed root. Same check as every
@@ -446,7 +443,7 @@ app.post(
     //     same suffix), and
     // (b) symlink-redirected writes (a symlink inside an allowed dir pointing
     //     outside the allowed root would trick the write into landing outside
-    //     ALLOWED_ROOTS).
+    //     ALLOWED_FILE_ROOTS).
     //
     // Verify the target directory exists before attempting writes. If it
     // doesn't, open() would throw ENOENT which would surface as a generic 500.
@@ -623,7 +620,7 @@ app.post(
     //     two concurrent callers pick the same suffix), and
     // (b) symlink-redirected writes (an attacker placing a symlink inside
     //     an allowed dir that points outside the allowed root would otherwise
-    //     trick the write into landing outside ALLOWED_ROOTS).
+    //     trick the write into landing outside ALLOWED_FILE_ROOTS).
     //
     // Try the chosen filename, then incrementing suffixes until O_EXCL
     // succeeds or we give up.

--- a/apps/server/src/routes/markdown.ts
+++ b/apps/server/src/routes/markdown.ts
@@ -5,23 +5,16 @@ import { resolve } from "node:path";
 import { createHash, randomBytes } from "node:crypto";
 import { spawn } from "node:child_process";
 import { db } from "../db.js";
-import { isPathAllowed as isPathAllowedShared } from "../lib/path-allowed.js";
+import {
+  ALLOWED_FILE_ROOTS,
+  isPathAllowed as isPathAllowedShared,
+} from "../lib/path-allowed.js";
 
 const app = new Hono();
 
-// Allowed root directories — kept in sync with files.ts. Uses the shared
-// hardened helper from apps/server/src/lib/path-allowed.ts (added in PR #62)
-// which enforces a separator boundary and resolves symlinks via realpath.
-const ALLOWED_ROOTS = [
-  "/home/claude/claudes-world",
-  "/home/claude/code",
-  "/home/claude/bin",
-  "/home/claude/.claude",
-  "/home/claude/claudes-world/.claude",
-];
 
 function isPathAllowed(absPath: string): Promise<boolean> {
-  return isPathAllowedShared(absPath, ALLOWED_ROOTS);
+  return isPathAllowedShared(absPath, ALLOWED_FILE_ROOTS);
 }
 
 // Env vars are read LAZILY (via getters) instead of snapshotted at module

--- a/apps/server/src/routes/reading-list.ts
+++ b/apps/server/src/routes/reading-list.ts
@@ -6,8 +6,6 @@ import { ALLOWED_FILE_ROOTS, isPathAllowed } from "../lib/path-allowed.js";
 
 const app = new Hono();
 
-const ALLOWED_ROOTS = [...ALLOWED_FILE_ROOTS];
-
 function normalizePath(input: string): string {
   const trimmed = input.trim();
   if (!trimmed.startsWith("/")) {
@@ -37,7 +35,7 @@ app.post("/save", async (c) => {
 
   const normalizedPath = normalizePath(path);
 
-  if (!(await isPathAllowed(normalizedPath, ALLOWED_ROOTS))) {
+  if (!(await isPathAllowed(normalizedPath, ALLOWED_FILE_ROOTS))) {
     return c.json({ error: "Access denied" }, 403);
   }
 

--- a/apps/server/src/routes/terminal/git.ts
+++ b/apps/server/src/routes/terminal/git.ts
@@ -3,23 +3,16 @@ import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { join, resolve } from "node:path";
 import { execAsync } from "../utils.js";
-import { isPathAllowed as isPathAllowedShared } from "../../lib/path-allowed.js";
+import {
+  ALLOWED_FILE_ROOTS,
+  isPathAllowed as isPathAllowedShared,
+} from "../../lib/path-allowed.js";
 
 const execFileAsync = promisify(execFile);
 
-// Allowed root directories for any user-supplied filesystem path reaching a
-// git command. Kept in sync with files.ts / markdown.ts until S-1 lands a
-// shared `lib/allowed-roots.ts`. See `plans/review/20260411-cpc-presrelease-swarm-review.md`.
-const ALLOWED_ROOTS = [
-  "/home/claude/claudes-world",
-  "/home/claude/code",
-  "/home/claude/bin",
-  "/home/claude/.claude",
-  "/home/claude/claudes-world/.claude",
-];
 
 function isPathAllowed(absPath: string): Promise<boolean> {
-  return isPathAllowedShared(absPath, ALLOWED_ROOTS);
+  return isPathAllowedShared(absPath, ALLOWED_FILE_ROOTS);
 }
 
 const app = new Hono();
@@ -114,7 +107,7 @@ app.get("/dir-branch", async (c) => {
     // into a `git -C "${dir}" ...` shell string, so a path like
     // `a"; curl evil; "` broke out of the quotes and executed arbitrary
     // commands as the claude user. The fix switches to execFile (argv, no
-    // shell) AND requires the path to live under ALLOWED_ROOTS so the
+    // shell) AND requires the path to live under ALLOWED_FILE_ROOTS so the
     // endpoint can never point git at /etc, /root, or a sibling-prefix dir.
     const absDir = resolve(dir);
     if (!(await isPathAllowed(absDir))) {


### PR DESCRIPTION
## Summary

- Remove 4 inline/spread-copy `ALLOWED_ROOTS` arrays from `audio.ts`, `markdown.ts`, `terminal/git.ts`, `files.ts`, and `reading-list.ts`
- All route files now import and use `ALLOWED_FILE_ROOTS` directly from `lib/path-allowed.ts` — single source of truth
- Widen `isPathAllowed` parameter type from `string[]` to `readonly string[]` so the `as const` tuple passes without spreading

Supersedes #188 (stale base, unresolvable merge conflicts).

Closes #155

## Test plan

- [x] `pnpm run typecheck` passes in `apps/server`
- [x] `pnpm run test:unit` — all 199 tests pass (127 server + 72 web)
- [ ] Verify `/roots` endpoint still returns the correct list
- [ ] Verify file search scoping still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)