### PR TITLE
chore(links): migrate inline <style> to Links.css file

### DIFF
--- a/apps/web/src/components/Links.css
+++ b/apps/web/src/components/Links.css
@@ -1,0 +1,7 @@
+.cpc-app-tile {
+  transition: transform 120ms ease-out;
+}
+
+.cpc-app-tile:active {
+  transform: scale(0.92);
+}

--- a/apps/web/src/components/Links.tsx
+++ b/apps/web/src/components/Links.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import "./Links.css";
 
 interface LinkItem {
   title: string;
@@ -54,15 +55,6 @@ const APPS: AppItem[] = [
   },
 ];
 
-const TILE_STYLE = `
-  .cpc-app-tile {
-    transition: transform 120ms ease-out;
-  }
-  .cpc-app-tile:active {
-    transform: scale(0.92);
-  }
-`;
-
 interface LinksProps {
   onClose: () => void;
 }
@@ -70,7 +62,6 @@ interface LinksProps {
 export function Links({ onClose }: LinksProps) {
   return (
     <div style={{ display: "flex", flexDirection: "column", height: "100%" }}>
-      <style>{TILE_STYLE}</style>
       <div
         style={{
           padding: "8px 12px",


### PR DESCRIPTION
## Summary
- Extracts the `TILE_STYLE` constant and `<style>` JSX injection from `Links.tsx` into a dedicated `Links.css` file
- Follows the project's existing plain-CSS-import convention (same pattern as `index.css`, `xterm.css`)
- The `.cpc-app-tile` class name is unchanged, so all existing `className` references continue to work

Closes #58

## Test plan
- [x] `pnpm run test:unit` — all 210 tests pass (138 server + 72 web)
- [x] `pnpm run build` — production build succeeds with no new warnings
- [ ] Manual: open Links panel in Telegram WebView, verify app tile tap animation still fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)