### PR TITLE
fix(uat): download via anchor click, PrTicker error handling, audio panel reopen state

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -159,20 +159,6 @@ export function FileViewer({ onClose, initialFile, showHidden = false, sortMode 
     if (!filePath || !fileName || downloadInFlightRef.current) return;
     downloadInFlightRef.current = true;
     setError(null);
-
-    const downloadWindow = window.open("about:blank", "_blank");
-    if (!downloadWindow) {
-      downloadInFlightRef.current = false;
-      setError("Download blocked by browser. Allow popups for this site.");
-      return;
-    }
-
-    try {
-      downloadWindow.opener = null;
-    } catch {
-      // Some WebViews make opener read-only. The ticket is still single-use.
-    }
-
     setDownloading(true);
     try {
       const res = await fetch("/api/files/download-ticket", {
@@ -184,7 +170,6 @@ export function FileViewer({ onClose, initialFile, showHidden = false, sortMode 
         body: JSON.stringify({ path: filePath }),
       });
       if (!res.ok) {
-        downloadWindow.close();
         let msg = `Download failed (${res.status})`;
         try {
           const data = await res.json();
@@ -195,13 +180,21 @@ export function FileViewer({ onClose, initialFile, showHidden = false, sortMode 
 
       const data = await res.json() as { ticket?: string };
       if (!data.ticket) {
-        downloadWindow.close();
         throw new Error("Download failed: missing ticket");
       }
 
-      downloadWindow.location.href = `/api/files/download?ticket=${encodeURIComponent(data.ticket)}`;
+      // Use a hidden <a> element with download attribute to trigger the
+      // browser's native download. This works in Telegram WebView where
+      // window.open("about:blank") is blocked as a popup.
+      const url = `/api/files/download?ticket=${encodeURIComponent(data.ticket)}`;
+      const anchor = document.createElement("a");
+      anchor.href = url;
+      anchor.download = fileName;
+      anchor.style.display = "none";
+      document.body.appendChild(anchor);
+      anchor.click();
+      document.body.removeChild(anchor);
     } catch (err) {
-      downloadWindow.close();
       setError(err instanceof Error ? err.message : "Download failed");
     } finally {
       downloadInFlightRef.current = false;

--- a/apps/web/src/components/PrTicker.tsx
+++ b/apps/web/src/components/PrTicker.tsx
@@ -110,6 +110,7 @@ export function PrTicker() {
       return "current";
     }
   });
+  const [loading, setLoading] = useState(true);
   const [lastPollAt, setLastPollAt] = useState<number>(0);
   const [pollError, setPollError] = useState<string | null>(null);
   const [refreshing, setRefreshing] = useState(false);
@@ -127,14 +128,22 @@ export function PrTicker() {
       const res = await fetch("/api/prs", { headers: getAuthHeaders() });
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const data = await res.json();
-      if (mountedRef.current && data.ok) {
-        setPrs(data.prs ?? []);
-        setLastPollAt(data.lastPollOk || Date.now());
-        setPollError(data.lastPollErr ?? null);
+      if (mountedRef.current) {
+        if (data.ok) {
+          setPrs(data.prs ?? []);
+          setLastPollAt(data.lastPollOk || Date.now());
+          setPollError(data.lastPollErr ?? null);
+        } else {
+          setPollError(data.error ?? "Unknown error");
+        }
       }
     } catch (err) {
       if (mountedRef.current) {
         setPollError(err instanceof Error ? err.message : String(err));
+      }
+    } finally {
+      if (mountedRef.current) {
+        setLoading(false);
       }
     }
   }, []);
@@ -277,7 +286,20 @@ export function PrTicker() {
         overflowY: "auto",
         WebkitOverflowScrolling: "touch",
       }}>
-        {filteredPrs.length === 0 ? (
+        {loading ? (
+          <div style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            height: "100%",
+            color: COLORS.textMuted,
+            fontSize: 14,
+            padding: 20,
+            textAlign: "center",
+          }}>
+            Loading PRs...
+          </div>
+        ) : filteredPrs.length === 0 ? (
           <div style={{
             display: "flex",
             alignItems: "center",

--- a/apps/web/src/components/action-bar/ActionBar.tsx
+++ b/apps/web/src/components/action-bar/ActionBar.tsx
@@ -208,9 +208,12 @@ export function ActionBar({ onReconnect, connected, activeTab, fileShowHidden, s
     setAudioLoading(true);
     setAudioOp("checking");
     try {
-      setAudioStatus(await checkAudio(filePath));
+      const status = await checkAudio(filePath);
+      // Guard: if generate/send started while check was in-flight, don't
+      // overwrite their loading/op state with a stale check result.
+      if (!audioInFlightRef.current) setAudioStatus(status);
     } catch {
-      setAudioStatus(null);
+      if (!audioInFlightRef.current) setAudioStatus(null);
     } finally {
       // Only clear loading if no generate/send started while we were checking
       if (!audioInFlightRef.current) {

--- a/apps/web/src/components/action-bar/ActionBar.tsx
+++ b/apps/web/src/components/action-bar/ActionBar.tsx
@@ -200,7 +200,25 @@ export function ActionBar({ onReconnect, connected, activeTab, fileShowHidden, s
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [searchCurrentFolderOnly, currentFolder, modal]);
 
-  const handleCheckAudio = async (filePath: string) => { setAudioStatus(null); setAudioLoading(true); setAudioOp("checking"); try { setAudioStatus(await checkAudio(filePath)); } catch { setAudioStatus(null); } finally { setAudioOp("idle"); setAudioLoading(false); } };
+  const handleCheckAudio = async (filePath: string) => {
+    // If a generate or send is already in-flight, don't clobber its
+    // loading/op state with a check — just show the in-progress panel.
+    if (audioInFlightRef.current) return;
+    setAudioStatus(null);
+    setAudioLoading(true);
+    setAudioOp("checking");
+    try {
+      setAudioStatus(await checkAudio(filePath));
+    } catch {
+      setAudioStatus(null);
+    } finally {
+      // Only clear loading if no generate/send started while we were checking
+      if (!audioInFlightRef.current) {
+        setAudioOp("idle");
+        setAudioLoading(false);
+      }
+    }
+  };
   const handleGenerateAudio = async (filePath: string) => {
     if (audioInFlightRef.current) return;
     audioInFlightRef.current = true;


### PR DESCRIPTION
## Summary
- **Download fix:** Replace `window.open("about:blank")` popup approach in FileViewer with hidden `<a download>` element click — popups are blocked in Telegram WebView
- **PrTicker fix:** Add `loading: true` initial state so component shows "Loading PRs..." on mount instead of rendering empty/error state before data arrives; add `finally` block to reliably clear loading; handle non-ok API responses
- **AudioGenModal fix:** Skip `handleCheckAudio` when a generate/send is already in-flight (`audioInFlightRef.current`), so reopening the panel during generation shows the in-progress animation instead of stale idle state

## Test plan
- [x] `pnpm run test:unit` — 97/97 pass
- [x] TypeScript typecheck clean
- [ ] Manual: open CPC in Telegram, view a file, tap Download — should trigger native download without popup blocker
- [ ] Manual: open PR Ticker tab — should show "Loading PRs..." briefly, then data or empty state
- [ ] Manual: start audio generation, close panel, reopen — should show generating animation

🤖 Generated with [Claude Code](https://claude.com/claude-code)