### PR TITLE
feat(file-viewer): wire Telegram BackButton for file navigation

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -461,7 +461,7 @@ export function FileViewer({ onClose, initialFile, showHidden = false, sortMode 
     }
   };
 
-  const handleBack = () => {
+  const handleBack = useCallback(() => {
     if (fileContent !== null) {
       setFileContent(null);
       setFileName("");
@@ -471,7 +471,27 @@ export function FileViewer({ onClose, initialFile, showHidden = false, sortMode 
     } else if (parentPath) {
       loadDirectory(parentPath);
     }
-  };
+  }, [fileContent, parentPath, loadDirectory, onViewChange]);
+
+  // Wire Telegram's native BackButton when viewing a file. Show it on
+  // file open, hide it when returning to the directory listing, and clean
+  // up the handler on unmount so we don't leak listeners.
+  useEffect(() => {
+    const bb = window.Telegram?.WebApp?.BackButton;
+    if (!bb) return;
+
+    if (fileContent !== null) {
+      bb.onClick(handleBack);
+      bb.show();
+    } else {
+      bb.hide();
+    }
+
+    return () => {
+      bb.offClick(handleBack);
+      bb.hide();
+    };
+  }, [fileContent, handleBack]);
 
   // Simple line folding for code
   const toggleFold = (lineNum: number) => {

--- a/apps/web/src/lib/telegram.ts
+++ b/apps/web/src/lib/telegram.ts
@@ -25,6 +25,12 @@ interface TelegramWebApp {
     hide(): void;
     onClick(callback: () => void): void;
   };
+  BackButton?: {
+    show(): void;
+    hide(): void;
+    onClick(callback: () => void): void;
+    offClick(callback: () => void): void;
+  };
   themeParams: Record<string, string>;
   colorScheme: "light" | "dark";
   isExpanded: boolean;


### PR DESCRIPTION
## Summary
- Show the native Telegram header BackButton when viewing a file, hide it on return to directory listing
- onClick handler triggers the existing `handleBack` logic; cleanup on unmount prevents listener leaks
- Guarded against `BackButton` not existing (desktop browser fallback)
- Added `BackButton` type to `TelegramWebApp` interface, wrapped `handleBack` in `useCallback` for stable identity

Closes #207

## Test plan
- [x] `pnpm run test:unit` — all 97 tests pass
- [x] `tsc --noEmit` — clean typecheck
- [ ] Manual: open file viewer in Telegram, tap a file, verify native back button appears in header
- [ ] Manual: tap the native back button, verify return to directory listing and button hides
- [ ] Manual: open in desktop browser (no Telegram), verify no errors (graceful fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)