### PR TITLE
test: add server route tests for prs, telegram, and utils

### DIFF
--- a/apps/server/src/routes/__tests__/prs-routes.test.ts
+++ b/apps/server/src/routes/__tests__/prs-routes.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { execFile, execFileSync } from "node:child_process";
 import type { PrRow, RepoInfo } from "../prs.js";
 
 /**
@@ -42,12 +43,15 @@ function makePr(overrides: Partial<PrRow> = {}): PrRow {
 }
 
 function makeRepoInfo(overrides: Partial<RepoInfo> = {}): RepoInfo {
+  // Use DISTINCT values for `name` (filesystem dir name) vs `repoName`
+  // (GitHub repo name) so the repo-shape test can assert the field mapping
+  // is correct and not passing by coincidence (same value in both fields).
   return {
-    path: "/home/claude/code/claude-pocket-console",
-    name: "claude-pocket-console",
+    path: "/home/claude/code/tryinbox-sh",
+    name: "tryinbox-sh",          // filesystem dir name
     owner: "claudes-world",
-    repoName: "claude-pocket-console",
-    fullName: "claudes-world/claude-pocket-console",
+    repoName: "inbox",            // GitHub repo name — intentionally different
+    fullName: "claudes-world/inbox",
     branch: "dev",
     ...overrides,
   };
@@ -134,8 +138,11 @@ describe("GET /", () => {
     expect(body.prs[1].number).toBe(10);
   });
 
-  it("includes repos summary with prCount", async () => {
-    const pr = makePr({ number: 42 });
+  it("includes repos summary with correct field mapping and prCount", async () => {
+    // makeRepoInfo() uses DISTINCT name ("tryinbox-sh") vs repoName ("inbox")
+    // so we can prove the route maps them to the right response fields.
+    // The PR's repo must match the RepoInfo fullName so prCount === 1.
+    const pr = makePr({ number: 42, repo: "claudes-world/inbox", key: "claudes-world/inbox#42" });
     mockPoller.snapshot.set(pr.key, pr);
     mockPoller.discoveredRepos = [makeRepoInfo()];
 
@@ -151,18 +158,20 @@ describe("GET /", () => {
       }>;
     };
     expect(body.repos).toHaveLength(1);
-    expect(body.repos[0].name).toBe("claude-pocket-console");
-    expect(body.repos[0].dirName).toBe("claude-pocket-console");
+    // name in the response = repoName (GitHub name), NOT the filesystem dir name
+    expect(body.repos[0].name).toBe("inbox");
+    // dirName = the filesystem directory name, different from name
+    expect(body.repos[0].dirName).toBe("tryinbox-sh");
     expect(body.repos[0].org).toBe("claudes-world");
-    expect(body.repos[0].fullName).toBe("claudes-world/claude-pocket-console");
+    expect(body.repos[0].fullName).toBe("claudes-world/inbox");
     expect(body.repos[0].branch).toBe("dev");
+    // PR.repo matches fullName → prCount must be 1
     expect(body.repos[0].prCount).toBe(1);
   });
 
   it("shows prCount=0 for repos with no open PRs", async () => {
-    mockPoller.discoveredRepos = [
-      makeRepoInfo({ fullName: "claudes-world/inbox", repoName: "inbox", name: "tryinbox-sh" }),
-    ];
+    // No PRs in snapshot — prCount must be 0 regardless of repo identity
+    mockPoller.discoveredRepos = [makeRepoInfo()];
 
     const res = await prsRoute.request("/");
     const body = (await res.json()) as { repos: Array<{ prCount: number }> };
@@ -231,13 +240,59 @@ describe("POST /refresh", () => {
 // GET /current-branch-scope
 // ---------------------------------------------------------------------------
 describe("GET /current-branch-scope", () => {
-  it("returns ok:true with branches array", async () => {
-    // With child_process mocked, discoverRepos returns [] (no repos found),
-    // so branches will be empty
+  it("returns ok:true with branches array (empty when all git calls fail)", async () => {
+    // With child_process mocked to fail, discoverRepos returns [] (no repos found),
+    // so branches will be empty — the route must still return ok:true.
     const res = await prsRoute.request("/current-branch-scope");
     expect(res.status).toBe(200);
     const body = (await res.json()) as { ok: boolean; branches: string[] };
     expect(body.ok).toBe(true);
     expect(Array.isArray(body.branches)).toBe(true);
+  });
+
+  it("returns branch names when discoverRepos and git worktree list succeed", async () => {
+    // Override execFileSync for the two discoverRepos git calls:
+    //   1st call: git remote get-url origin → GitHub SSH URL
+    //   2nd call: git rev-parse --abbrev-ref HEAD → branch name
+    // Override execFile for the currentBranchScope worktree list call.
+    // The real readdirSync will iterate ~/code/* — the first directory with
+    // a .git dir will trigger both execFileSync calls.
+    const mockExecFileSync = vi.mocked(execFileSync);
+    // remote URL call
+    mockExecFileSync.mockImplementationOnce(() => "git@github.com:claudes-world/claude-pocket-console.git" as any);
+    // branch call
+    mockExecFileSync.mockImplementationOnce(() => "feat/server-route-tests\n" as any);
+
+    const mockExecFile = vi.mocked(execFile);
+    // worktree list call — return a porcelain block with two worktrees
+    mockExecFile.mockImplementationOnce((_cmd: any, _args: any, _opts: any, cb?: any) => {
+      const worktreeOutput = [
+        "worktree /home/claude/code/claude-pocket-console",
+        "HEAD abc123",
+        "branch refs/heads/feat/server-route-tests",
+        "",
+        "worktree /home/claude/code/claude-pocket-console-feat-test",
+        "HEAD def456",
+        "branch refs/heads/feat/another-branch",
+        "",
+      ].join("\n");
+      if (cb) cb(null, worktreeOutput, "");
+      return { on: vi.fn() } as any;
+    });
+
+    const res = await prsRoute.request("/current-branch-scope");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ok: boolean; branches: string[] };
+    expect(body.ok).toBe(true);
+    expect(Array.isArray(body.branches)).toBe(true);
+    // Must include the branch names returned by the mocked git calls
+    expect(body.branches).toContain("feat/server-route-tests");
+    expect(body.branches).toContain("feat/another-branch");
+    // Must not have duplicates for the same branch seen in both HEAD and worktree
+    const seen = new Set<string>();
+    for (const b of body.branches) {
+      expect(seen.has(b)).toBe(false);
+      seen.add(b);
+    }
   });
 });

--- a/apps/server/src/routes/__tests__/prs-routes.test.ts
+++ b/apps/server/src/routes/__tests__/prs-routes.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { execFile, execFileSync } from "node:child_process";
+import { existsSync, readdirSync } from "node:fs";
 import type { PrRow, RepoInfo } from "../prs.js";
 
 /**
@@ -59,6 +60,15 @@ function makeRepoInfo(overrides: Partial<RepoInfo> = {}): RepoInfo {
 
 // We need to mock discoverRepos and currentBranchScope to avoid real git calls
 // from the /current-branch-scope route. Mock the module-level functions.
+vi.mock("node:fs", async () => {
+  const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+  return {
+    ...actual,
+    existsSync: vi.fn(actual.existsSync),
+    readdirSync: vi.fn(actual.readdirSync),
+  };
+});
+
 vi.mock("node:child_process", async () => {
   const actual = await vi.importActual<typeof import("node:child_process")>(
     "node:child_process",
@@ -251,6 +261,14 @@ describe("GET /current-branch-scope", () => {
   });
 
   it("returns branch names when discoverRepos and git worktree list succeed", async () => {
+    const mockExistsSync = vi.mocked(existsSync);
+    const mockReaddirSync = vi.mocked(readdirSync);
+    // Make codeDir exist and contain one repo dir
+    mockExistsSync.mockReturnValueOnce(true);  // existsSync(codeDir)
+    mockReaddirSync.mockReturnValueOnce(["claude-pocket-console"] as any);
+    // Make .git check pass for that repo
+    mockExistsSync.mockReturnValueOnce(true);  // existsSync(join(repoPath, '.git'))
+
     // Override execFileSync for the two discoverRepos git calls:
     //   1st call: git remote get-url origin → GitHub SSH URL
     //   2nd call: git rev-parse --abbrev-ref HEAD → branch name

--- a/apps/server/src/routes/__tests__/prs-routes.test.ts
+++ b/apps/server/src/routes/__tests__/prs-routes.test.ts
@@ -1,0 +1,243 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { PrRow, RepoInfo } from "../prs.js";
+
+/**
+ * Tests for the HTTP route handlers in `prs.ts`:
+ *   - GET /           — snapshot of PRs + repo summary
+ *   - POST /refresh   — force-poll and return diff counts
+ *   - GET /current-branch-scope — list active branches
+ *
+ * The pure-logic tests (parseGitRemote, diffSnapshots, PrPoller backoff,
+ * getSnapshot sorting) already live in pr-poller.test.ts. This file covers
+ * the Hono HTTP layer exclusively.
+ *
+ * Strategy:
+ *   - Use the exported __setPollerForTests() to inject a mock PrPoller so
+ *     no real `gh` CLI or `git` commands run.
+ *   - Use __resetScopeCacheForTests() to clear the scope cache between tests.
+ *   - Drive routes via Hono `app.request()`.
+ */
+
+// --- Helpers ---
+
+function makePr(overrides: Partial<PrRow> = {}): PrRow {
+  const num = overrides.number ?? 1;
+  return {
+    key: overrides.key ?? `claudes-world/claude-pocket-console#${num}`,
+    repo: overrides.repo ?? "claudes-world/claude-pocket-console",
+    number: num,
+    title: `PR #${num}`,
+    state: "OPEN",
+    isDraft: false,
+    headRefName: "feat/test",
+    author: "claude-do",
+    reviewDecision: null,
+    ciStatus: null,
+    url: `https://github.com/claudes-world/claude-pocket-console/pull/${num}`,
+    updatedAt: new Date().toISOString(),
+    firstSeen: Date.now(),
+    lastChanged: Date.now(),
+    ...overrides,
+  };
+}
+
+function makeRepoInfo(overrides: Partial<RepoInfo> = {}): RepoInfo {
+  return {
+    path: "/home/claude/code/claude-pocket-console",
+    name: "claude-pocket-console",
+    owner: "claudes-world",
+    repoName: "claude-pocket-console",
+    fullName: "claudes-world/claude-pocket-console",
+    branch: "dev",
+    ...overrides,
+  };
+}
+
+// We need to mock discoverRepos and currentBranchScope to avoid real git calls
+// from the /current-branch-scope route. Mock the module-level functions.
+vi.mock("node:child_process", async () => {
+  const actual = await vi.importActual<typeof import("node:child_process")>(
+    "node:child_process",
+  );
+  return {
+    ...actual,
+    execFile: vi.fn((_cmd: string, _args: string[], _opts: any, cb?: any) => {
+      if (cb) cb(new Error("mocked"), "", "");
+      return { on: vi.fn() };
+    }),
+    execFileSync: vi.fn(() => {
+      throw new Error("mocked");
+    }),
+  };
+});
+
+const {
+  prsRoute,
+  PrPoller,
+  __setPollerForTests,
+  __resetScopeCacheForTests,
+  __resetRepoCacheForTests,
+} = await import("../prs.js");
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+let mockPoller: InstanceType<typeof PrPoller>;
+
+beforeEach(() => {
+  __resetScopeCacheForTests();
+  __resetRepoCacheForTests();
+  // Create a poller in static mode (empty repos = no network calls)
+  mockPoller = new PrPoller([], 999_999);
+  __setPollerForTests(mockPoller);
+});
+
+afterEach(() => {
+  __setPollerForTests(null);
+  vi.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// GET /
+// ---------------------------------------------------------------------------
+describe("GET /", () => {
+  it("returns ok:true with empty prs when poller has no data", async () => {
+    const res = await prsRoute.request("/");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      ok: boolean;
+      prs: PrRow[];
+      repos: any[];
+      lastPollOk: number;
+      lastPollErr: string | null;
+    };
+    expect(body.ok).toBe(true);
+    expect(body.prs).toEqual([]);
+    expect(body.repos).toEqual([]);
+    expect(body.lastPollErr).toBeNull();
+  });
+
+  it("returns PRs from the poller snapshot", async () => {
+    const pr1 = makePr({ number: 10, updatedAt: "2026-04-01T00:00:00Z" });
+    const pr2 = makePr({ number: 20, updatedAt: "2026-04-10T00:00:00Z" });
+    mockPoller.snapshot.set(pr1.key, pr1);
+    mockPoller.snapshot.set(pr2.key, pr2);
+
+    const res = await prsRoute.request("/");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ok: boolean; prs: PrRow[] };
+    expect(body.ok).toBe(true);
+    expect(body.prs).toHaveLength(2);
+    // Sorted by updatedAt descending
+    expect(body.prs[0].number).toBe(20);
+    expect(body.prs[1].number).toBe(10);
+  });
+
+  it("includes repos summary with prCount", async () => {
+    const pr = makePr({ number: 42 });
+    mockPoller.snapshot.set(pr.key, pr);
+    mockPoller.discoveredRepos = [makeRepoInfo()];
+
+    const res = await prsRoute.request("/");
+    const body = (await res.json()) as {
+      repos: Array<{
+        name: string;
+        dirName: string;
+        org: string;
+        fullName: string;
+        branch: string;
+        prCount: number;
+      }>;
+    };
+    expect(body.repos).toHaveLength(1);
+    expect(body.repos[0].name).toBe("claude-pocket-console");
+    expect(body.repos[0].dirName).toBe("claude-pocket-console");
+    expect(body.repos[0].org).toBe("claudes-world");
+    expect(body.repos[0].fullName).toBe("claudes-world/claude-pocket-console");
+    expect(body.repos[0].branch).toBe("dev");
+    expect(body.repos[0].prCount).toBe(1);
+  });
+
+  it("shows prCount=0 for repos with no open PRs", async () => {
+    mockPoller.discoveredRepos = [
+      makeRepoInfo({ fullName: "claudes-world/inbox", repoName: "inbox", name: "tryinbox-sh" }),
+    ];
+
+    const res = await prsRoute.request("/");
+    const body = (await res.json()) as { repos: Array<{ prCount: number }> };
+    expect(body.repos[0].prCount).toBe(0);
+  });
+
+  it("exposes lastPollOk and lastPollErr", async () => {
+    mockPoller.lastPollOk = 1_700_000_000_000;
+    mockPoller.lastPollErr = "rate limited";
+
+    const res = await prsRoute.request("/");
+    const body = (await res.json()) as {
+      lastPollOk: number;
+      lastPollErr: string | null;
+    };
+    expect(body.lastPollOk).toBe(1_700_000_000_000);
+    expect(body.lastPollErr).toBe("rate limited");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /refresh
+// ---------------------------------------------------------------------------
+describe("POST /refresh", () => {
+  it("returns ok:true with diff counts after polling", async () => {
+    const res = await prsRoute.request("/refresh", { method: "POST" });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      ok: boolean;
+      prs: PrRow[];
+      repos: any[];
+      diff: { added: number; removed: number; changed: number };
+    };
+    expect(body.ok).toBe(true);
+    expect(body.diff).toEqual({ added: 0, removed: 0, changed: 0 });
+  });
+
+  it("reports diff counts when snapshot changes", async () => {
+    // Pre-populate snapshot with a PR that will be "removed" after poll
+    // (since static poller with empty repos produces empty snapshot)
+    const pr = makePr({ number: 99 });
+    mockPoller.snapshot.set(pr.key, pr);
+
+    const res = await prsRoute.request("/refresh", { method: "POST" });
+    const body = (await res.json()) as {
+      diff: { added: number; removed: number; changed: number };
+    };
+    // The old PR should be reported as removed since empty static repos
+    // yield an empty next snapshot
+    expect(body.diff.removed).toBe(1);
+  });
+
+  it("includes repos in response when discoveredRepos is set", async () => {
+    // pollOnce() in static mode clears discoveredRepos to [].
+    // The GET / route reads discoveredRepos without calling pollOnce,
+    // so test via GET / instead where we control the state directly.
+    // For POST /refresh, verify the repos key exists (even if empty in
+    // static mode since discoveredRepos is cleared by pollOnce).
+    const res = await prsRoute.request("/refresh", { method: "POST" });
+    const body = (await res.json()) as { repos: any[] };
+    expect(Array.isArray(body.repos)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /current-branch-scope
+// ---------------------------------------------------------------------------
+describe("GET /current-branch-scope", () => {
+  it("returns ok:true with branches array", async () => {
+    // With child_process mocked, discoverRepos returns [] (no repos found),
+    // so branches will be empty
+    const res = await prsRoute.request("/current-branch-scope");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ok: boolean; branches: string[] };
+    expect(body.ok).toBe(true);
+    expect(Array.isArray(body.branches)).toBe(true);
+  });
+});

--- a/apps/server/src/routes/__tests__/telegram.test.ts
+++ b/apps/server/src/routes/__tests__/telegram.test.ts
@@ -5,8 +5,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
  *   - POST /send-to-chat — sends a file-sharing message to Telegram
  *
  * Strategy:
- *   - Mock `../utils.js` to stub getTelegramCreds, tgRaw, tgSanitize, and
- *     execAsync so no real shell or curl calls run.
+ *   - Mock `../utils.js` to stub getTelegramCreds and execAsync so no real
+ *     shell or curl calls run. tgRaw and tgSanitize are NOT stubbed — they
+ *     are pure functions exercised through their real implementations.
  *   - Drive the telegramRoute Hono sub-app via `app.request()`.
  */
 
@@ -149,7 +150,7 @@ describe("POST /send-to-chat", () => {
     expect(body.ok).toBe(false);
   });
 
-  it("returns 400 when request body is not valid JSON", async () => {
+  it("returns 500 when request body is not valid JSON", async () => {
     // Send a raw invalid-JSON body directly (bypasses postSendToChat helper).
     // c.req.json() throws on invalid JSON; Hono's default error handler returns 500 for unhandled throws.
     const res = await telegramRoute.request("/send-to-chat", {

--- a/apps/server/src/routes/__tests__/telegram.test.ts
+++ b/apps/server/src/routes/__tests__/telegram.test.ts
@@ -1,0 +1,162 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Tests for `telegram.ts` route endpoints:
+ *   - POST /send-to-chat — sends a file-sharing message to Telegram
+ *
+ * Strategy:
+ *   - Mock `../utils.js` to stub getTelegramCreds, tgRaw, tgSanitize, and
+ *     execAsync so no real shell or curl calls run.
+ *   - Drive the telegramRoute Hono sub-app via `app.request()`.
+ */
+
+// ---------------------------------------------------------------------------
+// Mocks — must be declared before dynamic imports
+// ---------------------------------------------------------------------------
+
+const mockExecAsync = vi.fn();
+const mockGetTelegramCreds = vi.fn();
+
+vi.mock("../utils.js", async () => {
+  const actual = await vi.importActual<typeof import("../utils.js")>("../utils.js");
+  return {
+    ...actual,
+    getTelegramCreds: (...args: any[]) => mockGetTelegramCreds(...args),
+    execAsync: (...args: any[]) => mockExecAsync(...args),
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Import route AFTER mocks
+// ---------------------------------------------------------------------------
+const { telegramRoute } = await import("../telegram.js");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function postSendToChat(body: unknown): Promise<Response> {
+  return telegramRoute.request("/send-to-chat", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  mockGetTelegramCreds.mockResolvedValue({
+    botToken: "123456:ABC-DEF",
+    chatId: "-1001234567890",
+  });
+  mockExecAsync.mockResolvedValue({
+    stdout: JSON.stringify({ ok: true, result: { message_id: 42 } }),
+  });
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("POST /send-to-chat", () => {
+  it("returns ok:true with messageId on success", async () => {
+    const res = await postSendToChat({ filePath: "/home/claude/code/test.ts" });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ok: boolean; messageId: number };
+    expect(body.ok).toBe(true);
+    expect(body.messageId).toBe(42);
+  });
+
+  it("calls getTelegramCreds", async () => {
+    await postSendToChat({ filePath: "/home/claude/test.txt" });
+    expect(mockGetTelegramCreds).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls execAsync with a curl command containing the botToken and chatId", async () => {
+    await postSendToChat({ filePath: "/home/claude/code/example.ts" });
+    expect(mockExecAsync).toHaveBeenCalledTimes(1);
+    const [cmd, opts] = mockExecAsync.mock.calls[0];
+    expect(cmd).toContain("curl");
+    expect(cmd).toContain("123456:ABC-DEF");
+    expect(cmd).toContain("-1001234567890");
+    expect(opts.shell).toBe("/bin/bash");
+  });
+
+  it("shortens /home/claude/ paths to ~/ in the message", async () => {
+    await postSendToChat({ filePath: "/home/claude/code/test.ts" });
+    const [cmd] = mockExecAsync.mock.calls[0];
+    // tgRaw escapes ~ and . — in the JSON payload within the curl command,
+    // the backslash is doubled (JSON encoding), so \~ becomes \\~
+    expect(cmd).toContain("\\\\~/code/test\\\\.ts");
+    // Original unescaped path should not appear
+    expect(cmd).not.toContain("/home/claude/code/test.ts");
+  });
+
+  it("includes MarkdownV2 parse_mode in the request", async () => {
+    await postSendToChat({ filePath: "/home/claude/test.md" });
+    const [cmd] = mockExecAsync.mock.calls[0];
+    expect(cmd).toContain("MarkdownV2");
+  });
+
+  it("returns 400 when filePath is missing", async () => {
+    const res = await postSendToChat({});
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { ok: boolean; error: string };
+    expect(body.ok).toBe(false);
+    expect(body.error).toBe("filePath required");
+  });
+
+  it("returns 400 when filePath is empty string", async () => {
+    const res = await postSendToChat({ filePath: "" });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { ok: boolean; error: string };
+    expect(body.ok).toBe(false);
+    expect(body.error).toBe("filePath required");
+  });
+
+  it("returns 500 when getTelegramCreds throws", async () => {
+    mockGetTelegramCreds.mockRejectedValueOnce(
+      new Error("Telegram not configured in common.sh"),
+    );
+    const res = await postSendToChat({ filePath: "/home/claude/test.txt" });
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as { ok: boolean; error: string };
+    expect(body.ok).toBe(false);
+    expect(body.error).toBe("Telegram not configured in common.sh");
+  });
+
+  it("returns 500 when execAsync (curl) throws", async () => {
+    mockExecAsync.mockRejectedValueOnce(new Error("curl failed"));
+    const res = await postSendToChat({ filePath: "/home/claude/test.txt" });
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as { ok: boolean; error: string };
+    expect(body.ok).toBe(false);
+    expect(body.error).toBe("curl failed");
+  });
+
+  it("returns 500 when Telegram API returns invalid JSON", async () => {
+    mockExecAsync.mockResolvedValueOnce({ stdout: "not json" });
+    const res = await postSendToChat({ filePath: "/home/claude/test.txt" });
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as { ok: boolean; error: string };
+    expect(body.ok).toBe(false);
+  });
+
+  it("handles paths not under /home/claude/ without error", async () => {
+    const res = await postSendToChat({ filePath: "/tmp/shared/file.txt" });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ok: boolean };
+    expect(body.ok).toBe(true);
+    // The shortPath goes through tgRaw which escapes dots; in the JSON
+    // payload the backslash is doubled, so \. becomes \\.
+    const [cmd] = mockExecAsync.mock.calls[0];
+    expect(cmd).toContain("/tmp/shared/file\\\\.txt");
+  });
+});

--- a/apps/server/src/routes/__tests__/telegram.test.ts
+++ b/apps/server/src/routes/__tests__/telegram.test.ts
@@ -149,6 +149,32 @@ describe("POST /send-to-chat", () => {
     expect(body.ok).toBe(false);
   });
 
+  it("returns 400 when request body is not valid JSON", async () => {
+    // Send a raw invalid-JSON body directly (bypasses postSendToChat helper).
+    // c.req.json() throws on invalid JSON; Hono's default error handler returns 500 for unhandled throws.
+    const res = await telegramRoute.request("/send-to-chat", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "this is { not valid } json",
+    });
+    expect(res.status).toBe(500);
+  });
+
+  it("returns 200 with undefined messageId when Telegram API returns ok:false", async () => {
+    // Current source does not check result.ok — it returns ok:true regardless.
+    // This test documents the current behaviour. If the source is later hardened
+    // to return 500 on ok:false, update this test and the source together.
+    mockExecAsync.mockResolvedValueOnce({
+      stdout: JSON.stringify({ ok: false, description: "Bad Request: chat not found" }),
+    });
+    const res = await postSendToChat({ filePath: "/home/claude/test.txt" });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ok: boolean; messageId: number | undefined };
+    expect(body.ok).toBe(true);
+    // result.result is undefined when ok:false, so messageId is undefined
+    expect(body.messageId).toBeUndefined();
+  });
+
   it("handles paths not under /home/claude/ without error", async () => {
     const res = await postSendToChat({ filePath: "/tmp/shared/file.txt" });
     expect(res.status).toBe(200);

--- a/apps/server/src/routes/__tests__/utils.test.ts
+++ b/apps/server/src/routes/__tests__/utils.test.ts
@@ -1,0 +1,351 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Tests for `utils.ts` — shared utility functions and constants.
+ *
+ * Coverage:
+ *   - TMUX_SESSION validation (module-load-time regex guard)
+ *   - sendToTmux — calls execFile with correct args, literal flag, and --
+ *   - tgRaw / tgSanitize — Telegram MarkdownV2 escaping
+ *   - loadOpenAIEnv / loadAnthropicEnv — secrets file loading
+ *   - getTelegramCreds — parses common.sh output
+ *   - Exported constants (HOME, CLAUDES_WORLD, SESSION_NAMES_FILE)
+ *
+ * Strategy:
+ *   - Mock `node:child_process` to spy on execFile without running real tmux/bash.
+ *   - Mock `node:fs` readFileSync for secrets file loading.
+ *   - Use real tgRaw/tgSanitize (pure functions, no side effects).
+ */
+
+// ---------------------------------------------------------------------------
+// Mocks — must be declared before dynamic imports
+// ---------------------------------------------------------------------------
+
+const execFileSpy = vi.fn(
+  (_cmd: string, _args: string[], _opts: any, cb?: (err: Error | null, stdout: string, stderr: string) => void) => {
+    if (cb) cb(null, "", "");
+  },
+);
+
+vi.mock("node:child_process", async () => {
+  const actual = await vi.importActual<typeof import("node:child_process")>(
+    "node:child_process",
+  );
+  return {
+    ...actual,
+    exec: vi.fn(
+      (_cmd: string, _opts: any, cb?: (err: Error | null, stdout: string, stderr: string) => void) => {
+        if (cb) cb(null, "", "");
+      },
+    ),
+    execFile: execFileSpy,
+  };
+});
+
+// Mock readFileSync for secrets loading tests. Keep a reference to control
+// per-test behavior.
+const readFileSyncSpy = vi.fn((_path: string, _enc?: string) => "");
+
+vi.mock("node:fs", async () => {
+  const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+  return {
+    ...actual,
+    readFileSync: (...args: any[]) => readFileSyncSpy(...args),
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Import AFTER mocks
+// ---------------------------------------------------------------------------
+
+const {
+  TMUX_SESSION,
+  HOME,
+  CLAUDES_WORLD,
+  SESSION_NAMES_FILE,
+  tgRaw,
+  tgSanitize,
+  sendToTmux,
+  loadOpenAIEnv,
+  loadAnthropicEnv,
+  execAsync,
+} = await import("../utils.js");
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  execFileSpy.mockClear();
+  readFileSyncSpy.mockClear();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Exported constants
+// ---------------------------------------------------------------------------
+describe("exported constants", () => {
+  it("TMUX_SESSION is a valid identifier (alphanumerics, hyphens, underscores, dots)", () => {
+    expect(TMUX_SESSION).toMatch(/^[A-Za-z0-9_.-]+$/);
+  });
+
+  it("HOME is set", () => {
+    expect(typeof HOME).toBe("string");
+    expect(HOME.length).toBeGreaterThan(0);
+  });
+
+  it("CLAUDES_WORLD is HOME/claudes-world", () => {
+    expect(CLAUDES_WORLD).toBe(`${HOME}/claudes-world`);
+  });
+
+  it("SESSION_NAMES_FILE is under CLAUDES_WORLD", () => {
+    expect(SESSION_NAMES_FILE).toBe(`${CLAUDES_WORLD}/.cpc-session-names`);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// tgRaw
+// ---------------------------------------------------------------------------
+describe("tgRaw", () => {
+  it("escapes all Telegram MarkdownV2 special characters", () => {
+    const specials = "_*[]()~`>#+-=|{}.!\\";
+    const escaped = tgRaw(specials);
+    // Each character should be preceded by a backslash
+    for (const ch of specials) {
+      expect(escaped).toContain(`\\${ch}`);
+    }
+  });
+
+  it("leaves plain alphanumeric text unchanged", () => {
+    expect(tgRaw("hello123")).toBe("hello123");
+  });
+
+  it("escapes dots, tildes, and exclamation marks", () => {
+    // ~ is a MarkdownV2 special character, so it gets escaped too
+    expect(tgRaw("~/code/test.ts")).toBe("\\~/code/test\\.ts");
+    expect(tgRaw("Done!")).toBe("Done\\!");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// tgSanitize
+// ---------------------------------------------------------------------------
+describe("tgSanitize", () => {
+  it("preserves *bold* markers while escaping inner content", () => {
+    const result = tgSanitize("Hello *world*");
+    // "Hello" should be unescaped (no special chars), *world* preserved
+    expect(result).toContain("*");
+    // The word "world" inside stars should have no leading backslash
+    expect(result).toMatch(/\*world\*/);
+  });
+
+  it("preserves _italic_ markers while escaping inner content", () => {
+    const result = tgSanitize("Hello _world_");
+    expect(result).toContain("_");
+    expect(result).toMatch(/_world_/);
+  });
+
+  it("preserves `code` markers", () => {
+    const result = tgSanitize("Use `npm install` here");
+    expect(result).toContain("`npm install`");
+  });
+
+  it("escapes special characters outside of format markers", () => {
+    const result = tgSanitize("Hello. World!");
+    expect(result).toContain("\\.");
+    expect(result).toContain("\\!");
+  });
+
+  it("handles text with no special characters", () => {
+    expect(tgSanitize("plain text")).toBe("plain text");
+  });
+
+  it("handles text with only special characters", () => {
+    const result = tgSanitize("...");
+    expect(result).toBe("\\.\\.\\.");
+  });
+
+  it("escapes special chars inside *bold* content", () => {
+    const result = tgSanitize("*hello.world*");
+    // The dot inside bold should be escaped
+    expect(result).toContain("*hello\\.world*");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sendToTmux
+// ---------------------------------------------------------------------------
+describe("sendToTmux", () => {
+  it("calls execFile twice (send-keys with -l, then Enter)", async () => {
+    await sendToTmux("hello");
+    expect(execFileSpy).toHaveBeenCalledTimes(2);
+
+    // First call: literal text
+    const [cmd1, args1] = execFileSpy.mock.calls[0];
+    expect(cmd1).toBe("tmux");
+    expect(args1).toContain("send-keys");
+    expect(args1).toContain("-l");
+    expect(args1).toContain("-t");
+    expect(args1).toContain(TMUX_SESSION);
+    expect(args1).toContain("--");
+    expect(args1).toContain("hello");
+
+    // Second call: Enter key
+    const [cmd2, args2] = execFileSpy.mock.calls[1];
+    expect(cmd2).toBe("tmux");
+    expect(args2).toContain("send-keys");
+    expect(args2).toContain("Enter");
+    expect(args2).toContain("-t");
+    expect(args2).toContain(TMUX_SESSION);
+  });
+
+  it("passes timeout option to both execFile calls", async () => {
+    await sendToTmux("test");
+    // Both calls should have a timeout option
+    const [, , opts1] = execFileSpy.mock.calls[0];
+    const [, , opts2] = execFileSpy.mock.calls[1];
+    expect(opts1.timeout).toBe(5_000);
+    expect(opts2.timeout).toBe(5_000);
+  });
+
+  it("uses -- separator to prevent tmux from interpreting keys as options", async () => {
+    await sendToTmux("-dangerous-flag");
+    const [, args] = execFileSpy.mock.calls[0];
+    // The -- should appear before the key text
+    const dashDashIdx = args.indexOf("--");
+    const keyIdx = args.indexOf("-dangerous-flag");
+    expect(dashDashIdx).toBeGreaterThan(-1);
+    expect(keyIdx).toBeGreaterThan(dashDashIdx);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// loadOpenAIEnv / loadAnthropicEnv
+// ---------------------------------------------------------------------------
+describe("loadOpenAIEnv", () => {
+  it("reads the secrets file and sets env vars", () => {
+    const original = process.env.OPENAI_API_KEY;
+    delete process.env.OPENAI_API_KEY;
+    try {
+      readFileSyncSpy.mockReturnValueOnce("OPENAI_API_KEY=sk-test-key\n");
+      loadOpenAIEnv();
+      expect(readFileSyncSpy).toHaveBeenCalledTimes(1);
+      const [path] = readFileSyncSpy.mock.calls[0];
+      expect(path).toContain(".secrets/openai.env");
+      expect(process.env.OPENAI_API_KEY).toBe("sk-test-key");
+    } finally {
+      if (original === undefined) delete process.env.OPENAI_API_KEY;
+      else process.env.OPENAI_API_KEY = original;
+    }
+  });
+
+  it("does not overwrite existing env vars", () => {
+    const original = process.env.OPENAI_API_KEY;
+    process.env.OPENAI_API_KEY = "existing-key";
+    try {
+      readFileSyncSpy.mockReturnValueOnce("OPENAI_API_KEY=new-key\n");
+      loadOpenAIEnv();
+      expect(process.env.OPENAI_API_KEY).toBe("existing-key");
+    } finally {
+      if (original === undefined) delete process.env.OPENAI_API_KEY;
+      else process.env.OPENAI_API_KEY = original;
+    }
+  });
+
+  it("skips comment lines and blank lines", () => {
+    delete process.env.SOME_TEST_VAR;
+    try {
+      readFileSyncSpy.mockReturnValueOnce(
+        "# This is a comment\n\nSOME_TEST_VAR=value\n  \n",
+      );
+      loadOpenAIEnv();
+      expect(process.env.SOME_TEST_VAR).toBe("value");
+    } finally {
+      delete process.env.SOME_TEST_VAR;
+    }
+  });
+
+  it("gracefully handles missing secrets file", () => {
+    readFileSyncSpy.mockImplementationOnce(() => {
+      throw new Error("ENOENT");
+    });
+    // Should not throw
+    expect(() => loadOpenAIEnv()).not.toThrow();
+  });
+});
+
+describe("loadAnthropicEnv", () => {
+  it("reads the anthropic secrets file", () => {
+    const original = process.env.ANTHROPIC_API_KEY;
+    delete process.env.ANTHROPIC_API_KEY;
+    try {
+      readFileSyncSpy.mockReturnValueOnce("ANTHROPIC_API_KEY=sk-ant-test\n");
+      loadAnthropicEnv();
+      expect(readFileSyncSpy).toHaveBeenCalledTimes(1);
+      const [path] = readFileSyncSpy.mock.calls[0];
+      expect(path).toContain(".secrets/anthropic.env");
+      expect(process.env.ANTHROPIC_API_KEY).toBe("sk-ant-test");
+    } finally {
+      if (original === undefined) delete process.env.ANTHROPIC_API_KEY;
+      else process.env.ANTHROPIC_API_KEY = original;
+    }
+  });
+
+  it("gracefully handles missing secrets file", () => {
+    readFileSyncSpy.mockImplementationOnce(() => {
+      throw new Error("ENOENT");
+    });
+    expect(() => loadAnthropicEnv()).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getTelegramCreds
+// ---------------------------------------------------------------------------
+describe("getTelegramCreds", () => {
+  it("parses botToken and chatId from common.sh output", async () => {
+    // getTelegramCreds uses execAsync (promisified exec), which we mocked
+    // at the module level. We need to re-mock exec for this specific test.
+    const { exec } = await import("node:child_process");
+    const mockExec = vi.mocked(exec);
+    mockExec.mockImplementationOnce((_cmd: any, _opts: any, cb: any) => {
+      cb(null, "bot123:ABC|||chat456", "");
+      return {} as any;
+    });
+
+    // execAsync wraps exec via promisify, but since we mocked exec,
+    // we need to test via the module's exported execAsync or getTelegramCreds.
+    // Since getTelegramCreds uses execAsync internally and execAsync uses
+    // the mocked exec, this should work. However, the promisify wrapper
+    // was created at import time with the original (mocked) exec reference.
+    // Let's verify the integration works.
+    const { getTelegramCreds: freshGetCreds } = await import("../utils.js");
+    // The exec mock needs the right callback signature for promisify
+    mockExec.mockImplementationOnce((_cmd: any, _opts: any, cb: any) => {
+      if (cb) cb(null, "mybot:TOKEN|||-100999", "");
+      return {} as any;
+    });
+
+    try {
+      const creds = await freshGetCreds();
+      expect(creds.botToken).toBe("mybot:TOKEN");
+      expect(creds.chatId).toBe("-100999");
+    } catch {
+      // If promisify doesn't pick up the mock (due to binding at import time),
+      // that's expected in the test environment. The unit behavior is validated
+      // by the telegram.test.ts integration tests.
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// execAsync
+// ---------------------------------------------------------------------------
+describe("execAsync", () => {
+  it("is exported and is a function", () => {
+    expect(typeof execAsync).toBe("function");
+  });
+});

--- a/apps/server/src/routes/__tests__/utils.test.ts
+++ b/apps/server/src/routes/__tests__/utils.test.ts
@@ -75,13 +75,22 @@ const {
 // Setup / teardown
 // ---------------------------------------------------------------------------
 
+let savedEnv: NodeJS.ProcessEnv;
+
 beforeEach(() => {
   execFileSpy.mockClear();
   readFileSyncSpy.mockClear();
+  // Snapshot env to prevent cross-test state bleed from loadOpenAIEnv / loadAnthropicEnv
+  savedEnv = { ...process.env };
 });
 
 afterEach(() => {
   vi.clearAllMocks();
+  // Restore full env snapshot
+  for (const key of Object.keys(process.env)) {
+    if (!(key in savedEnv)) delete process.env[key];
+  }
+  Object.assign(process.env, savedEnv);
 });
 
 // ---------------------------------------------------------------------------
@@ -110,20 +119,35 @@ describe("exported constants", () => {
 // tgRaw
 // ---------------------------------------------------------------------------
 describe("tgRaw", () => {
-  it("escapes all Telegram MarkdownV2 special characters", () => {
-    const specials = "_*[]()~`>#+-=|{}.!\\";
-    const escaped = tgRaw(specials);
-    // Each character should be preceded by a backslash
-    for (const ch of specials) {
-      expect(escaped).toContain(`\\${ch}`);
-    }
+  it("escapes each Telegram MarkdownV2 special character individually", () => {
+    // Use exact toBe assertions on single chars to catch double-escape bugs.
+    // toContain on a full string would pass even if output is "\\__" etc.
+    expect(tgRaw("_")).toBe("\\_");
+    expect(tgRaw("*")).toBe("\\*");
+    expect(tgRaw("[")).toBe("\\[");
+    expect(tgRaw("]")).toBe("\\]");
+    expect(tgRaw("(")).toBe("\\(");
+    expect(tgRaw(")")).toBe("\\)");
+    expect(tgRaw("~")).toBe("\\~");
+    expect(tgRaw("`")).toBe("\\`");
+    expect(tgRaw(">")).toBe("\\>");
+    expect(tgRaw("#")).toBe("\\#");
+    expect(tgRaw("+")).toBe("\\+");
+    expect(tgRaw("-")).toBe("\\-");
+    expect(tgRaw("=")).toBe("\\=");
+    expect(tgRaw("|")).toBe("\\|");
+    expect(tgRaw("{")).toBe("\\{");
+    expect(tgRaw("}")).toBe("\\}");
+    expect(tgRaw(".")).toBe("\\.");
+    expect(tgRaw("!")).toBe("\\!");
+    expect(tgRaw("\\")).toBe("\\\\");
   });
 
   it("leaves plain alphanumeric text unchanged", () => {
     expect(tgRaw("hello123")).toBe("hello123");
   });
 
-  it("escapes dots, tildes, and exclamation marks", () => {
+  it("escapes dots, tildes, and exclamation marks in strings", () => {
     // ~ is a MarkdownV2 special character, so it gets escaped too
     expect(tgRaw("~/code/test.ts")).toBe("\\~/code/test\\.ts");
     expect(tgRaw("Done!")).toBe("Done\\!");
@@ -134,23 +158,43 @@ describe("tgRaw", () => {
 // tgSanitize
 // ---------------------------------------------------------------------------
 describe("tgSanitize", () => {
-  it("preserves *bold* markers while escaping inner content", () => {
-    const result = tgSanitize("Hello *world*");
-    // "Hello" should be unescaped (no special chars), *world* preserved
-    expect(result).toContain("*");
-    // The word "world" inside stars should have no leading backslash
-    expect(result).toMatch(/\*world\*/);
+  it("preserves *bold* markers while escaping outer text AND inner special chars", () => {
+    // Input has special chars both outside ("!") and inside ("." in "5.00") the
+    // bold markers. A no-op identity function would return the raw string — these
+    // assertions would fail because "!" and "." would be unescaped.
+    const result = tgSanitize("Price: *$5.00* today!");
+    // The asterisk markers must survive intact
+    expect(result).toMatch(/\*/);
+    // The dot inside bold must be escaped: *$5\.00*
+    expect(result).toContain("*$5\\.00*");
+    // The "!" outside bold must be escaped
+    expect(result).toContain("\\!");
+    // Identity function returns "Price: *$5.00* today!" — raw dot, unescaped "!"
+    expect(result).not.toBe("Price: *$5.00* today!");
   });
 
-  it("preserves _italic_ markers while escaping inner content", () => {
-    const result = tgSanitize("Hello _world_");
-    expect(result).toContain("_");
-    expect(result).toMatch(/_world_/);
+  it("preserves _italic_ markers while escaping inner special chars", () => {
+    // Dot inside italic must be escaped; dot after "details" (outside) also escaped.
+    const result = tgSanitize("See _v1.2_ for details.");
+    // Italic markers must survive
+    expect(result).toMatch(/_/);
+    // The dot inside italic must be escaped
+    expect(result).toContain("_v1\\.2_");
+    // The dot after "details" (outside italic) must also be escaped
+    expect(result).toContain("details\\.");
+    // Identity function would return raw input, which this test must reject
+    expect(result).not.toBe("See _v1.2_ for details.");
   });
 
-  it("preserves `code` markers", () => {
-    const result = tgSanitize("Use `npm install` here");
+  it("preserves `code` markers with inner content verbatim (no escaping inside code)", () => {
+    // tgSanitize holds code spans as placeholders, so raw content inside backticks
+    // survives unchanged. Special chars OUTSIDE backticks are still escaped.
+    const result = tgSanitize("Run `npm install` now!");
     expect(result).toContain("`npm install`");
+    // The "!" outside code must still be escaped
+    expect(result).toContain("\\!");
+    // Identity function fails because "!" is unescaped in the raw input
+    expect(result).not.toBe("Run `npm install` now!");
   });
 
   it("escapes special characters outside of format markers", () => {
@@ -305,41 +349,22 @@ describe("loadAnthropicEnv", () => {
 // ---------------------------------------------------------------------------
 // getTelegramCreds
 // ---------------------------------------------------------------------------
-describe("getTelegramCreds", () => {
-  it("parses botToken and chatId from common.sh output", async () => {
-    // getTelegramCreds uses execAsync (promisified exec), which we mocked
-    // at the module level. We need to re-mock exec for this specific test.
-    const { exec } = await import("node:child_process");
-    const mockExec = vi.mocked(exec);
-    mockExec.mockImplementationOnce((_cmd: any, _opts: any, cb: any) => {
-      cb(null, "bot123:ABC|||chat456", "");
-      return {} as any;
-    });
-
-    // execAsync wraps exec via promisify, but since we mocked exec,
-    // we need to test via the module's exported execAsync or getTelegramCreds.
-    // Since getTelegramCreds uses execAsync internally and execAsync uses
-    // the mocked exec, this should work. However, the promisify wrapper
-    // was created at import time with the original (mocked) exec reference.
-    // Let's verify the integration works.
-    const { getTelegramCreds: freshGetCreds } = await import("../utils.js");
-    // The exec mock needs the right callback signature for promisify
-    mockExec.mockImplementationOnce((_cmd: any, _opts: any, cb: any) => {
-      if (cb) cb(null, "mybot:TOKEN|||-100999", "");
-      return {} as any;
-    });
-
-    try {
-      const creds = await freshGetCreds();
-      expect(creds.botToken).toBe("mybot:TOKEN");
-      expect(creds.chatId).toBe("-100999");
-    } catch {
-      // If promisify doesn't pick up the mock (due to binding at import time),
-      // that's expected in the test environment. The unit behavior is validated
-      // by the telegram.test.ts integration tests.
-    }
-  });
-});
+// getTelegramCreds is intentionally NOT unit-tested here.
+//
+// The function uses `execAsync = promisify(exec)`. The `promisify` call
+// happens at module import time and captures the `exec` reference in a
+// closure that is NOT re-evaluated when we later call
+// `vi.mocked(exec).mockImplementationOnce(...)`. As a result, any try-catch
+// wrapper that swallowed assertion failures would be a false-green test —
+// the assertions would silently not run. Removing the try-catch surfaces
+// a test that is either genuinely broken (wrong) or genuinely passing.
+//
+// The actual parsing logic ("botToken|||chatId" split) is exercised end-to-end
+// in telegram.test.ts, which mocks `../utils.js` at the module level and
+// drives the real HTTP route. That is the correct seam for this test.
+//
+// If a future refactor decouples the `exec` call from `promisify`
+// (e.g. by accepting an injected executor), add a unit test here then.
 
 // ---------------------------------------------------------------------------
 // execAsync

--- a/apps/server/src/routes/__tests__/utils.test.ts
+++ b/apps/server/src/routes/__tests__/utils.test.ts
@@ -8,8 +8,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
  *   - sendToTmux — calls execFile with correct args, literal flag, and --
  *   - tgRaw / tgSanitize — Telegram MarkdownV2 escaping
  *   - loadOpenAIEnv / loadAnthropicEnv — secrets file loading
- *   - getTelegramCreds — parses common.sh output
  *   - Exported constants (HOME, CLAUDES_WORLD, SESSION_NAMES_FILE)
+ *
+ * NOT covered here (see rationale in the getTelegramCreds section below):
+ *   - getTelegramCreds — parsing logic not unit-tested; see section comment
  *
  * Strategy:
  *   - Mock `node:child_process` to spy on execFile without running real tmux/bash.
@@ -351,20 +353,17 @@ describe("loadAnthropicEnv", () => {
 // ---------------------------------------------------------------------------
 // getTelegramCreds is intentionally NOT unit-tested here.
 //
-// The function uses `execAsync = promisify(exec)`. The `promisify` call
-// happens at module import time and captures the `exec` reference in a
-// closure that is NOT re-evaluated when we later call
-// `vi.mocked(exec).mockImplementationOnce(...)`. As a result, any try-catch
-// wrapper that swallowed assertion failures would be a false-green test —
-// the assertions would silently not run. Removing the try-catch surfaces
-// a test that is either genuinely broken (wrong) or genuinely passing.
+// getTelegramCreds calls execAsync (the module-level `promisify(exec)` export).
+// To mock that at this level, we would need to mock `node:child_process` exec
+// AND ensure `execAsync` re-evaluates — but `execAsync` is a module-level
+// constant, not looked up fresh per-call. The correct seam is to mock
+// `../utils.js` as a whole (replacing execAsync directly), which is what
+// telegram.test.ts does. Note: telegram.test.ts stubs getTelegramCreds itself,
+// so the "botToken|||chatId" parsing logic in getTelegramCreds is not currently
+// covered by any unit test. It is exercised only through real integration runs.
 //
-// The actual parsing logic ("botToken|||chatId" split) is exercised end-to-end
-// in telegram.test.ts, which mocks `../utils.js` at the module level and
-// drives the real HTTP route. That is the correct seam for this test.
-//
-// If a future refactor decouples the `exec` call from `promisify`
-// (e.g. by accepting an injected executor), add a unit test here then.
+// If a future refactor makes execAsync injectable (e.g. a parameter or DI),
+// add a focused unit test here at that point.
 
 // ---------------------------------------------------------------------------
 // execAsync


### PR DESCRIPTION
## Summary

- Adds test coverage for 3 previously untested CPC server routes
- **prs-routes.test.ts** (9 tests): GET /, POST /refresh, GET /current-branch-scope
- **telegram.test.ts** (13 tests): POST /send-to-chat — happy path, validation, error paths, ok:false response
- **utils.test.ts** (25 tests): tgRaw escaping, tgSanitize preservation, sendToTmux, loadOpenAIEnv/loadAnthropicEnv, constants

Total: 47 new tests. All 256 tests pass across 19 test files (previously 209 across 16).

## Review notes

- 3-reviewer local swarm (Claude + Codex + Gemini) completed
- 8 findings addressed in fix round: false-positive tests, dead try-catch, env bleed, missing edge cases
- No production code changes — test-only additions

## Test plan

- [x] `pnpm --filter server test` — 256 tests, 19 files, all pass
- [x] No prod code modifications

🤖 Generated with [Claude Code](https://claude.com/claude-code)