### PR TITLE
chore: add changelog infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -345,3 +345,6 @@ test-results/
 # Worktree-local port allocations from port-for (ADR 0003)
 .world/ports.lock
 
+# Release notes extracted by scripts/extract-release-section.sh
+/tmp/release-notes-*.md
+

--- a/changelogs/README.md
+++ b/changelogs/README.md
@@ -1,0 +1,16 @@
+# Changelog Fragments
+
+Drop a `.md` file here for each PR that should appear in the next release's CHANGELOG.
+
+## Format
+
+```yaml
+---
+type: feature|fix|infrastructure|breaking
+pr: 123
+---
+One-line description of the change.
+```
+
+The `changelog-writer` agent compiles these into `CHANGELOG.md` at release time.
+Files are deleted (`git rm`) when the release PR merges.

--- a/scripts/extract-release-section.sh
+++ b/scripts/extract-release-section.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Extract a single release section from CHANGELOG.md
+# Usage: scripts/extract-release-section.sh <version> [<changelog-path>]
+set -euo pipefail
+VERSION="${1:?version required (e.g. 1.10.0, no v prefix)}"
+FILE="${2:-CHANGELOG.md}"
+OUT="/tmp/release-notes-${VERSION}.md"
+
+awk -v v="$VERSION" '
+  $0 ~ "^## \\[" v "\\]" { found=1; next }
+  found && /^## \[/ { exit }
+  found { print }
+' "$FILE" > "$OUT"
+
+# Validate: non-empty and has at least one bullet point
+if [ ! -s "$OUT" ] || ! grep -q '^- ' "$OUT"; then
+  echo "ERROR: extracted notes for $VERSION are empty or malformed" >&2
+  exit 2
+fi
+
+echo "$OUT"

--- a/scripts/extract-release-section.sh
+++ b/scripts/extract-release-section.sh
@@ -3,10 +3,20 @@
 # Usage: scripts/extract-release-section.sh <version> [<changelog-path>]
 set -euo pipefail
 VERSION="${1:?version required (e.g. 1.10.0, no v prefix)}"
+
+# Validate semver format (no v prefix) — prevents path traversal via /tmp filename
+if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$'; then
+  echo "ERROR: version must be semver format (e.g. 1.10.0)" >&2
+  exit 1
+fi
+
 FILE="${2:-CHANGELOG.md}"
 OUT="/tmp/release-notes-${VERSION}.md"
 
-awk -v v="$VERSION" '
+# Escape dots so awk treats them as literal characters, not regex wildcards
+ESC_VERSION=$(echo "$VERSION" | sed 's/\./\\./g')
+
+awk -v v="$ESC_VERSION" '
   $0 ~ "^## \\[" v "\\]" { found=1; next }
   found && /^## \[/ { exit }
   found { print }


### PR DESCRIPTION
## Summary

- Add `scripts/extract-release-section.sh` — extracts a single version's section from CHANGELOG.md for use by release workflows and the changelog-writer agent
- Add `changelogs/unreleased/` directory with `.gitkeep` for changelog fragment workflow
- Add `changelogs/README.md` documenting the fragment format and lifecycle
- Update `.gitignore` to exclude `/tmp/release-notes-*.md` (extract script output)

## Verification

- Extract script tested against existing CHANGELOG.md v1.10.0 — output correct
- Error case (non-existent version) returns exit code 2 with descriptive message
- All 210 unit tests pass (138 server + 72 web)

## Test plan

- [x] `scripts/extract-release-section.sh 1.10.0` extracts correct section
- [x] Script fails with exit 2 on missing version
- [x] `pnpm run test:unit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)