### PR TITLE
fix(db): add 30-day TTL cleanup for tldr_cache on startup

### DIFF
--- a/apps/server/src/db.ts
+++ b/apps/server/src/db.ts
@@ -60,6 +60,12 @@ db.exec(`
   -- constraint already creates an identical implicit index.
 `);
 
+// Prune stale TL;DR cache entries older than 30 days.
+// Runs on every startup; idx_tldr_created keeps this fast.
+db.exec(
+  `DELETE FROM tldr_cache WHERE created_at < unixepoch() * 1000 - 30 * 86400 * 1000`
+);
+
 // Migration: early builds of reading_list shipped `created_at TEXT DEFAULT
 // (datetime('now'))`. The route layer (and tests) now assume epoch-ms
 // INTEGER. `CREATE TABLE IF NOT EXISTS` never rewrites an existing schema,


### PR DESCRIPTION
## Summary
- Adds a startup cleanup that deletes `tldr_cache` entries older than 30 days
- Uses the existing `idx_tldr_created` index so the DELETE is efficient even on large tables
- No new dependencies, no schema changes — just a single `db.exec()` call after table creation

Closes #82

## Test plan
- [x] `pnpm run typecheck` passes
- [x] `pnpm -w run test:unit` — all 210 tests pass (138 server + 72 web)
- [ ] Manual: insert a row with `created_at` older than 30 days, restart server, verify it's pruned

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>