### PR TITLE
fix(security): validate filePath + replace curl with fetch in send-to-chat (closes #226)

### DIFF
--- a/apps/server/src/routes/__tests__/telegram.test.ts
+++ b/apps/server/src/routes/__tests__/telegram.test.ts
@@ -1,0 +1,140 @@
+import { resolve } from "node:path";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+/**
+ * Tests for the /send-to-chat endpoint in telegram.ts.
+ *
+ * Covers:
+ *   1. Missing filePath returns 400
+ *   2. Disallowed filePath returns 403 (path validation)
+ *   3. Happy path: allowed path triggers fetch to Telegram API, returns messageId
+ *   4. Telegram API failure surfaces as 500
+ */
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+// Mock path-allowed: allow only paths starting with /home/claude/code
+// Uses resolve() to normalize traversals (e.g. /../..) like the real impl.
+vi.mock("../../lib/path-allowed.js", () => ({
+  ALLOWED_FILE_ROOTS: ["/home/claude/code"],
+  isPathAllowed: async (candidate: string, _roots: string[]) => {
+    const resolved = resolve(candidate);
+    return resolved.startsWith("/home/claude/code/");
+  },
+}));
+
+// Mock getTelegramCreds so we don't need real secrets
+vi.mock("../utils.js", async () => {
+  const real = await vi.importActual<typeof import("../utils.js")>("../utils.js");
+  return {
+    ...real,
+    getTelegramCreds: async () => ({
+      botToken: "test-bot-token",
+      chatId: "12345",
+    }),
+  };
+});
+
+// We need to mock global fetch
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+const { telegramRoute } = await import("../telegram.js");
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+// ---------------------------------------------------------------------------
+// POST /send-to-chat
+// ---------------------------------------------------------------------------
+describe("POST /send-to-chat", () => {
+  it("returns 400 when filePath is missing", async () => {
+    const res = await telegramRoute.request("/send-to-chat", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { ok: boolean; error: string };
+    expect(body.ok).toBe(false);
+    expect(body.error).toBe("filePath required");
+  });
+
+  it("returns 403 for a disallowed filePath", async () => {
+    const res = await telegramRoute.request("/send-to-chat", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ filePath: "/etc/passwd" }),
+    });
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { ok: boolean; error: string };
+    expect(body.ok).toBe(false);
+    expect(body.error).toBe("Access denied");
+  });
+
+  it("returns 403 for path traversal attempt", async () => {
+    const res = await telegramRoute.request("/send-to-chat", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ filePath: "/home/claude/code/../../../etc/shadow" }),
+    });
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { ok: boolean; error: string };
+    expect(body.ok).toBe(false);
+    expect(body.error).toBe("Access denied");
+  });
+
+  it("sends message via fetch and returns messageId on success", async () => {
+    mockFetch.mockResolvedValueOnce({
+      json: async () => ({ ok: true, result: { message_id: 42 } }),
+    });
+
+    const res = await telegramRoute.request("/send-to-chat", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ filePath: "/home/claude/code/test-file.ts" }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ok: boolean; messageId: number };
+    expect(body.ok).toBe(true);
+    expect(body.messageId).toBe(42);
+
+    // Verify fetch was called with the right URL and payload
+    expect(mockFetch).toHaveBeenCalledOnce();
+    const [url, opts] = mockFetch.mock.calls[0];
+    expect(url).toBe("https://api.telegram.org/bottest-bot-token/sendMessage");
+    expect(opts.method).toBe("POST");
+    expect(opts.headers["Content-Type"]).toBe("application/json");
+    const payload = JSON.parse(opts.body);
+    expect(payload.chat_id).toBe("12345");
+    expect(payload.parse_mode).toBe("MarkdownV2");
+    // The text should contain the shortened path
+    expect(payload.text).toContain("~/code/test\\-file\\.ts");
+  });
+
+  it("does not call fetch when path is disallowed", async () => {
+    await telegramRoute.request("/send-to-chat", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ filePath: "/tmp/evil" }),
+    });
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("returns 500 when fetch throws", async () => {
+    mockFetch.mockRejectedValueOnce(new Error("network failure"));
+
+    const res = await telegramRoute.request("/send-to-chat", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ filePath: "/home/claude/code/test-file.ts" }),
+    });
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as { ok: boolean; error: string };
+    expect(body.ok).toBe(false);
+    expect(body.error).toBe("network failure");
+  });
+});

--- a/apps/server/src/routes/__tests__/telegram.test.ts
+++ b/apps/server/src/routes/__tests__/telegram.test.ts
@@ -89,6 +89,7 @@ describe("POST /send-to-chat", () => {
 
   it("sends message via fetch and returns messageId on success", async () => {
     mockFetch.mockResolvedValueOnce({
+      ok: true,
       json: async () => ({ ok: true, result: { message_id: 42 } }),
     });
 
@@ -136,5 +137,22 @@ describe("POST /send-to-chat", () => {
     const body = (await res.json()) as { ok: boolean; error: string };
     expect(body.ok).toBe(false);
     expect(body.error).toBe("network failure");
+  });
+
+  it("returns 502 when Telegram returns ok:false", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ ok: false, description: "Bad Request: chat not found" }),
+    });
+
+    const res = await telegramRoute.request("/send-to-chat", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ filePath: "/home/claude/code/test-file.ts" }),
+    });
+    expect(res.status).toBe(502);
+    const body = (await res.json()) as { ok: boolean; error: string };
+    expect(body.ok).toBe(false);
+    expect(body.error).toBe("Bad Request: chat not found");
   });
 });

--- a/apps/server/src/routes/telegram.ts
+++ b/apps/server/src/routes/telegram.ts
@@ -1,3 +1,4 @@
+import { resolve as resolvePath } from "node:path";
 import { Hono } from "hono";
 import { getTelegramCreds, tgRaw, tgSanitize } from "./utils.js";
 import { isPathAllowed, ALLOWED_FILE_ROOTS } from "../lib/path-allowed.js";
@@ -14,7 +15,8 @@ app.post("/send-to-chat", async (c) => {
 
   try {
     const { botToken, chatId } = await getTelegramCreds();
-    const shortPath = filePath.replace(/^\/home\/claude\//, "~/");
+    const normalizedPath = resolvePath(filePath);
+    const shortPath = normalizedPath.replace(/^\/home\/claude\//, "~/");
     const message = [
       `📄 *Shared from Pocket Console*`,
       ``,
@@ -30,6 +32,9 @@ app.post("/send-to-chat", async (c) => {
       body: JSON.stringify({ chat_id: chatId, text: message, parse_mode: "MarkdownV2" }),
     });
     const result = await response.json();
+    if (!response.ok || !result.ok) {
+      return c.json({ ok: false, error: result.description || "Telegram API error" }, 502);
+    }
     return c.json({ ok: true, messageId: result?.result?.message_id });
   } catch (err: any) {
     return c.json({ ok: false, error: err.message }, 500);

--- a/apps/server/src/routes/telegram.ts
+++ b/apps/server/src/routes/telegram.ts
@@ -1,11 +1,16 @@
 import { Hono } from "hono";
-import { getTelegramCreds, tgRaw, tgSanitize, execAsync } from "./utils.js";
+import { getTelegramCreds, tgRaw, tgSanitize } from "./utils.js";
+import { isPathAllowed, ALLOWED_FILE_ROOTS } from "../lib/path-allowed.js";
 
 const app = new Hono();
 
 app.post("/send-to-chat", async (c) => {
   const { filePath } = await c.req.json<{ filePath: string }>();
   if (!filePath) return c.json({ ok: false, error: "filePath required" }, 400);
+
+  if (!(await isPathAllowed(filePath, ALLOWED_FILE_ROOTS))) {
+    return c.json({ ok: false, error: "Access denied" }, 403);
+  }
 
   try {
     const { botToken, chatId } = await getTelegramCreds();
@@ -18,10 +23,13 @@ app.post("/send-to-chat", async (c) => {
       tgSanitize(`_User is sharing this file with you. Read it and consider how it relates to our current work. If you can infer the intent, act on it. If you need slight clarification, offer 2-3 multiple choice options so the user can respond quickly. Only ask an open-ended question if you truly cannot guess._`),
     ].join("\n");
 
-    const payload = JSON.stringify({ chat_id: chatId, text: message, parse_mode: "MarkdownV2" });
-    const curlCmd = `curl -s -X POST "https://api.telegram.org/bot${botToken}/sendMessage" -H "Content-Type: application/json" -d '${payload.replace(/'/g, "'\\''")}'`;
-    const { stdout } = await execAsync(curlCmd, { shell: "/bin/bash" });
-    const result = JSON.parse(stdout);
+    const url = `https://api.telegram.org/bot${botToken}/sendMessage`;
+    const response = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ chat_id: chatId, text: message, parse_mode: "MarkdownV2" }),
+    });
+    const result = await response.json();
     return c.json({ ok: true, messageId: result?.result?.message_id });
   } catch (err: any) {
     return c.json({ ok: false, error: err.message }, 500);


### PR DESCRIPTION
## Summary

Security hardening for the `/api/telegram/send-to-chat` route.

### Changes
- **Path validation**: Added `isPathAllowed()` check on `filePath` — rejects paths outside allowed roots with 403
- **Shell injection eliminated**: Replaced `execAsync(curlCmd, { shell: "/bin/bash" })` with native `fetch()` to Telegram Bot API
- **Response validation**: Check `response.ok` and `result.ok` — return 502 on Telegram API failures instead of silently returning success
- **Display normalization**: `path.resolve(filePath)` before the `~/` shortening to handle dot-components

### Security review notes
- 2-reviewer local swarm (Codex + Gemini)
- Round 1: found missing response.ok check (regression from curl→fetch migration)
- Round 2: fix applied, all tests green

## Test plan

- [x] `pnpm --filter server test` — 216 tests, 17 files, all pass
- [x] Path traversal rejection tested (`/etc/passwd`, `/../../../etc/shadow`)
- [x] Telegram API failure response tested (ok:false → 502)
- [x] Fetch network error tested (throw → 500)

🤖 Generated with [Claude Code](https://claude.com/claude-code)