### PR TITLE
fix(markdown): GitHub alerts, syntax highlighting, touch isolation, external links

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,14 +16,17 @@
     "@xterm/addon-fit": "^0.10",
     "@xterm/addon-web-links": "^0.11",
     "@xterm/xterm": "^5",
+    "highlight.js": "^11.11.1",
     "mermaid": "^11.14.0",
     "react": "^19",
     "react-dom": "^19",
     "react-icons": "^5.6.0",
     "react-markdown": "^10.1.0",
+    "rehype-highlight": "^7.0.2",
     "rehype-slug": "^6.0.0",
     "remark-breaks": "^4.0.0",
-    "remark-gfm": "^4.0.1"
+    "remark-gfm": "^4.0.1",
+    "remark-github-blockquote-alert": "^2.1.0"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.2.2",

--- a/apps/web/src/__tests__/__snapshots__/markdown-snapshots.test.ts.snap
+++ b/apps/web/src/__tests__/__snapshots__/markdown-snapshots.test.ts.snap
@@ -98,25 +98,25 @@ exports[`MarkdownViewer (react-markdown baseline) > renders 02-lists.md consiste
 exports[`MarkdownViewer (react-markdown baseline) > renders 03-code-block-short.md consistently 1`] = `
 "<div class="md-content"><h1 id="short-code-block" data-has-section="true">Short code block</h1><section class="cpc-section" id="section-short-code-block" data-fold-slug="short-code-block">
 <p>Here is a small TypeScript snippet:</p>
-<pre><code class="language-ts">function greet(name: string): string {
-  return \`Hello, \${name}!\`;
+<pre><code class="hljs language-ts"><span class="hljs-keyword">function</span> <span class="hljs-title function_">greet</span>(<span class="hljs-params"><span class="hljs-attr">name</span>: <span class="hljs-built_in">string</span></span>): <span class="hljs-built_in">string</span> {
+  <span class="hljs-keyword">return</span> <span class="hljs-string">\`Hello, <span class="hljs-subst">\${name}</span>!\`</span>;
 }
 
-greet(&quot;world&quot;);
+<span class="hljs-title function_">greet</span>(<span class="hljs-string">&quot;world&quot;</span>);
 </code></pre>
 <p>And a short bash example:</p>
-<pre><code class="language-bash">pnpm install
-pnpm test
+<pre><code class="hljs language-bash">pnpm install
+pnpm <span class="hljs-built_in">test</span>
 </code></pre></section></div>"
 `;
 
 exports[`MarkdownViewer (react-markdown baseline) > renders 04-code-block-wide.md consistently 1`] = `
 "<div class="md-content"><h1 id="wide-code-block-horizontal-scroll-target" data-has-section="true">Wide code block (horizontal scroll target)</h1><section class="cpc-section" id="section-wide-code-block-horizontal-scroll-target" data-fold-slug="wide-code-block-horizontal-scroll-target">
 <p>This fixture exists to pin down the PR #20 regression around wide code blocks and horizontal scrolling.</p>
-<pre><code class="language-ts">// This single line is intentionally very long to force horizontal scrolling inside the rendered &lt;pre&gt;&lt;code&gt; container so we can diff how marked and react-markdown lay out the overflow behavior under the same CSS.
-const veryLongIdentifier = { alpha: 1, beta: 2, gamma: 3, delta: 4, epsilon: 5, zeta: 6, eta: 7, theta: 8, iota: 9, kappa: 10, lambda: 11, mu: 12, nu: 13, xi: 14, omicron: 15, pi: 16, rho: 17, sigma: 18, tau: 19, upsilon: 20, phi: 21, chi: 22, psi: 23, omega: 24 };
-function doSomethingThatTakesAbsurdlyManyArgumentsAndReturnsAnAbsurdlyLongInlineTypeAnnotation(arg1: string, arg2: number, arg3: boolean, arg4: Record&lt;string, unknown&gt;, arg5: Array&lt;{ id: string; value: number; metadata: Record&lt;string, string&gt; }&gt;): Promise&lt;{ ok: true; data: Array&lt;{ id: string; value: number; metadata: Record&lt;string, string&gt; }&gt; } | { ok: false; error: string }&gt; {
-  return Promise.resolve({ ok: true, data: arg5 });
+<pre><code class="hljs language-ts"><span class="hljs-comment">// This single line is intentionally very long to force horizontal scrolling inside the rendered &lt;pre&gt;&lt;code&gt; container so we can diff how marked and react-markdown lay out the overflow behavior under the same CSS.</span>
+<span class="hljs-keyword">const</span> veryLongIdentifier = { <span class="hljs-attr">alpha</span>: <span class="hljs-number">1</span>, <span class="hljs-attr">beta</span>: <span class="hljs-number">2</span>, <span class="hljs-attr">gamma</span>: <span class="hljs-number">3</span>, <span class="hljs-attr">delta</span>: <span class="hljs-number">4</span>, <span class="hljs-attr">epsilon</span>: <span class="hljs-number">5</span>, <span class="hljs-attr">zeta</span>: <span class="hljs-number">6</span>, <span class="hljs-attr">eta</span>: <span class="hljs-number">7</span>, <span class="hljs-attr">theta</span>: <span class="hljs-number">8</span>, <span class="hljs-attr">iota</span>: <span class="hljs-number">9</span>, <span class="hljs-attr">kappa</span>: <span class="hljs-number">10</span>, <span class="hljs-attr">lambda</span>: <span class="hljs-number">11</span>, <span class="hljs-attr">mu</span>: <span class="hljs-number">12</span>, <span class="hljs-attr">nu</span>: <span class="hljs-number">13</span>, <span class="hljs-attr">xi</span>: <span class="hljs-number">14</span>, <span class="hljs-attr">omicron</span>: <span class="hljs-number">15</span>, <span class="hljs-attr">pi</span>: <span class="hljs-number">16</span>, <span class="hljs-attr">rho</span>: <span class="hljs-number">17</span>, <span class="hljs-attr">sigma</span>: <span class="hljs-number">18</span>, <span class="hljs-attr">tau</span>: <span class="hljs-number">19</span>, <span class="hljs-attr">upsilon</span>: <span class="hljs-number">20</span>, <span class="hljs-attr">phi</span>: <span class="hljs-number">21</span>, <span class="hljs-attr">chi</span>: <span class="hljs-number">22</span>, <span class="hljs-attr">psi</span>: <span class="hljs-number">23</span>, <span class="hljs-attr">omega</span>: <span class="hljs-number">24</span> };
+<span class="hljs-keyword">function</span> <span class="hljs-title function_">doSomethingThatTakesAbsurdlyManyArgumentsAndReturnsAnAbsurdlyLongInlineTypeAnnotation</span>(<span class="hljs-params"><span class="hljs-attr">arg1</span>: <span class="hljs-built_in">string</span>, <span class="hljs-attr">arg2</span>: <span class="hljs-built_in">number</span>, <span class="hljs-attr">arg3</span>: <span class="hljs-built_in">boolean</span>, <span class="hljs-attr">arg4</span>: <span class="hljs-title class_">Record</span>&lt;<span class="hljs-built_in">string</span>, <span class="hljs-built_in">unknown</span>&gt;, <span class="hljs-attr">arg5</span>: <span class="hljs-title class_">Array</span>&lt;{ id: <span class="hljs-built_in">string</span>; value: <span class="hljs-built_in">number</span>; metadata: Record&lt;<span class="hljs-built_in">string</span>, <span class="hljs-built_in">string</span>&gt; }&gt;</span>): <span class="hljs-title class_">Promise</span>&lt;{ <span class="hljs-attr">ok</span>: <span class="hljs-literal">true</span>; <span class="hljs-attr">data</span>: <span class="hljs-title class_">Array</span>&lt;{ <span class="hljs-attr">id</span>: <span class="hljs-built_in">string</span>; <span class="hljs-attr">value</span>: <span class="hljs-built_in">number</span>; <span class="hljs-attr">metadata</span>: <span class="hljs-title class_">Record</span>&lt;<span class="hljs-built_in">string</span>, <span class="hljs-built_in">string</span>&gt; }&gt; } | { <span class="hljs-attr">ok</span>: <span class="hljs-literal">false</span>; <span class="hljs-attr">error</span>: <span class="hljs-built_in">string</span> }&gt; {
+  <span class="hljs-keyword">return</span> <span class="hljs-title class_">Promise</span>.<span class="hljs-title function_">resolve</span>({ <span class="hljs-attr">ok</span>: <span class="hljs-literal">true</span>, <span class="hljs-attr">data</span>: arg5 });
 }
 </code></pre>
 <p>And a short line afterwards to verify the following paragraph wraps normally after a wide code block:</p>
@@ -174,7 +174,7 @@ It spans two lines of markdown source.</p>
 </blockquote>
 <p>Blockquote containing a code block:</p>
 <blockquote>
-<pre><code class="language-ts">const quoted = &quot;code inside blockquote&quot;;
+<pre><code class="hljs language-ts"><span class="hljs-keyword">const</span> quoted = <span class="hljs-string">&quot;code inside blockquote&quot;</span>;
 </code></pre>
 </blockquote></section></div>"
 `;
@@ -775,37 +775,37 @@ exports[`MarkdownViewer (react-markdown baseline) > renders 12-real-doc-collapsi
 </ol>
 <h3 id="hide-mechanism-a-single-css-class">Hide mechanism: a single CSS class</h3>
 <p>Add to the existing <code>&lt;style&gt;</code> block:</p>
-<pre><code class="language-css">.cpc-folded { display: none !important; }
-.md-content h1, .md-content h2, .md-content h3,
-.md-content h4, .md-content h5, .md-content h6 {
-  position: relative;
+<pre><code class="hljs language-css"><span class="hljs-selector-class">.cpc-folded</span> { <span class="hljs-attribute">display</span>: none <span class="hljs-meta">!important</span>; }
+<span class="hljs-selector-class">.md-content</span> <span class="hljs-selector-tag">h1</span>, <span class="hljs-selector-class">.md-content</span> <span class="hljs-selector-tag">h2</span>, <span class="hljs-selector-class">.md-content</span> <span class="hljs-selector-tag">h3</span>,
+<span class="hljs-selector-class">.md-content</span> <span class="hljs-selector-tag">h4</span>, <span class="hljs-selector-class">.md-content</span> <span class="hljs-selector-tag">h5</span>, <span class="hljs-selector-class">.md-content</span> <span class="hljs-selector-tag">h6</span> {
+  <span class="hljs-attribute">position</span>: relative;
 }
-.md-content .cpc-toggle {
-  position: absolute;
-  left: -22px;
-  top: 50%;
-  transform: translateY(-50%);
-  width: 32px; height: 32px;
-  display: flex; align-items: center; justify-content: center;
-  background: transparent; border: none; color: #565f89;
-  cursor: pointer; font-size: 14px;
-  /* hit area extends past the visible 14px triangle */
+<span class="hljs-selector-class">.md-content</span> <span class="hljs-selector-class">.cpc-toggle</span> {
+  <span class="hljs-attribute">position</span>: absolute;
+  <span class="hljs-attribute">left</span>: -<span class="hljs-number">22px</span>;
+  <span class="hljs-attribute">top</span>: <span class="hljs-number">50%</span>;
+  <span class="hljs-attribute">transform</span>: <span class="hljs-built_in">translateY</span>(-<span class="hljs-number">50%</span>);
+  <span class="hljs-attribute">width</span>: <span class="hljs-number">32px</span>; <span class="hljs-attribute">height</span>: <span class="hljs-number">32px</span>;
+  <span class="hljs-attribute">display</span>: flex; <span class="hljs-attribute">align-items</span>: center; <span class="hljs-attribute">justify-content</span>: center;
+  <span class="hljs-attribute">background</span>: transparent; <span class="hljs-attribute">border</span>: none; <span class="hljs-attribute">color</span>: <span class="hljs-number">#565f89</span>;
+  <span class="hljs-attribute">cursor</span>: pointer; <span class="hljs-attribute">font-size</span>: <span class="hljs-number">14px</span>;
+  <span class="hljs-comment">/* hit area extends past the visible 14px triangle */</span>
 }
-.md-content .cpc-toggle:hover { color: #7aa2f7; }
+<span class="hljs-selector-class">.md-content</span> <span class="hljs-selector-class">.cpc-toggle</span><span class="hljs-selector-pseudo">:hover</span> { <span class="hljs-attribute">color</span>: <span class="hljs-number">#7aa2f7</span>; }
 </code></pre>
 <p>Then <code>node.classList.add(&quot;cpc-folded&quot;)</code> / <code>removeAttribute(&quot;class&quot;)</code> is the entire collapse mechanic. We never touch <code>style.display</code>, so we never have to remember original display values. This cleanly handles <code>display: block</code>, <code>display: flex</code> (none of the markdown elements use it but defensively), <code>display: table</code> (for <code>&lt;table&gt;</code>), etc.</p>
 <h3 id="nested-fold-preservation">Nested fold preservation</h3>
 <p>Because hidden ancestors don&#x27;t run their own fold logic (we just <code>display: none</code> everything inside them), a collapsed h3 stays in <code>foldedSections</code> even when its parent h2 is also collapsed. When the h2 expands, the h3 remains collapsed because its slug is still in the set and the next post-process pass re-applies it. Exactly what we want.</p>
 <h3 id="click-handling">Click handling</h3>
 <p>Single delegated listener on <code>rootRef.current</code>:</p>
-<pre><code class="language-ts">const onClick = (e: MouseEvent) =&gt; {
-  const btn = (e.target as HTMLElement).closest(&#x27;.cpc-toggle&#x27;);
-  if (!btn) return;
-  const slug = btn.getAttribute(&#x27;data-slug&#x27;);
-  if (!slug) return;
-  e.preventDefault();
-  e.stopPropagation();
-  toggleFold(slug);
+<pre><code class="hljs language-ts"><span class="hljs-keyword">const</span> <span class="hljs-title function_">onClick</span> = (<span class="hljs-params"><span class="hljs-attr">e</span>: <span class="hljs-title class_">MouseEvent</span></span>) =&gt; {
+  <span class="hljs-keyword">const</span> btn = (e.<span class="hljs-property">target</span> <span class="hljs-keyword">as</span> <span class="hljs-title class_">HTMLElement</span>).<span class="hljs-title function_">closest</span>(<span class="hljs-string">&#x27;.cpc-toggle&#x27;</span>);
+  <span class="hljs-keyword">if</span> (!btn) <span class="hljs-keyword">return</span>;
+  <span class="hljs-keyword">const</span> slug = btn.<span class="hljs-title function_">getAttribute</span>(<span class="hljs-string">&#x27;data-slug&#x27;</span>);
+  <span class="hljs-keyword">if</span> (!slug) <span class="hljs-keyword">return</span>;
+  e.<span class="hljs-title function_">preventDefault</span>();
+  e.<span class="hljs-title function_">stopPropagation</span>();
+  <span class="hljs-title function_">toggleFold</span>(slug);
 };
 </code></pre>
 <p>Where <code>toggleFold</code> is a callback passed from <code>App.tsx</code> (or <code>FileViewer</code>) that updates <code>foldedSections</code>.</p>
@@ -813,24 +813,24 @@ exports[`MarkdownViewer (react-markdown baseline) > renders 12-real-doc-collapsi
 <h2 id="part-5--toc-sync-strategy">Part 5 — TOC sync strategy</h2>
 <h3 id="state-management--recommendation">State management — recommendation</h3>
 <p><strong>Lift to <code>App.tsx</code>.</strong> Add:</p>
-<pre><code class="language-ts">const [foldedSections, setFoldedSections] = useState&lt;Set&lt;string&gt;&gt;(new Set());
+<pre><code class="hljs language-ts"><span class="hljs-keyword">const</span> [foldedSections, setFoldedSections] = useState&lt;<span class="hljs-title class_">Set</span>&lt;<span class="hljs-built_in">string</span>&gt;&gt;(<span class="hljs-keyword">new</span> <span class="hljs-title class_">Set</span>());
 
-// Reset whenever the viewing file changes
-useEffect(() =&gt; { setFoldedSections(new Set()); }, [viewingFile?.path]);
+<span class="hljs-comment">// Reset whenever the viewing file changes</span>
+<span class="hljs-title function_">useEffect</span>(<span class="hljs-function">() =&gt;</span> { <span class="hljs-title function_">setFoldedSections</span>(<span class="hljs-keyword">new</span> <span class="hljs-title class_">Set</span>()); }, [viewingFile?.<span class="hljs-property">path</span>]);
 
-const toggleFold = useCallback((slug: string) =&gt; {
-  setFoldedSections(prev =&gt; {
-    const next = new Set(prev);
-    if (next.has(slug)) next.delete(slug); else next.add(slug);
-    return next;
+<span class="hljs-keyword">const</span> toggleFold = <span class="hljs-title function_">useCallback</span>(<span class="hljs-function">(<span class="hljs-params"><span class="hljs-attr">slug</span>: <span class="hljs-built_in">string</span></span>) =&gt;</span> {
+  <span class="hljs-title function_">setFoldedSections</span>(<span class="hljs-function"><span class="hljs-params">prev</span> =&gt;</span> {
+    <span class="hljs-keyword">const</span> next = <span class="hljs-keyword">new</span> <span class="hljs-title class_">Set</span>(prev);
+    <span class="hljs-keyword">if</span> (next.<span class="hljs-title function_">has</span>(slug)) next.<span class="hljs-title function_">delete</span>(slug); <span class="hljs-keyword">else</span> next.<span class="hljs-title function_">add</span>(slug);
+    <span class="hljs-keyword">return</span> next;
   });
 }, []);
 
-const expandAncestors = useCallback((slugs: string[]) =&gt; {
-  setFoldedSections(prev =&gt; {
-    const next = new Set(prev);
-    for (const s of slugs) next.delete(s);
-    return next;
+<span class="hljs-keyword">const</span> expandAncestors = <span class="hljs-title function_">useCallback</span>(<span class="hljs-function">(<span class="hljs-params"><span class="hljs-attr">slugs</span>: <span class="hljs-built_in">string</span>[]</span>) =&gt;</span> {
+  <span class="hljs-title function_">setFoldedSections</span>(<span class="hljs-function"><span class="hljs-params">prev</span> =&gt;</span> {
+    <span class="hljs-keyword">const</span> next = <span class="hljs-keyword">new</span> <span class="hljs-title class_">Set</span>(prev);
+    <span class="hljs-keyword">for</span> (<span class="hljs-keyword">const</span> s <span class="hljs-keyword">of</span> slugs) next.<span class="hljs-title function_">delete</span>(s);
+    <span class="hljs-keyword">return</span> next;
   });
 }, []);
 </code></pre>
@@ -904,17 +904,17 @@ const expandAncestors = useCallback((slugs: string[]) =&gt; {
 <ol>
 <li>Add a slug helper in <code>MarkdownViewer.tsx</code> (or a new <code>lib/slug.ts</code> if you prefer): <code>function slugify(text: string, used: Set&lt;string&gt;): string</code> that lowercases, strips punctuation, replaces whitespace with <code>-</code>, and appends <code>-2</code>, <code>-3</code> for duplicates.</li>
 <li>Override marked&#x27;s heading renderer:
-<pre><code class="language-ts">const slugCounts = new Map&lt;string, number&gt;();
-marked.use({
-  renderer: {
-    heading({ tokens, depth }) {
-      const text = this.parser.parseInline(tokens);
-      const plain = text.replace(/&lt;[^&gt;]*&gt;/g, &#x27;&#x27;);  // strip inline HTML for slug
-      const base = slugify(plain);
-      const n = (slugCounts.get(base) ?? 0) + 1;
-      slugCounts.set(base, n);
-      const slug = n === 1 ? base : \`\${base}-\${n}\`;
-      return \`&lt;h\${depth} id=&quot;\${slug}&quot;&gt;\${text}&lt;/h\${depth}&gt;\\n\`;
+<pre><code class="hljs language-ts"><span class="hljs-keyword">const</span> slugCounts = <span class="hljs-keyword">new</span> <span class="hljs-title class_">Map</span>&lt;<span class="hljs-built_in">string</span>, <span class="hljs-built_in">number</span>&gt;();
+marked.<span class="hljs-title function_">use</span>({
+  <span class="hljs-attr">renderer</span>: {
+    <span class="hljs-title function_">heading</span>(<span class="hljs-params">{ tokens, depth }</span>) {
+      <span class="hljs-keyword">const</span> text = <span class="hljs-variable language_">this</span>.<span class="hljs-property">parser</span>.<span class="hljs-title function_">parseInline</span>(tokens);
+      <span class="hljs-keyword">const</span> plain = text.<span class="hljs-title function_">replace</span>(<span class="hljs-regexp">/&lt;[^&gt;]*&gt;/g</span>, <span class="hljs-string">&#x27;&#x27;</span>);  <span class="hljs-comment">// strip inline HTML for slug</span>
+      <span class="hljs-keyword">const</span> base = <span class="hljs-title function_">slugify</span>(plain);
+      <span class="hljs-keyword">const</span> n = (slugCounts.<span class="hljs-title function_">get</span>(base) ?? <span class="hljs-number">0</span>) + <span class="hljs-number">1</span>;
+      slugCounts.<span class="hljs-title function_">set</span>(base, n);
+      <span class="hljs-keyword">const</span> slug = n === <span class="hljs-number">1</span> ? base : <span class="hljs-string">\`<span class="hljs-subst">\${base}</span>-<span class="hljs-subst">\${n}</span>\`</span>;
+      <span class="hljs-keyword">return</span> <span class="hljs-string">\`&lt;h<span class="hljs-subst">\${depth}</span> id=&quot;<span class="hljs-subst">\${slug}</span>&quot;&gt;<span class="hljs-subst">\${text}</span>&lt;/h<span class="hljs-subst">\${depth}</span>&gt;\\n\`</span>;
     }
   }
 });
@@ -979,8 +979,8 @@ exports[`MarkdownViewer (react-markdown baseline) > renders 13-mermaid.md consis
 <h2 id="flowchart">Flowchart</h2>
 <div class="mermaid-mount"><div class="mermaid-loading">Loading diagram…</div></div>
 <h2 id="regular-code-block-should-stay-as-code">Regular code block (should stay as code)</h2>
-<pre><code class="language-js">const hello = &quot;world&quot;;
-console.log(hello);
+<pre><code class="hljs language-js"><span class="hljs-keyword">const</span> hello = <span class="hljs-string">&quot;world&quot;</span>;
+<span class="hljs-variable language_">console</span>.<span class="hljs-title function_">log</span>(hello);
 </code></pre>
 <p>Done.</p></section></div>"
 `;

--- a/apps/web/src/components/MarkdownViewer.tsx
+++ b/apps/web/src/components/MarkdownViewer.tsx
@@ -2,7 +2,10 @@ import React, { Children, isValidElement, useState, useCallback, useMemo, useRef
 import ReactMarkdown, { type Components, type ExtraProps } from "react-markdown";
 import remarkGfm from "remark-gfm";
 import remarkBreaks from "remark-breaks";
+import { remarkAlert } from "remark-github-blockquote-alert";
+import rehypeHighlight from "rehype-highlight";
 import rehypeSlug from "rehype-slug";
+import "highlight.js/styles/tokyo-night-dark.css";
 import { MermaidDiagram } from "./MermaidDiagram";
 import { rehypeCollapsibleSections } from "./markdown/rehype-collapsible-sections";
 import { makeHeadingComponent, type HeadingEntry } from "./markdown/CollapsibleHeading";
@@ -12,12 +15,17 @@ interface MarkdownViewerProps {
   fileName: string;
 }
 
-export const markdownRemarkPlugins = [remarkGfm, remarkBreaks];
+export const markdownRemarkPlugins = [remarkGfm, remarkBreaks, remarkAlert];
 
+// rehype-highlight runs first so code blocks get syntax spans before slug/section processing.
 // rehype-slug is pinned to major 6 in package.json. Heading IDs are a contract
 // for deep links, TOC state, and collapsible headings.
 // rehypeCollapsibleSections must run AFTER rehypeSlug so slug IDs exist.
-export const markdownRehypePlugins = [rehypeSlug, rehypeCollapsibleSections];
+export const markdownRehypePlugins = [
+  [rehypeHighlight, { detect: false, plainText: ["mermaid"] }] as [typeof rehypeHighlight, Parameters<typeof rehypeHighlight>[0]],
+  rehypeSlug,
+  rehypeCollapsibleSections,
+];
 
 function getLanguage(className?: string): string {
   return (
@@ -73,6 +81,9 @@ function isMermaidCodeChild(child: ReactNode): boolean {
   );
 }
 
+/** Stop horizontal touch events from bubbling to the app-level tab-swipe handler. */
+const stopTouchPropagation = (e: React.TouchEvent) => e.stopPropagation();
+
 function PreBlock({ children, node: _node, ...props }: React.ComponentPropsWithoutRef<'pre'> & ExtraProps) {
   const childArray = Children.toArray(children);
 
@@ -80,13 +91,58 @@ function PreBlock({ children, node: _node, ...props }: React.ComponentPropsWitho
     return <>{children}</>;
   }
 
-  return <pre {...props}>{children}</pre>;
+  return (
+    <pre
+      {...props}
+      onTouchStart={stopTouchPropagation}
+      onTouchMove={stopTouchPropagation}
+      onTouchEnd={stopTouchPropagation}
+    >
+      {children}
+    </pre>
+  );
+}
+
+function isExternalUrl(href: string | undefined): boolean {
+  if (!href) return false;
+  try {
+    const url = new URL(href, window.location.origin);
+    return (url.protocol === "http:" || url.protocol === "https:") && url.origin !== window.location.origin;
+  } catch {
+    return false;
+  }
+}
+
+function MarkdownLink({ href, children, node: _node, ...props }: React.ComponentPropsWithoutRef<'a'> & ExtraProps) {
+  if (!isExternalUrl(href)) {
+    return <a href={href} {...props}>{children}</a>;
+  }
+
+  const handleClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+    try {
+      const tg = window.Telegram?.WebApp;
+      if (tg && typeof (tg as any).openLink === "function") {
+        (tg as any).openLink(href);
+        return;
+      }
+    } catch { /* fallback */ }
+    window.open(href!, "_blank", "noopener,noreferrer");
+  };
+
+  return (
+    <a href={href} onClick={handleClick} {...props}>
+      {children}
+    </a>
+  );
 }
 
 const baseComponents: Partial<Components> = {
   code: CodeBlock,
   table: ScrollableTable,
   pre: PreBlock,
+  a: MarkdownLink,
 };
 
 /** @deprecated Use baseComponents internally; kept for test compatibility */
@@ -273,6 +329,7 @@ export function MarkdownViewer({ content, fileName: _fileName }: MarkdownViewerP
           padding: 12px 16px;
           overflow-x: auto;
           -webkit-overflow-scrolling: touch;
+          touch-action: pan-y;
           margin: 12px 0;
         }
         .md-content pre code {
@@ -326,6 +383,58 @@ export function MarkdownViewer({ content, fileName: _fileName }: MarkdownViewerP
           color: var(--color-fg-muted);
           background: var(--color-bg);
           border-radius: 0 4px 4px 0;
+        }
+        /* GitHub-style alert admonitions */
+        .md-content .markdown-alert {
+          border-left-width: 3px;
+          border-left-style: solid;
+          border-radius: 0 4px 4px 0;
+          margin: 12px 0;
+          padding: 8px 16px;
+          background: var(--color-bg);
+        }
+        .md-content .markdown-alert .markdown-alert-title {
+          display: flex;
+          align-items: center;
+          gap: 6px;
+          font-weight: 600;
+          font-size: 13px;
+          margin-bottom: 4px;
+        }
+        .md-content .markdown-alert .markdown-alert-title svg.octicon {
+          width: 16px;
+          height: 16px;
+          fill: currentColor;
+        }
+        .md-content .markdown-alert-note {
+          border-left-color: #7aa2f7;
+        }
+        .md-content .markdown-alert-note .markdown-alert-title {
+          color: #7aa2f7;
+        }
+        .md-content .markdown-alert-tip {
+          border-left-color: #9ece6a;
+        }
+        .md-content .markdown-alert-tip .markdown-alert-title {
+          color: #9ece6a;
+        }
+        .md-content .markdown-alert-important {
+          border-left-color: #bb9af7;
+        }
+        .md-content .markdown-alert-important .markdown-alert-title {
+          color: #bb9af7;
+        }
+        .md-content .markdown-alert-warning {
+          border-left-color: #e0af68;
+        }
+        .md-content .markdown-alert-warning .markdown-alert-title {
+          color: #e0af68;
+        }
+        .md-content .markdown-alert-caution {
+          border-left-color: #f7768e;
+        }
+        .md-content .markdown-alert-caution .markdown-alert-title {
+          color: #f7768e;
         }
         .md-content hr {
           border: none;
@@ -391,18 +500,19 @@ export function MarkdownViewer({ content, fileName: _fileName }: MarkdownViewerP
         .md-content .cpc-collapsible-heading {
           display: flex;
           align-items: center;
-          gap: 6px;
         }
         .md-content .cpc-fold-btn {
           all: unset;
-          flex: 0 0 auto;
           cursor: pointer;
           display: inline-flex;
           align-items: center;
-          justify-content: center;
-          width: 20px;
-          height: 20px;
+          gap: 6px;
           border-radius: 3px;
+          width: 100%;
+        }
+        .md-content .cpc-fold-label {
+          flex: 1 1 auto;
+          min-width: 0;
         }
         .md-content .cpc-fold-btn:focus-visible {
           outline: 2px solid var(--color-accent-blue);

--- a/apps/web/src/components/__tests__/__snapshots__/markdown-parity.test.ts.snap
+++ b/apps/web/src/components/__tests__/__snapshots__/markdown-parity.test.ts.snap
@@ -42,32 +42,32 @@ exports[`Markdown parity baseline (react-markdown) > renders code-blocks through
 "<div class="md-content"><h1 id="code-blocks-and-commands" data-has-section="true">Code Blocks And Commands</h1><section class="cpc-section" id="section-code-blocks-and-commands" data-fold-slug="code-blocks-and-commands">
 <p>Inline code such as <code>getAuthHeaders()</code> and <code>Telegram.WebApp.disableVerticalSwipes()</code><br/>
 appears beside fenced examples in CPC docs.</p>
-<pre><code class="language-ts">type SessionStatus = &quot;connected&quot; | &quot;paused&quot; | &quot;failed&quot;;
+<pre><code class="hljs language-ts"><span class="hljs-keyword">type</span> <span class="hljs-title class_">SessionStatus</span> = <span class="hljs-string">&quot;connected&quot;</span> | <span class="hljs-string">&quot;paused&quot;</span> | <span class="hljs-string">&quot;failed&quot;</span>;
 
-export function labelForStatus(status: SessionStatus): string {
-  switch (status) {
-    case &quot;connected&quot;:
-      return &quot;Connected&quot;;
-    case &quot;paused&quot;:
-      return &quot;Paused&quot;;
-    case &quot;failed&quot;:
-      return &quot;Needs attention&quot;;
+<span class="hljs-keyword">export</span> <span class="hljs-keyword">function</span> <span class="hljs-title function_">labelForStatus</span>(<span class="hljs-params"><span class="hljs-attr">status</span>: <span class="hljs-title class_">SessionStatus</span></span>): <span class="hljs-built_in">string</span> {
+  <span class="hljs-keyword">switch</span> (status) {
+    <span class="hljs-keyword">case</span> <span class="hljs-string">&quot;connected&quot;</span>:
+      <span class="hljs-keyword">return</span> <span class="hljs-string">&quot;Connected&quot;</span>;
+    <span class="hljs-keyword">case</span> <span class="hljs-string">&quot;paused&quot;</span>:
+      <span class="hljs-keyword">return</span> <span class="hljs-string">&quot;Paused&quot;</span>;
+    <span class="hljs-keyword">case</span> <span class="hljs-string">&quot;failed&quot;</span>:
+      <span class="hljs-keyword">return</span> <span class="hljs-string">&quot;Needs attention&quot;</span>;
   }
 }
 </code></pre>
-<pre><code class="language-bash">cd /home/claude/code/cpc-impl-react-markdown
+<pre><code class="hljs language-bash"><span class="hljs-built_in">cd</span> /home/claude/code/cpc-impl-react-markdown
 pnpm install --silent
-pnpm --filter @cpc/web exec tsc -b
-pnpm --filter @cpc/web test
+pnpm --filter @cpc/web <span class="hljs-built_in">exec</span> tsc -b
+pnpm --filter @cpc/web <span class="hljs-built_in">test</span>
 </code></pre>
-<pre><code class="language-json">{
-  &quot;server&quot;: {
-    &quot;port&quot;: 38830,
-    &quot;prodTunnel&quot;: &quot;https://cpc.claude.do&quot;,
-    &quot;devTunnel&quot;: &quot;https://cpc-dev.claude.do&quot;
-  },
-  &quot;features&quot;: [&quot;files&quot;, &quot;terminal&quot;, &quot;voice&quot;]
-}
+<pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
+  <span class="hljs-attr">&quot;server&quot;</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">{</span>
+    <span class="hljs-attr">&quot;port&quot;</span><span class="hljs-punctuation">:</span> <span class="hljs-number">38830</span><span class="hljs-punctuation">,</span>
+    <span class="hljs-attr">&quot;prodTunnel&quot;</span><span class="hljs-punctuation">:</span> <span class="hljs-string">&quot;https://cpc.claude.do&quot;</span><span class="hljs-punctuation">,</span>
+    <span class="hljs-attr">&quot;devTunnel&quot;</span><span class="hljs-punctuation">:</span> <span class="hljs-string">&quot;https://cpc-dev.claude.do&quot;</span>
+  <span class="hljs-punctuation">}</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">&quot;features&quot;</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">&quot;files&quot;</span><span class="hljs-punctuation">,</span> <span class="hljs-string">&quot;terminal&quot;</span><span class="hljs-punctuation">,</span> <span class="hljs-string">&quot;voice&quot;</span><span class="hljs-punctuation">]</span>
+<span class="hljs-punctuation">}</span>
 </code></pre>
 <p>An unlabelled block still matters:</p>
 <pre><code>Actions -&gt; Develop -&gt; Voice
@@ -105,7 +105,7 @@ unexpected empty paragraphs.</p>
 <li>Unordered child
 <blockquote>
 <p>Quote inside a list item.</p>
-<pre><code class="language-bash">pnpm --filter @cpc/web test
+<pre><code class="hljs language-bash">pnpm --filter @cpc/web <span class="hljs-built_in">test</span>
 </code></pre>
 </blockquote>
 </li>
@@ -118,7 +118,7 @@ unexpected empty paragraphs.</p>
 <li>A quoted list item</li>
 <li>Another quoted list item with <code>code</code></li>
 </ul>
-<pre><code class="language-ts">const source = &quot;quoted code&quot;;
+<pre><code class="hljs language-ts"><span class="hljs-keyword">const</span> source = <span class="hljs-string">&quot;quoted code&quot;</span>;
 </code></pre>
 </blockquote>
 <hr/>
@@ -215,16 +215,16 @@ Do not edit the external Telegram plugin.</p>
 <h2 id="6-example-route-notes">6. Example Route Notes</h2>
 <p>The web app uses a base path from Vite. Static assets should keep working at<br/>
 both <code>https://cpc.claude.do</code> and <code>https://cpc-dev.claude.do</code>.</p>
-<pre><code class="language-ts">export function buildAssetPath(baseUrl: string, name: string): string {
-  const base = baseUrl.endsWith(&quot;/&quot;) ? baseUrl : \`\${baseUrl}/\`;
-  return new URL(name, base).toString();
+<pre><code class="hljs language-ts"><span class="hljs-keyword">export</span> <span class="hljs-keyword">function</span> <span class="hljs-title function_">buildAssetPath</span>(<span class="hljs-params"><span class="hljs-attr">baseUrl</span>: <span class="hljs-built_in">string</span>, <span class="hljs-attr">name</span>: <span class="hljs-built_in">string</span></span>): <span class="hljs-built_in">string</span> {
+  <span class="hljs-keyword">const</span> base = baseUrl.<span class="hljs-title function_">endsWith</span>(<span class="hljs-string">&quot;/&quot;</span>) ? baseUrl : <span class="hljs-string">\`<span class="hljs-subst">\${baseUrl}</span>/\`</span>;
+  <span class="hljs-keyword">return</span> <span class="hljs-keyword">new</span> <span class="hljs-title function_">URL</span>(name, base).<span class="hljs-title function_">toString</span>();
 }
 </code></pre>
 <h2 id="7-shell-recipe">7. Shell Recipe</h2>
-<pre><code class="language-bash">set -euo pipefail
+<pre><code class="hljs language-bash"><span class="hljs-built_in">set</span> -euo pipefail
 pnpm install --silent
-pnpm --filter @cpc/web exec tsc -b
-pnpm --filter @cpc/web test
+pnpm --filter @cpc/web <span class="hljs-built_in">exec</span> tsc -b
+pnpm --filter @cpc/web <span class="hljs-built_in">test</span>
 pnpm --filter @cpc/web build
 </code></pre>
 <h2 id="8-failure-modes">8. Failure Modes</h2>
@@ -259,15 +259,15 @@ WebView does not expose the browser media prompt consistently.</p>
 <p>Terminal output can include long paths such as<br/>
 <code>/home/claude/code/cpc-impl-react-markdown/apps/web/src/components/MarkdownViewer.tsx</code>.</p>
 <h2 id="11-json-payload">11. JSON Payload</h2>
-<pre><code class="language-json">{
-  &quot;kind&quot;: &quot;SessionStart&quot;,
-  &quot;buttons&quot;: [&quot;Actions&quot;, &quot;Develop&quot;, &quot;Voice&quot;],
-  &quot;viewer&quot;: {
-    &quot;markdown&quot;: true,
-    &quot;mermaid&quot;: true,
-    &quot;rawHtml&quot;: &quot;baseline-only&quot;
-  }
-}
+<pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
+  <span class="hljs-attr">&quot;kind&quot;</span><span class="hljs-punctuation">:</span> <span class="hljs-string">&quot;SessionStart&quot;</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">&quot;buttons&quot;</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">&quot;Actions&quot;</span><span class="hljs-punctuation">,</span> <span class="hljs-string">&quot;Develop&quot;</span><span class="hljs-punctuation">,</span> <span class="hljs-string">&quot;Voice&quot;</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">&quot;viewer&quot;</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">{</span>
+    <span class="hljs-attr">&quot;markdown&quot;</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">true</span></span><span class="hljs-punctuation">,</span>
+    <span class="hljs-attr">&quot;mermaid&quot;</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">true</span></span><span class="hljs-punctuation">,</span>
+    <span class="hljs-attr">&quot;rawHtml&quot;</span><span class="hljs-punctuation">:</span> <span class="hljs-string">&quot;baseline-only&quot;</span>
+  <span class="hljs-punctuation">}</span>
+<span class="hljs-punctuation">}</span>
 </code></pre>
 <h2 id="12-closing-notes">12. Closing Notes</h2>
 <p>Soft breaks appear here<br/>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,6 +60,9 @@ importers:
       '@xterm/xterm':
         specifier: ^5
         version: 5.5.0
+      highlight.js:
+        specifier: ^11.11.1
+        version: 11.11.1
       mermaid:
         specifier: ^11.14.0
         version: 11.14.0
@@ -75,6 +78,9 @@ importers:
       react-markdown:
         specifier: ^10.1.0
         version: 10.1.0(@types/react@19.2.14)(react@19.2.4)
+      rehype-highlight:
+        specifier: ^7.0.2
+        version: 7.0.2
       rehype-slug:
         specifier: ^6.0.0
         version: 6.0.0
@@ -84,6 +90,9 @@ importers:
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1
+      remark-github-blockquote-alert:
+        specifier: ^2.1.0
+        version: 2.1.0
     devDependencies:
       '@tailwindcss/vite':
         specifier: ^4.2.2
@@ -1635,14 +1644,24 @@ packages:
   hast-util-heading-rank@3.0.0:
     resolution: {integrity: sha512-EJKb8oMUXVHcWZTDepnr+WNbfnXKFNf9duMesmr4S8SXTJBJ9M4Yok08pu9vxdJwdlGRhVumk9mEhkEvKGifwA==}
 
+  hast-util-is-element@3.0.0:
+    resolution: {integrity: sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==}
+
   hast-util-to-jsx-runtime@2.3.6:
     resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
 
   hast-util-to-string@3.0.1:
     resolution: {integrity: sha512-XelQVTDWvqcl3axRfI0xSeoVKzyIFPwsAGSLIsKdJKQMXDYJS4WYrBNF/8J7RdhIcFI2BOHgAifggsvsxp/3+A==}
 
+  hast-util-to-text@4.0.2:
+    resolution: {integrity: sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==}
+
   hast-util-whitespace@3.0.0:
     resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
+  highlight.js@11.11.1:
+    resolution: {integrity: sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==}
+    engines: {node: '>=12.0.0'}
 
   hono@4.12.12:
     resolution: {integrity: sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==}
@@ -1837,6 +1856,9 @@ packages:
 
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
+
+  lowlight@3.3.0:
+    resolution: {integrity: sha512-0JNhgFoPvP6U6lE/UdVsSq99tn6DhjjpAj5MxG49ewd2mOBVtwWYIT8ClyABhq198aXXODMU6Ox8DrGy/CpTZQ==}
 
   lru-cache@11.3.2:
     resolution: {integrity: sha512-wgWa6FWQ3QRRJbIjbsldRJZxdxYngT/dO0I5Ynmlnin8qy7tC6xYzbcJjtN4wHLXtkbVwHzk0C+OejVw1XM+DQ==}
@@ -2160,6 +2182,9 @@ packages:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
 
+  rehype-highlight@7.0.2:
+    resolution: {integrity: sha512-k158pK7wdC2qL3M5NcZROZ2tR/l7zOzjxXd5VGdcfIyoijjQqpHd3JKtYSBDpDZ38UI2WJWuFAtkMDxmx5kstA==}
+
   rehype-slug@6.0.0:
     resolution: {integrity: sha512-lWyvf/jwu+oS5+hL5eClVd3hNdmwM1kAC0BUvEGD19pajQMIzcNUd/k9GsfQ+FfECvX+JE+e9/btsKH0EjJT6A==}
 
@@ -2168,6 +2193,10 @@ packages:
 
   remark-gfm@4.0.1:
     resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
+
+  remark-github-blockquote-alert@2.1.0:
+    resolution: {integrity: sha512-J392jmIP684d7iGsENN0uguL10IGbRdc8bTUSrd/jOLzdWkwg721Fj3JPQGN8tF6fTIrE5HHOIA3nBuwuaeuPQ==}
+    engines: {node: '>=16'}
 
   remark-parse@11.0.0:
     resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
@@ -2389,6 +2418,9 @@ packages:
 
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
+
+  unist-util-find-after@5.0.0:
+    resolution: {integrity: sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==}
 
   unist-util-is@6.0.1:
     resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
@@ -3949,6 +3981,10 @@ snapshots:
     dependencies:
       '@types/hast': 3.0.4
 
+  hast-util-is-element@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
   hast-util-to-jsx-runtime@2.3.6:
     dependencies:
       '@types/estree': 1.0.8
@@ -3973,9 +4009,18 @@ snapshots:
     dependencies:
       '@types/hast': 3.0.4
 
+  hast-util-to-text@4.0.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      hast-util-is-element: 3.0.0
+      unist-util-find-after: 5.0.0
+
   hast-util-whitespace@3.0.0:
     dependencies:
       '@types/hast': 3.0.4
+
+  highlight.js@11.11.1: {}
 
   hono@4.12.12: {}
 
@@ -4137,6 +4182,12 @@ snapshots:
   lodash-es@4.18.1: {}
 
   longest-streak@3.1.0: {}
+
+  lowlight@3.3.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      devlop: 1.1.0
+      highlight.js: 11.11.1
 
   lru-cache@11.3.2: {}
 
@@ -4709,6 +4760,14 @@ snapshots:
       indent-string: 4.0.0
       strip-indent: 3.0.0
 
+  rehype-highlight@7.0.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-to-text: 4.0.2
+      lowlight: 3.3.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+
   rehype-slug@6.0.0:
     dependencies:
       '@types/hast': 3.0.4
@@ -4733,6 +4792,10 @@ snapshots:
       unified: 11.0.5
     transitivePeerDependencies:
       - supports-color
+
+  remark-github-blockquote-alert@2.1.0:
+    dependencies:
+      unist-util-visit: 5.1.0
 
   remark-parse@11.0.0:
     dependencies:
@@ -4980,6 +5043,11 @@ snapshots:
       is-plain-obj: 4.1.0
       trough: 2.2.0
       vfile: 6.0.3
+
+  unist-util-find-after@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
 
   unist-util-is@6.0.1:
     dependencies:


### PR DESCRIPTION
## Summary

Fixes 4 UAT markdown rendering bugs in the web frontend (Bugs 2-5 from v1.11.1 UAT):

- **Bug 2 - GitHub alert admonitions**: Added `remark-github-blockquote-alert` plugin to transform `> [!NOTE]` / `> [!TIP]` / etc. into styled alert boxes with Tokyo Night palette colors
- **Bug 3 - Code block h-scroll vs tab swipe**: Added `touch-action: pan-y` CSS and `stopPropagation` touch handlers on `PreBlock` to prevent horizontal code scrolling from triggering tab swipe navigation
- **Bug 4 - Syntax highlighting**: Added `rehype-highlight` with `highlight.js/styles/tokyo-night-dark.css` theme. Mermaid blocks excluded via `plainText: ["mermaid"]` option
- **Bug 5 - External links escape mini app**: Added `MarkdownLink` component that intercepts external URLs and opens them via `Telegram.WebApp.openLink()` (falling back to `window.open`) instead of navigating away

## Test plan

- [x] `pnpm --filter @cpc/web typecheck` passes
- [x] `pnpm --filter @cpc/web test` passes (97 tests, 25 snapshots updated)
- [x] `pnpm run build` succeeds
- [ ] Manual verification in Telegram WebView: alerts render as colored callouts, code blocks have syntax colors, horizontal code scroll doesn't switch tabs, external links open in Telegram browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>