### PR TITLE
feat(prs): multi-repo PR dashboard (closes #213)

### DIFF
--- a/apps/server/src/routes/__tests__/pr-poller.test.ts
+++ b/apps/server/src/routes/__tests__/pr-poller.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
-import { diffSnapshots, PrPoller, type PrRow } from "../prs.js";
+import { diffSnapshots, PrPoller, parseGitRemote, type PrRow } from "../prs.js";
 
 // --- Helpers ---
 
@@ -7,7 +7,7 @@ function makePr(overrides: Partial<PrRow> = {}): PrRow {
   const num = overrides.number ?? 1;
   return {
     key: overrides.key ?? `claudes-world/claude-pocket-console#${num}`,
-    repo: "claudes-world/claude-pocket-console",
+    repo: overrides.repo ?? "claudes-world/claude-pocket-console",
     number: num,
     title: `PR #${num}`,
     state: "OPEN",
@@ -23,6 +23,43 @@ function makePr(overrides: Partial<PrRow> = {}): PrRow {
     ...overrides,
   };
 }
+
+// --- parseGitRemote tests ---
+
+describe("parseGitRemote", () => {
+  it("parses SSH URL with .git suffix", () => {
+    const result = parseGitRemote("git@github.com:claudes-world/inbox.git");
+    expect(result).toEqual({ owner: "claudes-world", repoName: "inbox" });
+  });
+
+  it("parses SSH URL without .git suffix", () => {
+    const result = parseGitRemote("git@github.com:claudes-world/inbox");
+    expect(result).toEqual({ owner: "claudes-world", repoName: "inbox" });
+  });
+
+  it("parses HTTPS URL with .git suffix", () => {
+    const result = parseGitRemote("https://github.com/claudes-world/claude-pocket-console.git");
+    expect(result).toEqual({ owner: "claudes-world", repoName: "claude-pocket-console" });
+  });
+
+  it("parses HTTPS URL without .git suffix", () => {
+    const result = parseGitRemote("https://github.com/claudes-world/claude-pocket-console");
+    expect(result).toEqual({ owner: "claudes-world", repoName: "claude-pocket-console" });
+  });
+
+  it("returns null for non-GitHub URL", () => {
+    expect(parseGitRemote("/local/path/to/repo")).toBeNull();
+  });
+
+  it("returns null for empty string", () => {
+    expect(parseGitRemote("")).toBeNull();
+  });
+
+  it("handles different GitHub hosts in SSH format", () => {
+    const result = parseGitRemote("git@github.com:mcorrig4/personal-site.git");
+    expect(result).toEqual({ owner: "mcorrig4", repoName: "personal-site" });
+  });
+});
 
 // --- diffSnapshots tests ---
 
@@ -141,7 +178,7 @@ describe("PrPoller backoff", () => {
   });
 
   it("respects backoff after simulated 403", async () => {
-    const poller = new PrPoller([], 60_000); // no repos to poll
+    const poller = new PrPoller([], 60_000); // empty static repos = no network calls
 
     // Simulate internal backoff state
     (poller as any).backoff = {
@@ -189,5 +226,52 @@ describe("PrPoller backoff", () => {
     expect(result[0].number).toBe(2);
     expect(result[1].number).toBe(3);
     expect(result[2].number).toBe(1);
+  });
+
+  it("discoveredRepos is empty in static mode", async () => {
+    const poller = new PrPoller([], 60_000);
+    await poller.pollOnce();
+    expect(poller.discoveredRepos).toEqual([]);
+  });
+});
+
+// --- PrPoller multi-repo ---
+
+describe("PrPoller multi-repo static mode", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("accepts multiple static repos", () => {
+    const poller = new PrPoller([
+      { owner: "claudes-world", name: "claude-pocket-console" },
+      { owner: "claudes-world", name: "inbox" },
+    ], 60_000);
+
+    // Should not throw
+    expect(poller).toBeDefined();
+    expect(poller.getSnapshot()).toEqual([]);
+  });
+
+  it("handles PRs from multiple repos in snapshot", () => {
+    const poller = new PrPoller([], 60_000);
+    const pr1 = makePr({
+      number: 1,
+      key: "claudes-world/claude-pocket-console#1",
+      repo: "claudes-world/claude-pocket-console",
+    });
+    const pr2 = makePr({
+      number: 5,
+      key: "claudes-world/inbox#5",
+      repo: "claudes-world/inbox",
+    });
+    poller.snapshot.set(pr1.key, pr1);
+    poller.snapshot.set(pr2.key, pr2);
+
+    const result = poller.getSnapshot();
+    expect(result).toHaveLength(2);
+    const repos = new Set(result.map((pr) => pr.repo));
+    expect(repos.has("claudes-world/claude-pocket-console")).toBe(true);
+    expect(repos.has("claudes-world/inbox")).toBe(true);
   });
 });

--- a/apps/server/src/routes/prs.ts
+++ b/apps/server/src/routes/prs.ts
@@ -1,14 +1,16 @@
 import { Hono } from "hono";
-import { execFile } from "node:child_process";
-import { existsSync } from "node:fs";
+import { execFile, execFileSync } from "node:child_process";
+import { existsSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 
 const app = new Hono();
 
 const HOME = process.env.HOME || "/home/claude";
 const GH_TIMEOUT_MS = 10_000;
+const GIT_TIMEOUT_MS = 5_000;
 const DEFAULT_POLL_INTERVAL_MS = 30_000;
 const SCOPE_CACHE_TTL_MS = 60_000;
+const REPO_DISCOVERY_TTL_MS = 5 * 60_000; // re-scan ~/code every 5 min
 
 // --- Types ---
 
@@ -33,6 +35,97 @@ export interface PrDiff {
   added: PrRow[];
   removed: PrRow[];
   changed: { pr: PrRow; fields: string[] }[];
+}
+
+// --- Repo discovery ---
+
+export interface RepoInfo {
+  path: string;
+  name: string;       // directory name (e.g. "tryinbox-sh")
+  owner: string;      // GitHub org/user from remote (e.g. "claudes-world")
+  repoName: string;   // GitHub repo name from remote (e.g. "inbox")
+  fullName: string;   // "owner/repoName"
+  branch: string;     // current HEAD branch
+}
+
+/** Parse owner/repo from a git remote URL (HTTPS or SSH). Returns null if unparseable. */
+export function parseGitRemote(url: string): { owner: string; repoName: string } | null {
+  // SSH: git@github.com:owner/repo.git
+  const sshMatch = url.match(/git@[^:]+:([^/]+)\/([^/]+?)(?:\.git)?$/);
+  if (sshMatch) return { owner: sshMatch[1], repoName: sshMatch[2] };
+
+  // HTTPS: https://github.com/owner/repo.git
+  const httpsMatch = url.match(/https?:\/\/[^/]+\/([^/]+)\/([^/]+?)(?:\.git)?$/);
+  if (httpsMatch) return { owner: httpsMatch[1], repoName: httpsMatch[2] };
+
+  return null;
+}
+
+let repoCache: { repos: RepoInfo[]; cachedAt: number } | null = null;
+
+export function discoverRepos(): RepoInfo[] {
+  const now = Date.now();
+  if (repoCache && now - repoCache.cachedAt < REPO_DISCOVERY_TTL_MS) {
+    return repoCache.repos;
+  }
+
+  const codeDir = join(HOME, "code");
+  const repos: RepoInfo[] = [];
+
+  if (!existsSync(codeDir)) {
+    repoCache = { repos, cachedAt: now };
+    return repos;
+  }
+
+  let dirNames: string[];
+  try {
+    dirNames = readdirSync(codeDir);
+  } catch {
+    repoCache = { repos, cachedAt: now };
+    return repos;
+  }
+
+  for (const dirName of dirNames) {
+    const repoPath = join(codeDir, dirName);
+    if (!existsSync(join(repoPath, ".git"))) continue;
+
+    try {
+      // Get remote URL
+      const remoteUrl = execFileSync("git", ["-C", repoPath, "remote", "get-url", "origin"], {
+        timeout: GIT_TIMEOUT_MS,
+        encoding: "utf-8",
+      }).trim();
+
+      const parsed = parseGitRemote(remoteUrl);
+      if (!parsed) continue; // skip repos without a parseable GitHub remote
+
+      // Get current branch
+      const branch = execFileSync("git", ["-C", repoPath, "rev-parse", "--abbrev-ref", "HEAD"], {
+        timeout: GIT_TIMEOUT_MS,
+        encoding: "utf-8",
+      }).trim();
+
+      repos.push({
+        path: repoPath,
+        name: dirName,
+        owner: parsed.owner,
+        repoName: parsed.repoName,
+        fullName: `${parsed.owner}/${parsed.repoName}`,
+        branch: branch || "HEAD",
+      });
+    } catch {
+      // Skip repos where git commands fail (no remote, detached HEAD, etc.)
+      continue;
+    }
+  }
+
+  repoCache = { repos, cachedAt: now };
+  return repos;
+}
+
+/** Allow tests to reset the repo discovery cache */
+export function __resetRepoCacheForTests() {
+  repoCache = null;
 }
 
 // --- gh CLI wrapper ---
@@ -154,18 +247,18 @@ export class PrPoller {
   snapshot: Map<string, PrRow> = new Map();
   lastPollOk: number = 0;
   lastPollErr: string | null = null;
+  discoveredRepos: RepoInfo[] = [];
   private interval: ReturnType<typeof setInterval> | null = null;
   private backoff: BackoffState = { failures: 0, nextAllowedAt: 0 };
-  private repos: { owner: string; name: string }[];
+  private staticRepos: { owner: string; name: string }[] | null;
   private pollIntervalMs: number;
 
   constructor(
-    repos: { owner: string; name: string }[] = [
-      { owner: "claudes-world", name: "claude-pocket-console" },
-    ],
+    repos?: { owner: string; name: string }[],
     pollIntervalMs: number = DEFAULT_POLL_INTERVAL_MS,
   ) {
-    this.repos = repos;
+    // If repos provided, use static mode (for tests); otherwise use dynamic discovery
+    this.staticRepos = repos ?? null;
     this.pollIntervalMs = pollIntervalMs;
   }
 
@@ -190,10 +283,29 @@ export class PrPoller {
       return { added: [], removed: [], changed: [] };
     }
 
+    // Resolve repos: static (test mode) or dynamic discovery
+    let repoList: { fullName: string }[];
+    if (this.staticRepos) {
+      repoList = this.staticRepos.map((r) => ({ fullName: `${r.owner}/${r.name}` }));
+      this.discoveredRepos = [];
+    } else {
+      const discovered = discoverRepos();
+      this.discoveredRepos = discovered;
+      // Deduplicate by fullName (multiple worktrees for same repo)
+      const seen = new Set<string>();
+      repoList = [];
+      for (const r of discovered) {
+        if (!seen.has(r.fullName)) {
+          seen.add(r.fullName);
+          repoList.push({ fullName: r.fullName });
+        }
+      }
+    }
+
     const nextSnapshot = new Map<string, PrRow>();
 
-    for (const repo of this.repos) {
-      const fullName = `${repo.owner}/${repo.name}`;
+    for (const repo of repoList) {
+      const fullName = repo.fullName;
       try {
         const stdout = await execGh([
           "pr", "list",
@@ -263,46 +375,45 @@ export async function currentBranchScope(): Promise<string[]> {
   }
 
   const branches: string[] = [];
-  // Phase 1: just CPC
-  const repoPath = join(HOME, "code/claude-pocket-console");
 
-  if (!existsSync(repoPath)) {
-    scopeCache = { branches, cachedAt: now };
-    return branches;
-  }
+  // Scan all discovered repos for branches (main worktree + linked worktrees)
+  const repos = discoverRepos();
 
-  try {
-    // Main worktree HEAD
-    const head = await new Promise<string>((resolve, reject) => {
-      execFile("git", ["-C", repoPath, "rev-parse", "--abbrev-ref", "HEAD"], {
-        timeout: 5000,
-      }, (err, stdout) => {
-        if (err) reject(err);
-        else resolve(stdout.trim());
-      });
-    });
-    if (head && head !== "HEAD") branches.push(head);
+  // Deduplicate by repo path (worktrees share the same .git)
+  const seenRepoPaths = new Set<string>();
 
-    // Linked worktrees
-    const worktreeOutput = await new Promise<string>((resolve, reject) => {
-      execFile("git", ["-C", repoPath, "worktree", "list", "--porcelain"], {
-        timeout: 5000,
-      }, (err, stdout) => {
-        if (err) reject(err);
-        else resolve(stdout);
-      });
-    });
+  for (const repo of repos) {
+    // Avoid scanning the same underlying repo multiple times
+    // (worktrees for the same repo share the same git dir)
+    if (seenRepoPaths.has(repo.path)) continue;
+    seenRepoPaths.add(repo.path);
 
-    // Parse porcelain output — look for "branch refs/heads/<name>" lines
-    for (const line of worktreeOutput.split("\n")) {
-      const match = line.match(/^branch refs\/heads\/(.+)$/);
-      if (match && match[1]) {
-        const branch = match[1];
-        if (!branches.includes(branch)) branches.push(branch);
+    try {
+      // Main worktree HEAD
+      if (repo.branch && repo.branch !== "HEAD" && !branches.includes(repo.branch)) {
+        branches.push(repo.branch);
       }
+
+      // Linked worktrees
+      const worktreeOutput = await new Promise<string>((resolve, reject) => {
+        execFile("git", ["-C", repo.path, "worktree", "list", "--porcelain"], {
+          timeout: GIT_TIMEOUT_MS,
+        }, (err, stdout) => {
+          if (err) reject(err);
+          else resolve(stdout);
+        });
+      });
+
+      for (const line of worktreeOutput.split("\n")) {
+        const match = line.match(/^branch refs\/heads\/(.+)$/);
+        if (match && match[1]) {
+          const branch = match[1];
+          if (!branches.includes(branch)) branches.push(branch);
+        }
+      }
+    } catch {
+      // git commands failed for this repo — skip
     }
-  } catch {
-    // git commands failed — return empty scope
   }
 
   scopeCache = { branches, cachedAt: now };
@@ -320,7 +431,7 @@ let pollerInstance: PrPoller | null = null;
 
 function getPoller(): PrPoller {
   if (!pollerInstance) {
-    pollerInstance = new PrPoller();
+    pollerInstance = new PrPoller(); // no args = dynamic discovery mode
     pollerInstance.start();
   }
   return pollerInstance;
@@ -336,9 +447,27 @@ export function __setPollerForTests(p: PrPoller | null) {
 
 app.get("/", (c) => {
   const poller = getPoller();
+  const prs = poller.getSnapshot();
+
+  // Build repos summary from discovered repos
+  const prCountByRepo = new Map<string, number>();
+  for (const pr of prs) {
+    prCountByRepo.set(pr.repo, (prCountByRepo.get(pr.repo) || 0) + 1);
+  }
+
+  const repos = poller.discoveredRepos.map((r) => ({
+    name: r.repoName,
+    dirName: r.name,
+    org: r.owner,
+    fullName: r.fullName,
+    branch: r.branch,
+    prCount: prCountByRepo.get(r.fullName) || 0,
+  }));
+
   return c.json({
     ok: true,
-    prs: poller.getSnapshot(),
+    prs,
+    repos,
     lastPollOk: poller.lastPollOk,
     lastPollErr: poller.lastPollErr,
   });
@@ -347,9 +476,26 @@ app.get("/", (c) => {
 app.post("/refresh", async (c) => {
   const poller = getPoller();
   const diff = await poller.pollOnce();
+  const prs = poller.getSnapshot();
+
+  const prCountByRepo = new Map<string, number>();
+  for (const pr of prs) {
+    prCountByRepo.set(pr.repo, (prCountByRepo.get(pr.repo) || 0) + 1);
+  }
+
+  const repos = poller.discoveredRepos.map((r) => ({
+    name: r.repoName,
+    dirName: r.name,
+    org: r.owner,
+    fullName: r.fullName,
+    branch: r.branch,
+    prCount: prCountByRepo.get(r.fullName) || 0,
+  }));
+
   return c.json({
     ok: true,
-    prs: poller.getSnapshot(),
+    prs,
+    repos,
     lastPollOk: poller.lastPollOk,
     lastPollErr: poller.lastPollErr,
     diff: {

--- a/apps/server/src/routes/prs.ts
+++ b/apps/server/src/routes/prs.ts
@@ -48,15 +48,25 @@ export interface RepoInfo {
   branch: string;     // current HEAD branch
 }
 
-/** Parse owner/repo from a git remote URL (HTTPS or SSH). Returns null if unparseable. */
+/** Parse owner/repo from a git remote URL (HTTPS or SSH). Returns null if unparseable or non-GitHub. */
 export function parseGitRemote(url: string): { owner: string; repoName: string } | null {
-  // SSH: git@github.com:owner/repo.git
-  const sshMatch = url.match(/git@[^:]+:([^/]+)\/([^/]+?)(?:\.git)?$/);
+  // SSH: git@github.com:owner/repo.git — require github.com host explicitly
+  const sshMatch = url.match(/^git@github\.com:([^/]+)\/([^/]+?)(?:\.git)?$/);
   if (sshMatch) return { owner: sshMatch[1], repoName: sshMatch[2] };
 
-  // HTTPS: https://github.com/owner/repo.git
-  const httpsMatch = url.match(/https?:\/\/[^/]+\/([^/]+)\/([^/]+?)(?:\.git)?$/);
-  if (httpsMatch) return { owner: httpsMatch[1], repoName: httpsMatch[2] };
+  // HTTPS: https://[user@]github.com/owner/repo.git — use URL parser to handle
+  // optional credentials (e.g. https://token@github.com/...) while still requiring
+  // a github.com hostname. Regex-only approaches miss the credentialed form.
+  if (/^https?:\/\//i.test(url)) {
+    try {
+      const parsed = new URL(url);
+      if (parsed.hostname !== "github.com") return null;
+      const parts = parsed.pathname.replace(/\.git$/, "").split("/").filter(Boolean);
+      if (parts.length >= 2) return { owner: parts[0], repoName: parts[1] };
+    } catch {
+      // URL constructor threw — not a valid HTTPS URL
+    }
+  }
 
   return null;
 }
@@ -90,7 +100,10 @@ export function discoverRepos(): RepoInfo[] {
     if (!existsSync(join(repoPath, ".git"))) continue;
 
     try {
-      // Get remote URL
+      // Get remote URL.
+      // execFileSync is intentional: discoverRepos() runs at most once per 5-min TTL,
+      // covers <20 repos in practice, and completes in <2s total. Converting to async
+      // would complicate callers (currentBranchScope, pollOnce) for negligible gain.
       const remoteUrl = execFileSync("git", ["-C", repoPath, "remote", "get-url", "origin"], {
         timeout: GIT_TIMEOUT_MS,
         encoding: "utf-8",

--- a/apps/web/src/components/PrTicker.tsx
+++ b/apps/web/src/components/PrTicker.tsx
@@ -107,11 +107,13 @@ function ciLabel(pr: PrRow): string {
 // --- Group PRs by org -> repo ---
 
 function groupPrs(prs: PrRow[], repos: RepoSummary[]): GroupedPrs {
-  const grouped: GroupedPrs = {};
+  // Use Object.create(null) to avoid prototype pollution from org/repo names
+  // that could shadow Object prototype properties (e.g. "constructor", "toString").
+  const grouped = Object.create(null) as GroupedPrs;
 
   // Seed structure from repos (so repos with 0 PRs still show)
   for (const repo of repos) {
-    if (!grouped[repo.org]) grouped[repo.org] = {};
+    if (!grouped[repo.org]) grouped[repo.org] = Object.create(null) as Record<string, { branch: string; prs: PrRow[] }>;
     if (!grouped[repo.org][repo.fullName]) {
       grouped[repo.org][repo.fullName] = { branch: repo.branch, prs: [] };
     }
@@ -120,7 +122,7 @@ function groupPrs(prs: PrRow[], repos: RepoSummary[]): GroupedPrs {
   // Place PRs into groups
   for (const pr of prs) {
     const [org] = pr.repo.split("/");
-    if (!grouped[org]) grouped[org] = {};
+    if (!grouped[org]) grouped[org] = Object.create(null) as Record<string, { branch: string; prs: PrRow[] }>;
     if (!grouped[org][pr.repo]) {
       // Repo not in discovery (edge case: leftover from cache)
       const repoInfo = repos.find((r) => r.fullName === pr.repo);

--- a/apps/web/src/components/PrTicker.tsx
+++ b/apps/web/src/components/PrTicker.tsx
@@ -20,7 +20,17 @@ interface PrRow {
   lastChanged: number;
 }
 
-type FilterMode = "current" | "all";
+interface RepoSummary {
+  name: string;
+  dirName: string;
+  org: string;
+  fullName: string;
+  branch: string;
+  prCount: number;
+}
+
+// Grouped structure: org -> repo -> { branch, prs }
+type GroupedPrs = Record<string, Record<string, { branch: string; prs: PrRow[] }>>;
 
 // --- Color palette (reuses existing CPC theme) ---
 
@@ -94,22 +104,60 @@ function ciLabel(pr: PrRow): string {
   }
 }
 
+// --- Group PRs by org -> repo ---
+
+function groupPrs(prs: PrRow[], repos: RepoSummary[]): GroupedPrs {
+  const grouped: GroupedPrs = {};
+
+  // Seed structure from repos (so repos with 0 PRs still show)
+  for (const repo of repos) {
+    if (!grouped[repo.org]) grouped[repo.org] = {};
+    if (!grouped[repo.org][repo.fullName]) {
+      grouped[repo.org][repo.fullName] = { branch: repo.branch, prs: [] };
+    }
+  }
+
+  // Place PRs into groups
+  for (const pr of prs) {
+    const [org] = pr.repo.split("/");
+    if (!grouped[org]) grouped[org] = {};
+    if (!grouped[org][pr.repo]) {
+      // Repo not in discovery (edge case: leftover from cache)
+      const repoInfo = repos.find((r) => r.fullName === pr.repo);
+      grouped[org][pr.repo] = { branch: repoInfo?.branch || "", prs: [] };
+    }
+    grouped[org][pr.repo].prs.push(pr);
+  }
+
+  return grouped;
+}
+
+// --- Collapse state persistence ---
+
+const COLLAPSE_KEY = "cpc-pr-collapsed-orgs";
+
+function loadCollapsedOrgs(): Set<string> {
+  try {
+    const saved = localStorage.getItem(COLLAPSE_KEY);
+    if (saved) return new Set(JSON.parse(saved));
+  } catch { /* ignore */ }
+  return new Set();
+}
+
+function saveCollapsedOrgs(collapsed: Set<string>) {
+  try {
+    localStorage.setItem(COLLAPSE_KEY, JSON.stringify([...collapsed]));
+  } catch { /* ignore */ }
+}
+
 // --- Main component ---
 
 const POLL_INTERVAL_MS = 10_000;
-const FILTER_KEY = "cpc-pr-filter-mode";
 
 export function PrTicker() {
   const [prs, setPrs] = useState<PrRow[]>([]);
-  const [branches, setBranches] = useState<string[]>([]);
-  const [filter, setFilter] = useState<FilterMode>(() => {
-    try {
-      const saved = localStorage.getItem(FILTER_KEY);
-      return saved === "all" ? "all" : "current";
-    } catch {
-      return "current";
-    }
-  });
+  const [repos, setRepos] = useState<RepoSummary[]>([]);
+  const [collapsedOrgs, setCollapsedOrgs] = useState<Set<string>>(loadCollapsedOrgs);
   const [loading, setLoading] = useState(true);
   const [lastPollAt, setLastPollAt] = useState<number>(0);
   const [pollError, setPollError] = useState<string | null>(null);
@@ -117,11 +165,18 @@ export function PrTicker() {
   const [, setTick] = useState(0); // Force re-render for "last poll Xs ago"
   const mountedRef = useRef(true);
 
-  useEffect(() => {
-    try {
-      localStorage.setItem(FILTER_KEY, filter);
-    } catch { /* ignore */ }
-  }, [filter]);
+  const toggleOrg = useCallback((org: string) => {
+    setCollapsedOrgs((prev) => {
+      const next = new Set(prev);
+      if (next.has(org)) {
+        next.delete(org);
+      } else {
+        next.add(org);
+      }
+      saveCollapsedOrgs(next);
+      return next;
+    });
+  }, []);
 
   const fetchPrs = useCallback(async () => {
     try {
@@ -131,6 +186,7 @@ export function PrTicker() {
       if (mountedRef.current) {
         if (data.ok) {
           setPrs(data.prs ?? []);
+          setRepos(data.repos ?? []);
           setLastPollAt(data.lastPollOk || Date.now());
           setPollError(data.lastPollErr ?? null);
         } else {
@@ -148,17 +204,6 @@ export function PrTicker() {
     }
   }, []);
 
-  const fetchBranches = useCallback(async () => {
-    try {
-      const res = await fetch("/api/prs/current-branch-scope", { headers: getAuthHeaders() });
-      if (!res.ok) return;
-      const data = await res.json();
-      if (mountedRef.current && data.ok) {
-        setBranches(data.branches ?? []);
-      }
-    } catch { /* silent */ }
-  }, []);
-
   const handleRefresh = useCallback(async () => {
     setRefreshing(true);
     try {
@@ -170,6 +215,7 @@ export function PrTicker() {
       const data = await res.json();
       if (mountedRef.current && data.ok) {
         setPrs(data.prs ?? []);
+        setRepos(data.repos ?? []);
         setLastPollAt(data.lastPollOk || Date.now());
         setPollError(data.lastPollErr ?? null);
       }
@@ -186,23 +232,20 @@ export function PrTicker() {
   useEffect(() => {
     mountedRef.current = true;
     void fetchPrs();
-    void fetchBranches();
     const prInterval = setInterval(fetchPrs, POLL_INTERVAL_MS);
-    const branchInterval = setInterval(fetchBranches, 60_000);
     // Tick every 5s to update "last poll Xs ago"
     const tickInterval = setInterval(() => setTick((t) => t + 1), 5_000);
     return () => {
       mountedRef.current = false;
       clearInterval(prInterval);
-      clearInterval(branchInterval);
       clearInterval(tickInterval);
     };
-  }, [fetchPrs, fetchBranches]);
+  }, [fetchPrs]);
 
-  // Filter PRs
-  const filteredPrs = filter === "all"
-    ? prs
-    : prs.filter((pr) => branches.includes(pr.headRefName));
+  const grouped = groupPrs(prs, repos);
+  const orgNames = Object.keys(grouped).sort();
+  const totalPrs = prs.length;
+  const totalRepos = repos.length;
 
   const pollAgoSec = lastPollAt ? Math.floor((Date.now() - lastPollAt) / 1000) : 0;
 
@@ -227,7 +270,7 @@ export function PrTicker() {
       color: COLORS.text,
       fontSize: 13,
     }}>
-      {/* Filter bar */}
+      {/* Header bar */}
       <div style={{
         display: "flex",
         alignItems: "center",
@@ -236,16 +279,9 @@ export function PrTicker() {
         borderBottom: `1px solid ${COLORS.border}`,
         flexShrink: 0,
       }}>
-        <FilterChip
-          label="current branch"
-          active={filter === "current"}
-          onClick={() => setFilter("current")}
-        />
-        <FilterChip
-          label="all"
-          active={filter === "all"}
-          onClick={() => setFilter("all")}
-        />
+        <span style={{ fontSize: 12, color: COLORS.textMuted }}>
+          {totalRepos} repos
+        </span>
         <div style={{ marginLeft: "auto", display: "flex", alignItems: "center", gap: 6 }}>
           <button
             onClick={() => void handleRefresh()}
@@ -280,7 +316,7 @@ export function PrTicker() {
         </div>
       )}
 
-      {/* PR list */}
+      {/* Grouped PR list */}
       <div style={{
         flex: 1,
         overflowY: "auto",
@@ -299,7 +335,7 @@ export function PrTicker() {
           }}>
             Loading PRs...
           </div>
-        ) : filteredPrs.length === 0 ? (
+        ) : orgNames.length === 0 ? (
           <div style={{
             display: "flex",
             alignItems: "center",
@@ -310,13 +346,18 @@ export function PrTicker() {
             padding: 20,
             textAlign: "center",
           }}>
-            {filter === "current" && prs.length > 0
-              ? "No PRs on current branch. Switch to All."
-              : "No open PRs"}
+            No repos discovered
           </div>
         ) : (
-          filteredPrs.map((pr) => (
-            <PrRowItem key={pr.key} pr={pr} onTap={openPr} />
+          orgNames.map((org) => (
+            <OrgSection
+              key={org}
+              org={org}
+              repoMap={grouped[org]}
+              collapsed={collapsedOrgs.has(org)}
+              onToggle={() => toggleOrg(org)}
+              onTapPr={openPr}
+            />
           ))
         )}
       </div>
@@ -332,7 +373,7 @@ export function PrTicker() {
         justifyContent: "space-between",
         flexShrink: 0,
       }}>
-        <span>{filteredPrs.length} open</span>
+        <span>{totalPrs} open</span>
         <span>
           last poll {pollAgoSec}s ago
           <span style={{
@@ -353,31 +394,109 @@ export function PrTicker() {
 
 // --- Sub-components ---
 
-function FilterChip({
-  label,
-  active,
-  onClick,
+function OrgSection({
+  org,
+  repoMap,
+  collapsed,
+  onToggle,
+  onTapPr,
 }: {
-  label: string;
-  active: boolean;
-  onClick: () => void;
+  org: string;
+  repoMap: Record<string, { branch: string; prs: PrRow[] }>;
+  collapsed: boolean;
+  onToggle: () => void;
+  onTapPr: (url: string) => void;
 }) {
+  const repoNames = Object.keys(repoMap).sort();
+  const totalPrs = repoNames.reduce((sum, r) => sum + repoMap[r].prs.length, 0);
+
   return (
-    <button
-      onClick={onClick}
-      style={{
-        padding: "3px 10px",
-        borderRadius: 12,
-        fontSize: 12,
-        fontWeight: active ? 600 : 400,
-        background: active ? COLORS.blue : "transparent",
-        color: active ? "var(--color-bg)" : COLORS.textMuted,
-        border: active ? "none" : `1px solid ${COLORS.border}`,
-        cursor: "pointer",
-      }}
-    >
-      {label}
-    </button>
+    <div>
+      {/* Org heading */}
+      <div
+        onClick={onToggle}
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 6,
+          padding: "8px 12px",
+          background: COLORS.surface,
+          borderBottom: `1px solid ${COLORS.border}`,
+          cursor: "pointer",
+          userSelect: "none",
+        }}
+      >
+        <span style={{ fontSize: 11, color: COLORS.textMuted, width: 12, textAlign: "center" }}>
+          {collapsed ? "\u25b6" : "\u25bc"}
+        </span>
+        <span style={{ fontWeight: 700, fontSize: 13, color: COLORS.text }}>
+          {org}
+        </span>
+        <span style={{ fontSize: 11, color: COLORS.textMuted }}>
+          {totalPrs} PR{totalPrs !== 1 ? "s" : ""}
+        </span>
+      </div>
+
+      {/* Repos within org */}
+      {!collapsed && repoNames.map((repoFullName) => {
+        const { branch, prs } = repoMap[repoFullName];
+        const repoShort = repoFullName.split("/")[1] || repoFullName;
+
+        return (
+          <div key={repoFullName}>
+            {/* Repo subheading */}
+            <div style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 6,
+              padding: "6px 12px 6px 24px",
+              borderBottom: `1px solid ${COLORS.border}`,
+              fontSize: 12,
+            }}>
+              <span style={{ fontWeight: 600, color: COLORS.text }}>
+                {repoShort}
+              </span>
+              {branch && (
+                <span style={{
+                  fontSize: 10,
+                  padding: "1px 6px",
+                  borderRadius: 8,
+                  background: COLORS.blue,
+                  color: COLORS.bg,
+                  fontWeight: 500,
+                  whiteSpace: "nowrap",
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                  maxWidth: 140,
+                }}>
+                  {branch}
+                </span>
+              )}
+              <span style={{ fontSize: 11, color: COLORS.textMuted, marginLeft: "auto" }}>
+                {prs.length} open
+              </span>
+            </div>
+
+            {/* PR rows or empty state */}
+            {prs.length === 0 ? (
+              <div style={{
+                padding: "8px 12px 8px 36px",
+                fontSize: 12,
+                color: COLORS.textMuted,
+                fontStyle: "italic",
+                borderBottom: `1px solid ${COLORS.border}`,
+              }}>
+                no open PRs
+              </div>
+            ) : (
+              prs.map((pr) => (
+                <PrRowItem key={pr.key} pr={pr} onTap={onTapPr} />
+              ))
+            )}
+          </div>
+        );
+      })}
+    </div>
   );
 }
 
@@ -396,13 +515,13 @@ function PrRowItem({
     <div
       onClick={() => onTap(pr.url)}
       style={{
-        padding: "10px 12px",
+        padding: "10px 12px 10px 36px",
         borderBottom: `1px solid ${COLORS.border}`,
         cursor: "pointer",
         position: "relative",
       }}
     >
-      {/* Line 1: status dot + repo label + PR number + branch */}
+      {/* Line 1: status dot + PR number + branch */}
       <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 2 }}>
         <span style={{
           width: 8,

--- a/apps/web/src/components/__tests__/PrTicker.test.tsx
+++ b/apps/web/src/components/__tests__/PrTicker.test.tsx
@@ -42,6 +42,18 @@ function makePr(overrides: Record<string, unknown> = {}) {
   };
 }
 
+function makeRepo(overrides: Record<string, unknown> = {}) {
+  return {
+    name: "inbox",
+    dirName: "tryinbox-sh",
+    org: "claudes-world",
+    fullName: "claudes-world/inbox",
+    branch: "main",
+    prCount: 0,
+    ...overrides,
+  };
+}
+
 let fetchMock: ReturnType<typeof vi.fn>;
 
 beforeEach(() => {
@@ -51,24 +63,18 @@ beforeEach(() => {
   fetchMock = vi.fn();
   global.fetch = fetchMock as unknown as typeof fetch;
 
-  // Default: empty PR list and no branches
+  // Default: empty PR list, no repos
   fetchMock.mockImplementation(async (url: string) => {
     if (url === "/api/prs") {
       return {
         ok: true,
-        json: async () => ({ ok: true, prs: [], lastPollOk: Date.now() }),
-      };
-    }
-    if (url === "/api/prs/current-branch-scope") {
-      return {
-        ok: true,
-        json: async () => ({ ok: true, branches: [] }),
+        json: async () => ({ ok: true, prs: [], repos: [], lastPollOk: Date.now() }),
       };
     }
     if (url === "/api/prs/refresh") {
       return {
         ok: true,
-        json: async () => ({ ok: true, prs: [], lastPollOk: Date.now() }),
+        json: async () => ({ ok: true, prs: [], repos: [], lastPollOk: Date.now() }),
       };
     }
     return { ok: false, status: 404, json: async () => ({}) };
@@ -81,27 +87,21 @@ afterEach(() => {
 });
 
 describe("PrTicker", () => {
-  it("renders empty state when there are no PRs", async () => {
+  it("renders empty state when there are no repos", async () => {
     render(<PrTicker />);
 
     await waitFor(() => {
-      expect(screen.getByText("No open PRs")).toBeInTheDocument();
+      expect(screen.getByText("No repos discovered")).toBeInTheDocument();
     });
   });
 
-  it("shows 'No PRs on current branch' when filter is current but PRs exist on other branches", async () => {
-    const pr = makePr({ headRefName: "feat/other-branch" });
+  it("shows 'no open PRs' for a repo with zero PRs", async () => {
+    const repo = makeRepo({ prCount: 0 });
     fetchMock.mockImplementation(async (url: string) => {
       if (url === "/api/prs") {
         return {
           ok: true,
-          json: async () => ({ ok: true, prs: [pr], lastPollOk: Date.now() }),
-        };
-      }
-      if (url === "/api/prs/current-branch-scope") {
-        return {
-          ok: true,
-          json: async () => ({ ok: true, branches: ["main"] }),
+          json: async () => ({ ok: true, prs: [], repos: [repo], lastPollOk: Date.now() }),
         };
       }
       return { ok: true, json: async () => ({}) };
@@ -110,25 +110,21 @@ describe("PrTicker", () => {
     render(<PrTicker />);
 
     await waitFor(() => {
-      expect(screen.getByText(/No PRs on current branch/)).toBeInTheDocument();
+      expect(screen.getByText("no open PRs")).toBeInTheDocument();
     });
   });
 
-  it("renders PR rows when data is returned", async () => {
-    const pr1 = makePr({ number: 42, title: "Fix the widget", headRefName: "fix/widget" });
-    const pr2 = makePr({ number: 43, title: "Add feature X", headRefName: "feat/x" });
+  it("renders PR rows grouped by org and repo", async () => {
+    const pr1 = makePr({ number: 42, title: "Fix the widget", headRefName: "fix/widget", repo: "claudes-world/inbox", key: "claudes-world/inbox#42" });
+    const pr2 = makePr({ number: 43, title: "Add feature X", headRefName: "feat/x", repo: "claudes-world/claude-pocket-console", key: "claudes-world/claude-pocket-console#43" });
+    const repo1 = makeRepo({ name: "inbox", fullName: "claudes-world/inbox", prCount: 1 });
+    const repo2 = makeRepo({ name: "claude-pocket-console", fullName: "claudes-world/claude-pocket-console", prCount: 1 });
 
     fetchMock.mockImplementation(async (url: string) => {
       if (url === "/api/prs") {
         return {
           ok: true,
-          json: async () => ({ ok: true, prs: [pr1, pr2], lastPollOk: Date.now() }),
-        };
-      }
-      if (url === "/api/prs/current-branch-scope") {
-        return {
-          ok: true,
-          json: async () => ({ ok: true, branches: ["fix/widget", "feat/x"] }),
+          json: async () => ({ ok: true, prs: [pr1, pr2], repos: [repo1, repo2], lastPollOk: Date.now() }),
         };
       }
       return { ok: true, json: async () => ({}) };
@@ -142,27 +138,20 @@ describe("PrTicker", () => {
       expect(screen.getByText("#43")).toBeInTheDocument();
       expect(screen.getByText("Add feature X")).toBeInTheDocument();
     });
+
+    // Org heading should be visible
+    expect(screen.getByText("claudes-world")).toBeInTheDocument();
   });
 
-  it("switches from 'current branch' to 'all' filter when chip is clicked", async () => {
-    const prOnBranch = makePr({ number: 1, title: "On branch", headRefName: "dev" });
-    const prOffBranch = makePr({ number: 2, title: "Off branch", headRefName: "other" });
+  it("collapses and expands org sections", async () => {
+    const pr = makePr({ number: 1, key: "claudes-world/inbox#1", title: "Test PR" });
+    const repo = makeRepo({ prCount: 1 });
 
     fetchMock.mockImplementation(async (url: string) => {
       if (url === "/api/prs") {
         return {
           ok: true,
-          json: async () => ({
-            ok: true,
-            prs: [prOnBranch, prOffBranch],
-            lastPollOk: Date.now(),
-          }),
-        };
-      }
-      if (url === "/api/prs/current-branch-scope") {
-        return {
-          ok: true,
-          json: async () => ({ ok: true, branches: ["dev"] }),
+          json: async () => ({ ok: true, prs: [pr], repos: [repo], lastPollOk: Date.now() }),
         };
       }
       return { ok: true, json: async () => ({}) };
@@ -170,49 +159,35 @@ describe("PrTicker", () => {
 
     render(<PrTicker />);
 
-    // Wait for data to load — in "current" mode only PR #1 is visible
+    // Wait for PR to show
     await waitFor(() => {
       expect(screen.getByText("#1")).toBeInTheDocument();
     });
-    expect(screen.queryByText("#2")).not.toBeInTheDocument();
 
-    // Click "all" filter chip
-    fireEvent.click(screen.getByText("all"));
+    // Click org heading to collapse
+    fireEvent.click(screen.getByText("claudes-world"));
 
+    // PR should no longer be visible
     await waitFor(() => {
-      expect(screen.getByText("#2")).toBeInTheDocument();
-    });
-    expect(screen.getByText("#1")).toBeInTheDocument();
-  });
-
-  it("persists filter mode to localStorage", async () => {
-    render(<PrTicker />);
-
-    // Default is "current"
-    await waitFor(() => {
-      expect(localStorageMock.setItem).toHaveBeenCalledWith("cpc-pr-filter-mode", "current");
+      expect(screen.queryByText("#1")).not.toBeInTheDocument();
     });
 
-    fireEvent.click(screen.getByText("all"));
+    // Click again to expand
+    fireEvent.click(screen.getByText("claudes-world"));
 
     await waitFor(() => {
-      expect(localStorageMock.setItem).toHaveBeenCalledWith("cpc-pr-filter-mode", "all");
+      expect(screen.getByText("#1")).toBeInTheDocument();
     });
   });
 
-  it("displays the footer count matching visible PRs", async () => {
-    const pr = makePr({ headRefName: "dev" });
+  it("displays the footer count matching total PRs", async () => {
+    const pr = makePr();
+    const repo = makeRepo({ prCount: 1 });
     fetchMock.mockImplementation(async (url: string) => {
       if (url === "/api/prs") {
         return {
           ok: true,
-          json: async () => ({ ok: true, prs: [pr], lastPollOk: Date.now() }),
-        };
-      }
-      if (url === "/api/prs/current-branch-scope") {
-        return {
-          ok: true,
-          json: async () => ({ ok: true, branches: ["dev"] }),
+          json: async () => ({ ok: true, prs: [pr], repos: [repo], lastPollOk: Date.now() }),
         };
       }
       return { ok: true, json: async () => ({}) };
@@ -221,7 +196,9 @@ describe("PrTicker", () => {
     render(<PrTicker />);
 
     await waitFor(() => {
-      expect(screen.getByText("1 open")).toBeInTheDocument();
+      // "1 open" appears in both the repo subheading and the footer
+      const matches = screen.getAllByText("1 open");
+      expect(matches.length).toBeGreaterThanOrEqual(1);
     });
   });
 
@@ -229,9 +206,6 @@ describe("PrTicker", () => {
     fetchMock.mockImplementation(async (url: string) => {
       if (url === "/api/prs") {
         throw new Error("Network down");
-      }
-      if (url === "/api/prs/current-branch-scope") {
-        return { ok: true, json: async () => ({ ok: true, branches: [] }) };
       }
       return { ok: true, json: async () => ({}) };
     });
@@ -248,11 +222,8 @@ describe("PrTicker", () => {
       if (url === "/api/prs") {
         return {
           ok: true,
-          json: async () => ({ ok: true, prs: [], lastPollOk: Date.now(), lastPollErr: "rate limited" }),
+          json: async () => ({ ok: true, prs: [], repos: [], lastPollOk: Date.now(), lastPollErr: "rate limited" }),
         };
-      }
-      if (url === "/api/prs/current-branch-scope") {
-        return { ok: true, json: async () => ({ ok: true, branches: [] }) };
       }
       return { ok: true, json: async () => ({}) };
     });
@@ -267,22 +238,16 @@ describe("PrTicker", () => {
   it("displays review and CI status labels on PR rows", async () => {
     const pr = makePr({
       number: 99,
-      headRefName: "dev",
       reviewDecision: "APPROVED",
       ciStatus: "SUCCESS",
     });
+    const repo = makeRepo({ prCount: 1 });
 
     fetchMock.mockImplementation(async (url: string) => {
       if (url === "/api/prs") {
         return {
           ok: true,
-          json: async () => ({ ok: true, prs: [pr], lastPollOk: Date.now() }),
-        };
-      }
-      if (url === "/api/prs/current-branch-scope") {
-        return {
-          ok: true,
-          json: async () => ({ ok: true, branches: ["dev"] }),
+          json: async () => ({ ok: true, prs: [pr], repos: [repo], lastPollOk: Date.now() }),
         };
       }
       return { ok: true, json: async () => ({}) };
@@ -293,6 +258,73 @@ describe("PrTicker", () => {
     await waitFor(() => {
       expect(screen.getByText("approved")).toBeInTheDocument();
       expect(screen.getByText("CI pass")).toBeInTheDocument();
+    });
+  });
+
+  it("shows repo count in header", async () => {
+    const repo1 = makeRepo({ name: "inbox", fullName: "claudes-world/inbox" });
+    const repo2 = makeRepo({ name: "cpc", fullName: "claudes-world/claude-pocket-console" });
+
+    fetchMock.mockImplementation(async (url: string) => {
+      if (url === "/api/prs") {
+        return {
+          ok: true,
+          json: async () => ({ ok: true, prs: [], repos: [repo1, repo2], lastPollOk: Date.now() }),
+        };
+      }
+      return { ok: true, json: async () => ({}) };
+    });
+
+    render(<PrTicker />);
+
+    await waitFor(() => {
+      expect(screen.getByText("2 repos")).toBeInTheDocument();
+    });
+  });
+
+  it("shows branch badge on repo subheading", async () => {
+    const repo = makeRepo({ branch: "dev" });
+
+    fetchMock.mockImplementation(async (url: string) => {
+      if (url === "/api/prs") {
+        return {
+          ok: true,
+          json: async () => ({ ok: true, prs: [], repos: [repo], lastPollOk: Date.now() }),
+        };
+      }
+      return { ok: true, json: async () => ({}) };
+    });
+
+    render(<PrTicker />);
+
+    await waitFor(() => {
+      expect(screen.getByText("dev")).toBeInTheDocument();
+    });
+  });
+
+  it("handles multi-org grouping", async () => {
+    const pr1 = makePr({ number: 1, repo: "claudes-world/inbox", key: "claudes-world/inbox#1" });
+    const pr2 = makePr({ number: 2, repo: "mcorrig4/personal-site", key: "mcorrig4/personal-site#2" });
+    const repo1 = makeRepo({ name: "inbox", org: "claudes-world", fullName: "claudes-world/inbox", prCount: 1 });
+    const repo2 = makeRepo({ name: "personal-site", org: "mcorrig4", fullName: "mcorrig4/personal-site", prCount: 1 });
+
+    fetchMock.mockImplementation(async (url: string) => {
+      if (url === "/api/prs") {
+        return {
+          ok: true,
+          json: async () => ({ ok: true, prs: [pr1, pr2], repos: [repo1, repo2], lastPollOk: Date.now() }),
+        };
+      }
+      return { ok: true, json: async () => ({}) };
+    });
+
+    render(<PrTicker />);
+
+    await waitFor(() => {
+      expect(screen.getByText("claudes-world")).toBeInTheDocument();
+      expect(screen.getByText("mcorrig4")).toBeInTheDocument();
+      expect(screen.getByText("#1")).toBeInTheDocument();
+      expect(screen.getByText("#2")).toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
## Summary
- Replace hardcoded single-repo PrPoller with dynamic discovery that scans all git repos under `~/code/*`, parses GitHub org/repo from remote URLs (SSH + HTTPS), and polls each unique repo for open PRs
- Frontend now groups PRs by org (collapsible) and repo (with branch badge) instead of the flat current-branch/all filter
- API responses include `repos[]` array with name, org, branch, and PR count per repo

## Changes

### Backend (`apps/server/src/routes/prs.ts`)
- `discoverRepos()` — scans `~/code/*` for git repos with GitHub remotes, 5-min TTL cache
- `parseGitRemote()` — extracts owner/repo from SSH and HTTPS remote URLs
- `PrPoller` — dynamic discovery mode (no constructor args) or static repos (for tests); deduplicates by fullName for worktrees
- `GET /api/prs` and `POST /api/prs/refresh` — include `repos[]` summary in response
- `currentBranchScope()` — now scans all discovered repos + their linked worktrees

### Frontend (`apps/web/src/components/PrTicker.tsx`)
- PRs grouped by `org -> repo` with collapsible org sections
- Branch badge on each repo subheading
- "no open PRs" per empty repo, "No repos discovered" when no repos found
- Collapse state persisted in localStorage
- Removed current-branch/all filter chips and branch-scope polling

### Tests
- New `parseGitRemote` tests (SSH, HTTPS, edge cases)
- New multi-repo snapshot tests for PrPoller
- Updated frontend tests for grouped layout, org collapse/expand, multi-org rendering

## Test plan
- [x] `pnpm run typecheck` — passes
- [x] `pnpm run test:unit` — 108 tests pass (0 failures)
- [x] `pnpm run build` — succeeds

Closes #213

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>