### PR TITLE
fix(uat): BackButton visibility restore, markdown images, code block h-scroll touch

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -476,6 +476,9 @@ export function FileViewer({ onClose, initialFile, showHidden = false, sortMode 
   // Wire Telegram's native BackButton when viewing a file. Show it on
   // file open, hide it when returning to the directory listing, and clean
   // up the handler on unmount so we don't leak listeners.
+  // Also restore BackButton after returning from an external link — the
+  // Telegram WebApp can lose the BackButton state when the webview is
+  // backgrounded (e.g. opening a link via tg.openLink).
   useEffect(() => {
     const bb = window.Telegram?.WebApp?.BackButton;
     if (!bb) return;
@@ -487,7 +490,15 @@ export function FileViewer({ onClose, initialFile, showHidden = false, sortMode 
       bb.hide();
     }
 
+    const onVisibilityChange = () => {
+      if (document.visibilityState === "visible" && fileContent !== null) {
+        bb.show();
+      }
+    };
+    document.addEventListener("visibilitychange", onVisibilityChange);
+
     return () => {
+      document.removeEventListener("visibilitychange", onVisibilityChange);
       bb.offClick(handleBack);
       bb.hide();
     };

--- a/apps/web/src/components/MarkdownViewer.tsx
+++ b/apps/web/src/components/MarkdownViewer.tsx
@@ -94,9 +94,7 @@ function PreBlock({ children, node: _node, ...props }: React.ComponentPropsWitho
   return (
     <pre
       {...props}
-      onTouchStart={stopTouchPropagation}
       onTouchMove={stopTouchPropagation}
-      onTouchEnd={stopTouchPropagation}
     >
       {children}
     </pre>
@@ -329,7 +327,7 @@ export function MarkdownViewer({ content, fileName: _fileName }: MarkdownViewerP
           padding: 12px 16px;
           overflow-x: auto;
           -webkit-overflow-scrolling: touch;
-          touch-action: pan-y;
+          touch-action: pan-x pan-y;
           margin: 12px 0;
         }
         .md-content pre code {
@@ -446,8 +444,11 @@ export function MarkdownViewer({ content, fileName: _fileName }: MarkdownViewerP
           font-weight: 600;
         }
         .md-content img {
+          display: block;
           max-width: 100%;
-          border-radius: 4px;
+          height: auto;
+          border-radius: 8px;
+          margin: 0.5em 0;
         }
         .md-content .mermaid-mount {
           margin: 12px 0;


### PR DESCRIPTION
## Summary
- **Bug A (BackButton lost after external link):** Added `visibilitychange` event listener in FileViewer's BackButton useEffect. When the document becomes visible again and a file is being viewed, `BackButton.show()` is re-called to restore the native back button that Telegram loses when the webview is backgrounded by `tg.openLink`.
- **Bug B (Images don't render in markdown):** Updated `.md-content img` CSS to include `display: block`, `height: auto`, `border-radius: 8px`, and `margin: 0.5em 0` for proper image sizing and layout in rendered markdown.
- **Bug C (Code blocks can't h-scroll by touch):** Changed `touch-action` on `.md-content pre` from `pan-y` (blocks horizontal) to `pan-x pan-y` (allows both). Removed unnecessary `onTouchStart`/`onTouchEnd` stopPropagation — only `onTouchMove` is needed to prevent tab swipe bubbling.

## Test plan
- [x] `pnpm run test:unit` — all 305 tests pass (199 server + 106 web)
- [x] `pnpm run build` — clean build
- [ ] Manual UAT: open a file, tap an external link, return — BackButton should still be visible
- [ ] Manual UAT: view a markdown doc with images — images should render with proper sizing
- [ ] Manual UAT: view a markdown doc with wide code blocks — horizontal touch scroll should work

🤖 Generated with [Claude Code](https://claude.com/claude-code)