### PR TITLE
feat(mini-app): haptic feedback on key events (closes #224)

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -7,6 +7,7 @@ import { Links } from "./components/Links";
 import { ActionBar } from "./components/action-bar";
 import { VoiceRecorder } from "./components/VoiceRecorder";
 import { getTelegramWebApp, getAuthHeaders, hasAuth, setSessionToken } from "./lib/telegram";
+import { haptic } from "./lib/haptic";
 import { DebugOverlay } from "./debug/DebugOverlay";
 import { PrTicker } from "./components/PrTicker";
 
@@ -181,8 +182,10 @@ export function App() {
     if (isDragging.current && Math.abs(dx) > SWIPE_THRESHOLD && Math.abs(dx) > Math.abs(dy) * 1.5) {
       const currentIdx = TABS.indexOf(activeTab);
       if (dx < 0 && currentIdx < TABS.length - 1) {
+        haptic.selection();
         setActiveTab(TABS[currentIdx + 1]);
       } else if (dx > 0 && currentIdx > 0) {
+        haptic.selection();
         setActiveTab(TABS[currentIdx - 1]);
       }
     }
@@ -306,7 +309,7 @@ export function App() {
             <button
               ref={(el) => { tabRefs.current[i] = el; }}
               key={tab}
-              onClick={() => { setIsAnimating(true); setActiveTab(tab); }}
+              onClick={() => { haptic.selection(); setIsAnimating(true); setActiveTab(tab); }}
               style={{
                 padding: "8px 14px",
                 fontSize: 13,

--- a/apps/web/src/__tests__/haptic.test.ts
+++ b/apps/web/src/__tests__/haptic.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { haptic } from "../lib/haptic";
+
+// Mock getTelegramWebApp
+let mockHapticFeedback: {
+  impactOccurred: ReturnType<typeof vi.fn>;
+  notificationOccurred: ReturnType<typeof vi.fn>;
+  selectionChanged: ReturnType<typeof vi.fn>;
+} | undefined;
+
+vi.mock("../lib/telegram", () => ({
+  getTelegramWebApp: () =>
+    mockHapticFeedback
+      ? { HapticFeedback: mockHapticFeedback }
+      : { HapticFeedback: undefined },
+}));
+
+beforeEach(() => {
+  mockHapticFeedback = {
+    impactOccurred: vi.fn(),
+    notificationOccurred: vi.fn(),
+    selectionChanged: vi.fn(),
+  };
+});
+
+describe("haptic — HapticFeedback present", () => {
+  it("success() calls notificationOccurred('success')", () => {
+    haptic.success();
+    expect(mockHapticFeedback!.notificationOccurred).toHaveBeenCalledWith("success");
+  });
+
+  it("error() calls notificationOccurred('error')", () => {
+    haptic.error();
+    expect(mockHapticFeedback!.notificationOccurred).toHaveBeenCalledWith("error");
+  });
+
+  it("selection() calls selectionChanged()", () => {
+    haptic.selection();
+    expect(mockHapticFeedback!.selectionChanged).toHaveBeenCalled();
+  });
+
+  it("impact('medium') calls impactOccurred('medium')", () => {
+    haptic.impact("medium");
+    expect(mockHapticFeedback!.impactOccurred).toHaveBeenCalledWith("medium");
+  });
+
+  it("impact() defaults to 'light'", () => {
+    haptic.impact();
+    expect(mockHapticFeedback!.impactOccurred).toHaveBeenCalledWith("light");
+  });
+});
+
+describe("haptic — HapticFeedback absent (older client)", () => {
+  beforeEach(() => {
+    mockHapticFeedback = undefined;
+  });
+
+  it("success() is a no-op", () => {
+    expect(() => haptic.success()).not.toThrow();
+  });
+
+  it("error() is a no-op", () => {
+    expect(() => haptic.error()).not.toThrow();
+  });
+
+  it("selection() is a no-op", () => {
+    expect(() => haptic.selection()).not.toThrow();
+  });
+
+  it("impact() is a no-op", () => {
+    expect(() => haptic.impact("medium")).not.toThrow();
+  });
+});

--- a/apps/web/src/components/PrTicker.tsx
+++ b/apps/web/src/components/PrTicker.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import { getAuthHeaders } from "../lib/telegram";
+import { haptic } from "../lib/haptic";
 
 // --- Types matching server PrRow ---
 
@@ -515,7 +516,7 @@ function PrRowItem({
 
   return (
     <div
-      onClick={() => onTap(pr.url)}
+      onClick={() => { haptic.impact("light"); onTap(pr.url); }}
       style={{
         padding: "10px 12px 10px 36px",
         borderBottom: `1px solid ${COLORS.border}`,

--- a/apps/web/src/components/__tests__/ActionBar.test.tsx
+++ b/apps/web/src/components/__tests__/ActionBar.test.tsx
@@ -1,0 +1,533 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
+
+// --- Mocks (must be declared before importing ActionBar) ---
+
+vi.mock("../../lib/telegram", () => ({
+  getAuthHeaders: () => ({ Authorization: "tma test" }),
+}));
+
+// Stub BottomSheet to render children directly
+vi.mock("../BottomSheet", () => ({
+  BottomSheet: ({ children, title }: { children: React.ReactNode; title?: string }) => (
+    <div data-testid="bottom-sheet">
+      {title && <div data-testid="bottom-sheet-title">{title}</div>}
+      {children}
+    </div>
+  ),
+}));
+
+// Stub file-icons (used by FileSearchSheet)
+vi.mock("../file-icons", () => ({
+  getFileIcon: () => null,
+}));
+
+// Stub FileViewer's SORT_OPTIONS (used by FileOptionsSheet)
+vi.mock("../FileViewer", () => ({
+  SORT_OPTIONS: [
+    { value: "name-asc", short: "A-Z", long: "Name (A-Z)" },
+    { value: "name-desc", short: "Z-A", long: "Name (Z-A)" },
+    { value: "date-asc", short: "Old", long: "Date (oldest)" },
+    { value: "date-desc", short: "New", long: "Date (newest)" },
+  ],
+}));
+
+// Mock the entire API module so no real fetches happen
+const mockPostAction = vi.fn();
+const mockFetchGitBranch = vi.fn();
+const mockFetchGitStatus = vi.fn();
+const mockFetchTodo = vi.fn();
+const mockFetchSessionNames = vi.fn();
+const mockDeleteSessionName = vi.fn();
+const mockSendToTmux = vi.fn();
+const mockSendCompactCommand = vi.fn();
+const mockRenameSession = vi.fn();
+const mockRunGitCommand = vi.fn();
+const mockSearchFiles = vi.fn();
+const mockCheckAudio = vi.fn();
+const mockGenerateAudio = vi.fn();
+const mockSendAudioTelegram = vi.fn();
+const mockRestartSession = vi.fn();
+const mockSendFileToChat = vi.fn();
+
+vi.mock("../action-bar/api", () => ({
+  postAction: (...args: unknown[]) => mockPostAction(...args),
+  fetchGitBranch: (...args: unknown[]) => mockFetchGitBranch(...args),
+  fetchGitStatus: (...args: unknown[]) => mockFetchGitStatus(...args),
+  fetchTodo: (...args: unknown[]) => mockFetchTodo(...args),
+  fetchSessionNames: (...args: unknown[]) => mockFetchSessionNames(...args),
+  deleteSessionName: (...args: unknown[]) => mockDeleteSessionName(...args),
+  sendToTmux: (...args: unknown[]) => mockSendToTmux(...args),
+  sendCompactCommand: (...args: unknown[]) => mockSendCompactCommand(...args),
+  renameSession: (...args: unknown[]) => mockRenameSession(...args),
+  runGitCommand: (...args: unknown[]) => mockRunGitCommand(...args),
+  searchFiles: (...args: unknown[]) => mockSearchFiles(...args),
+  checkAudio: (...args: unknown[]) => mockCheckAudio(...args),
+  generateAudio: (...args: unknown[]) => mockGenerateAudio(...args),
+  sendAudioTelegram: (...args: unknown[]) => mockSendAudioTelegram(...args),
+  restartSession: (...args: unknown[]) => mockRestartSession(...args),
+  sendFileToChat: (...args: unknown[]) => mockSendFileToChat(...args),
+}));
+
+import { ActionBar } from "../action-bar";
+
+beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+  vi.clearAllMocks();
+  // Default: fetchGitBranch resolves (called on mount)
+  mockFetchGitBranch.mockResolvedValue({ branch: "main", treeType: "main-worktree" });
+  mockFetchTodo.mockResolvedValue("- [ ] Write tests");
+  mockFetchGitStatus.mockResolvedValue("On branch main\nnothing to commit");
+  mockFetchSessionNames.mockResolvedValue([]);
+  mockPostAction.mockResolvedValue({ ok: true, output: "Done" });
+  mockSendToTmux.mockResolvedValue(undefined);
+  mockSendCompactCommand.mockResolvedValue({ ok: true });
+  mockRenameSession.mockResolvedValue({ ok: true });
+  mockRunGitCommand.mockResolvedValue("branch output");
+  mockSearchFiles.mockResolvedValue([]);
+  mockCheckAudio.mockResolvedValue({ exists: false });
+  mockGenerateAudio.mockResolvedValue({ ok: true, path: "/tmp/audio.ogg" });
+  mockSendAudioTelegram.mockResolvedValue({ ok: true });
+  mockRestartSession.mockResolvedValue({ ok: true });
+  mockSendFileToChat.mockResolvedValue({ ok: true });
+  mockDeleteSessionName.mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe("ActionBar", () => {
+  // ─── Rendering basics ───────────────────────────────────────────
+
+  it("renders without crashing with no props", async () => {
+    render(<ActionBar />);
+    // The TODO button is always present
+    expect(screen.getByText("TODO")).toBeInTheDocument();
+  });
+
+  it("shows TODO button regardless of active tab", () => {
+    const { rerender } = render(<ActionBar activeTab="terminal" />);
+    expect(screen.getByText("TODO")).toBeInTheDocument();
+
+    rerender(<ActionBar activeTab="files" />);
+    expect(screen.getByText("TODO")).toBeInTheDocument();
+  });
+
+  it("shows terminal-specific buttons when activeTab is terminal", () => {
+    render(<ActionBar activeTab="terminal" onReconnect={() => {}} />);
+    expect(screen.getByText("Git")).toBeInTheDocument();
+    expect(screen.getByText("/commands")).toBeInTheDocument();
+    expect(screen.getByText("Reconnect")).toBeInTheDocument();
+  });
+
+  it("hides terminal buttons when activeTab is files", () => {
+    render(<ActionBar activeTab="files" />);
+    expect(screen.queryByText("Git")).not.toBeInTheDocument();
+    expect(screen.queryByText("/commands")).not.toBeInTheDocument();
+    expect(screen.queryByText("Reconnect")).not.toBeInTheDocument();
+  });
+
+  it("shows Search and Options buttons in files tab without viewingFile", () => {
+    render(<ActionBar activeTab="files" />);
+    expect(screen.getByText("Search")).toBeInTheDocument();
+    expect(screen.getByText("Options")).toBeInTheDocument();
+  });
+
+  it("shows Send to Chat button when viewing a file", () => {
+    render(<ActionBar activeTab="files" viewingFile={{ path: "/tmp/test.txt", name: "test.txt" }} />);
+    expect(screen.getByText("Send to Chat")).toBeInTheDocument();
+    // Search and Options should be hidden when viewing a file
+    expect(screen.queryByText("Search")).not.toBeInTheDocument();
+    expect(screen.queryByText("Options")).not.toBeInTheDocument();
+  });
+
+  it("shows TL;DR and Audio buttons for markdown files", () => {
+    render(<ActionBar activeTab="files" viewingFile={{ path: "/tmp/README.md", name: "README.md" }} />);
+    expect(screen.getByText("TL;DR")).toBeInTheDocument();
+    expect(screen.getByText("Audio")).toBeInTheDocument();
+  });
+
+  it("hides TL;DR and Audio buttons for non-markdown files", () => {
+    render(<ActionBar activeTab="files" viewingFile={{ path: "/tmp/app.ts", name: "app.ts" }} />);
+    expect(screen.queryByText("TL;DR")).not.toBeInTheDocument();
+    expect(screen.queryByText("Audio")).not.toBeInTheDocument();
+    // But Send to Chat is still present
+    expect(screen.getByText("Send to Chat")).toBeInTheDocument();
+  });
+
+  it("hides Reconnect button when onReconnect is not provided", () => {
+    render(<ActionBar activeTab="terminal" />);
+    expect(screen.queryByText("Reconnect")).not.toBeInTheDocument();
+    // Git and /commands should still appear
+    expect(screen.getByText("Git")).toBeInTheDocument();
+    expect(screen.getByText("/commands")).toBeInTheDocument();
+  });
+
+  // ─── StatusLine ─────────────────────────────────────────────────
+
+  it("shows disconnected status when connected is false", async () => {
+    render(<ActionBar connected={false} />);
+    await waitFor(() => {
+      expect(screen.getByText("[disconnected]")).toBeInTheDocument();
+    });
+  });
+
+  it("shows git branch info when connected", async () => {
+    render(<ActionBar connected={true} />);
+    await waitFor(() => {
+      expect(screen.getByText(/main.*main-worktree/)).toBeInTheDocument();
+    });
+  });
+
+  // ─── Modal: TODO ────────────────────────────────────────────────
+
+  it("opens TODO sheet when TODO button is clicked", async () => {
+    render(<ActionBar activeTab="terminal" />);
+    fireEvent.click(screen.getByText("TODO"));
+
+    await waitFor(() => {
+      expect(mockFetchTodo).toHaveBeenCalled();
+      expect(screen.getByTestId("bottom-sheet-title")).toHaveTextContent("TODO");
+    });
+  });
+
+  // ─── Modal: /commands ───────────────────────────────────────────
+
+  it("opens commands sheet and shows command buttons", async () => {
+    render(<ActionBar activeTab="terminal" />);
+    fireEvent.click(screen.getByText("/commands"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("bottom-sheet-title")).toHaveTextContent("/commands");
+    });
+    expect(screen.getByText("/new")).toBeInTheDocument();
+    expect(screen.getByText("/resume")).toBeInTheDocument();
+    expect(screen.getByText("/rename")).toBeInTheDocument();
+    expect(screen.getByText("/compact")).toBeInTheDocument();
+    expect(screen.getByText("/reload-plugins")).toBeInTheDocument();
+  });
+
+  it("navigates from /commands to rename modal", async () => {
+    render(<ActionBar activeTab="terminal" />);
+    fireEvent.click(screen.getByText("/commands"));
+
+    await waitFor(() => {
+      expect(screen.getByText("/rename")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText("/rename"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Rename Session")).toBeInTheDocument();
+      expect(screen.getByPlaceholderText("Session name...")).toBeInTheDocument();
+    });
+  });
+
+  it("navigates from /commands to new-confirm modal", async () => {
+    render(<ActionBar activeTab="terminal" />);
+    fireEvent.click(screen.getByText("/commands"));
+
+    await waitFor(() => {
+      expect(screen.getByText("/new")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText("/new"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Start new session?")).toBeInTheDocument();
+      expect(screen.getByText("Cancel")).toBeInTheDocument();
+      expect(screen.getByText("New")).toBeInTheDocument();
+    });
+  });
+
+  it("navigates from /commands to compact-confirm modal", async () => {
+    render(<ActionBar activeTab="terminal" />);
+    fireEvent.click(screen.getByText("/commands"));
+
+    await waitFor(() => {
+      expect(screen.getByText("/compact")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText("/compact"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Compact Context")).toBeInTheDocument();
+      expect(screen.getByText("Compact Now")).toBeInTheDocument();
+      expect(screen.getByText("Prompt for Continuity")).toBeInTheDocument();
+    });
+  });
+
+  // ─── Modal: Rename flow ─────────────────────────────────────────
+
+  it("submits rename and calls renameSession API", async () => {
+    render(<ActionBar activeTab="terminal" />);
+    fireEvent.click(screen.getByText("/commands"));
+    await waitFor(() => expect(screen.getByText("/rename")).toBeInTheDocument());
+    fireEvent.click(screen.getByText("/rename"));
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText("Session name...")).toBeInTheDocument();
+    });
+
+    const input = screen.getByPlaceholderText("Session name...");
+    fireEvent.change(input, { target: { value: "my-session" } });
+    fireEvent.click(screen.getByText("Rename"));
+
+    await waitFor(() => {
+      expect(mockRenameSession).toHaveBeenCalledWith("my-session");
+      expect(mockSendToTmux).toHaveBeenCalledWith("/rename my-session");
+    });
+  });
+
+  it("does not submit rename when name is empty", async () => {
+    render(<ActionBar activeTab="terminal" />);
+    fireEvent.click(screen.getByText("/commands"));
+    await waitFor(() => expect(screen.getByText("/rename")).toBeInTheDocument());
+    fireEvent.click(screen.getByText("/rename"));
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText("Session name...")).toBeInTheDocument();
+    });
+
+    // Leave input empty, click Rename
+    fireEvent.click(screen.getByText("Rename"));
+
+    expect(mockRenameSession).not.toHaveBeenCalled();
+  });
+
+  // ─── Modal: Git ─────────────────────────────────────────────────
+
+  it("opens git status sheet when Git button is clicked", async () => {
+    render(<ActionBar activeTab="terminal" />);
+    fireEvent.click(screen.getByText("Git"));
+
+    await waitFor(() => {
+      expect(mockFetchGitStatus).toHaveBeenCalled();
+      expect(screen.getByTestId("bottom-sheet-title")).toHaveTextContent("Git Status");
+    });
+  });
+
+  it("opens git menu via dropdown arrow button", async () => {
+    render(<ActionBar activeTab="terminal" />);
+    const gitMenuBtn = screen.getByLabelText("Open git menu");
+    fireEvent.click(gitMenuBtn);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("bottom-sheet-title")).toHaveTextContent("Git");
+      expect(screen.getByText("View Status")).toBeInTheDocument();
+      expect(screen.getByText("Check Branch")).toBeInTheDocument();
+      expect(screen.getByText("View Log")).toBeInTheDocument();
+      expect(screen.getByText("Pull")).toBeInTheDocument();
+    });
+  });
+
+  it("runs a git command from the git menu", async () => {
+    render(<ActionBar activeTab="terminal" />);
+    fireEvent.click(screen.getByLabelText("Open git menu"));
+    await waitFor(() => expect(screen.getByText("Pull")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByText("Pull"));
+
+    await waitFor(() => {
+      expect(mockRunGitCommand).toHaveBeenCalledWith("pull");
+    });
+  });
+
+  // ─── Modal: Reconnect menu ─────────────────────────────────────
+
+  it("opens reconnect menu and shows restart option", async () => {
+    const onReconnect = vi.fn();
+    render(<ActionBar activeTab="terminal" onReconnect={onReconnect} />);
+    fireEvent.click(screen.getByLabelText("Open reconnect menu"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("bottom-sheet-title")).toHaveTextContent("Session Controls");
+      expect(screen.getByText("Reconnect Terminal")).toBeInTheDocument();
+      expect(screen.getByText("Restart Claude Session")).toBeInTheDocument();
+    });
+  });
+
+  it("calls onReconnect when reconnect terminal is clicked in menu", async () => {
+    const onReconnect = vi.fn();
+    render(<ActionBar activeTab="terminal" onReconnect={onReconnect} />);
+    fireEvent.click(screen.getByLabelText("Open reconnect menu"));
+    await waitFor(() => expect(screen.getByText("Reconnect Terminal")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByText("Reconnect Terminal"));
+
+    expect(onReconnect).toHaveBeenCalledOnce();
+  });
+
+  it("calls restartSession when restart button is clicked", async () => {
+    const onReconnect = vi.fn();
+    render(<ActionBar activeTab="terminal" onReconnect={onReconnect} />);
+    fireEvent.click(screen.getByLabelText("Open reconnect menu"));
+    await waitFor(() => expect(screen.getByText("Restart Claude Session")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByText("Restart Claude Session"));
+
+    await waitFor(() => {
+      expect(mockRestartSession).toHaveBeenCalled();
+    });
+  });
+
+  // ─── Modal: New session confirm ────────────────────────────────
+
+  it("sends /new command when new session is confirmed", async () => {
+    render(<ActionBar activeTab="terminal" />);
+    fireEvent.click(screen.getByText("/commands"));
+    await waitFor(() => expect(screen.getByText("/new")).toBeInTheDocument());
+    fireEvent.click(screen.getByText("/new"));
+    await waitFor(() => expect(screen.getByText("New")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByText("New"));
+
+    await waitFor(() => {
+      expect(mockSendCompactCommand).toHaveBeenCalledWith("/new");
+    });
+  });
+
+  // ─── Modal: Compact flow ───────────────────────────────────────
+
+  it("opens compact focus from compact-confirm and submits", async () => {
+    render(<ActionBar activeTab="terminal" />);
+    fireEvent.click(screen.getByText("/commands"));
+    await waitFor(() => expect(screen.getByText("/compact")).toBeInTheDocument());
+    fireEvent.click(screen.getByText("/compact"));
+    await waitFor(() => expect(screen.getByText("Compact Now")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByText("Compact Now"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Compact Focus")).toBeInTheDocument();
+    });
+
+    // Submit without focus text should send plain /compact
+    fireEvent.click(screen.getByText("Compact"));
+
+    await waitFor(() => {
+      expect(mockSendCompactCommand).toHaveBeenCalledWith("/compact");
+    });
+  });
+
+  it("sends compact with focus text when provided", async () => {
+    render(<ActionBar activeTab="terminal" />);
+    fireEvent.click(screen.getByText("/commands"));
+    await waitFor(() => expect(screen.getByText("/compact")).toBeInTheDocument());
+    fireEvent.click(screen.getByText("/compact"));
+    await waitFor(() => expect(screen.getByText("Compact Now")).toBeInTheDocument());
+    fireEvent.click(screen.getByText("Compact Now"));
+    await waitFor(() => expect(screen.getByText("Compact Focus")).toBeInTheDocument());
+
+    const textarea = screen.getByPlaceholderText(/Focus on/);
+    fireEvent.change(textarea, { target: { value: "auth refactor" } });
+    fireEvent.click(screen.getByText("Compact"));
+
+    await waitFor(() => {
+      expect(mockSendCompactCommand).toHaveBeenCalledWith("/compact auth refactor");
+    });
+  });
+
+  // ─── Modal: File Search ─────────────────────────────────────────
+
+  it("opens file search sheet when Search button is clicked", async () => {
+    render(<ActionBar activeTab="files" />);
+    fireEvent.click(screen.getByText("Search"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("bottom-sheet-title")).toHaveTextContent("Search Files");
+      expect(screen.getByPlaceholderText("Search files...")).toBeInTheDocument();
+    });
+  });
+
+  // ─── Modal: File Options ────────────────────────────────────────
+
+  it("opens file options sheet when Options button is clicked", async () => {
+    render(<ActionBar activeTab="files" />);
+    fireEvent.click(screen.getByText("Options"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("bottom-sheet-title")).toHaveTextContent("File Options");
+    });
+  });
+
+  // ─── Send to Chat ──────────────────────────────────────────────
+
+  it("sends file to chat when Send to Chat is clicked", async () => {
+    render(<ActionBar activeTab="files" viewingFile={{ path: "/tmp/test.txt", name: "test.txt" }} />);
+    fireEvent.click(screen.getByText("Send to Chat"));
+
+    await waitFor(() => {
+      expect(mockSendFileToChat).toHaveBeenCalledWith("/tmp/test.txt");
+    });
+  });
+
+  // ─── Status message lifecycle ──────────────────────────────────
+
+  it("clears status message after timeout", async () => {
+    render(<ActionBar activeTab="files" viewingFile={{ path: "/tmp/test.txt", name: "test.txt" }} />);
+    fireEvent.click(screen.getByText("Send to Chat"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Sent to chat")).toBeInTheDocument();
+    });
+
+    // Advance past the 2-second clear timeout for handleSendToChat
+    act(() => { vi.advanceTimersByTime(2500); });
+
+    await waitFor(() => {
+      expect(screen.queryByText("Sent to chat")).not.toBeInTheDocument();
+    });
+  });
+
+  // ─── Error handling ─────────────────────────────────────────────
+
+  it("shows error status when rename fails", async () => {
+    mockRenameSession.mockRejectedValue(new Error("Server error"));
+
+    render(<ActionBar activeTab="terminal" />);
+    fireEvent.click(screen.getByText("/commands"));
+    await waitFor(() => expect(screen.getByText("/rename")).toBeInTheDocument());
+    fireEvent.click(screen.getByText("/rename"));
+    await waitFor(() => expect(screen.getByPlaceholderText("Session name...")).toBeInTheDocument());
+
+    const input = screen.getByPlaceholderText("Session name...");
+    fireEvent.change(input, { target: { value: "fail-name" } });
+    fireEvent.click(screen.getByText("Rename"));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Failed: Server error/)).toBeInTheDocument();
+    });
+  });
+
+  it("shows error status when restart session fails", async () => {
+    mockRestartSession.mockRejectedValue(new Error("Connection refused"));
+
+    const onReconnect = vi.fn();
+    render(<ActionBar activeTab="terminal" onReconnect={onReconnect} />);
+    fireEvent.click(screen.getByLabelText("Open reconnect menu"));
+    await waitFor(() => expect(screen.getByText("Restart Claude Session")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByText("Restart Claude Session"));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Restart failed: Connection refused/)).toBeInTheDocument();
+    });
+  });
+
+  // ─── Accessibility ─────────────────────────────────────────────
+
+  it("has aria-label on git menu dropdown button", () => {
+    render(<ActionBar activeTab="terminal" />);
+    const gitMenuBtn = screen.getByLabelText("Open git menu");
+    expect(gitMenuBtn).toBeInTheDocument();
+  });
+
+  it("has aria-label on reconnect menu dropdown button", () => {
+    render(<ActionBar activeTab="terminal" onReconnect={() => {}} />);
+    const reconnectMenuBtn = screen.getByLabelText("Open reconnect menu");
+    expect(reconnectMenuBtn).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/__tests__/ActionBar.test.tsx
+++ b/apps/web/src/components/__tests__/ActionBar.test.tsx
@@ -67,6 +67,7 @@ vi.mock("../action-bar/api", () => ({
   sendAudioTelegram: (...args: unknown[]) => mockSendAudioTelegram(...args),
   restartSession: (...args: unknown[]) => mockRestartSession(...args),
   sendFileToChat: (...args: unknown[]) => mockSendFileToChat(...args),
+  summarizeMarkdown: vi.fn().mockResolvedValue({ ok: true, summary: "Test summary", cached: false, ms: 100 }),
 }));
 
 import { ActionBar } from "../action-bar";
@@ -157,6 +158,48 @@ describe("ActionBar", () => {
     expect(screen.getByText("Send to Chat")).toBeInTheDocument();
   });
 
+  it("opens TL;DR modal when TL;DR button is clicked", async () => {
+    render(<ActionBar activeTab="files" viewingFile={{ path: "/tmp/README.md", name: "README.md" }} />);
+    fireEvent.click(screen.getByText("TL;DR"));
+
+    await waitFor(() => {
+      // TldrModal renders inside a BottomSheet stub — the sheet should be present
+      expect(screen.getByTestId("bottom-sheet")).toBeInTheDocument();
+    });
+  });
+
+  it("calls checkAudio when Audio button is clicked", async () => {
+    render(<ActionBar activeTab="files" viewingFile={{ path: "/tmp/README.md", name: "README.md" }} />);
+    fireEvent.click(screen.getByText("Audio"));
+
+    await waitFor(() => {
+      expect(mockCheckAudio).toHaveBeenCalledWith("/tmp/README.md");
+    });
+  });
+
+  it("calls generateAudio when audio does not exist and generate is triggered", async () => {
+    // checkAudio reports no cached audio → AudioGenModal shows a Generate button
+    mockCheckAudio.mockResolvedValue({ exists: false });
+
+    render(<ActionBar activeTab="files" viewingFile={{ path: "/tmp/README.md", name: "README.md" }} />);
+    fireEvent.click(screen.getByText("Audio"));
+
+    // Wait for modal to open and checkAudio to resolve
+    await waitFor(() => {
+      expect(mockCheckAudio).toHaveBeenCalledWith("/tmp/README.md");
+      expect(screen.getByTestId("bottom-sheet")).toBeInTheDocument();
+    });
+
+    // Find and click the Generate Audio button inside the AudioGenModal
+    const generateBtn = screen.queryByText("Generate Audio");
+    if (generateBtn) {
+      fireEvent.click(generateBtn);
+      await waitFor(() => {
+        expect(mockGenerateAudio).toHaveBeenCalledWith("/tmp/README.md", expect.any(AbortSignal));
+      });
+    }
+  });
+
   it("hides Reconnect button when onReconnect is not provided", () => {
     render(<ActionBar activeTab="terminal" />);
     expect(screen.queryByText("Reconnect")).not.toBeInTheDocument();
@@ -179,6 +222,20 @@ describe("ActionBar", () => {
     await waitFor(() => {
       expect(screen.getByText(/main.*main-worktree/)).toBeInTheDocument();
     });
+  });
+
+  it("shows idle state (non-breaking space) when fetchGitBranch returns null", async () => {
+    mockFetchGitBranch.mockResolvedValue(null);
+    render(<ActionBar connected={true} />);
+    await waitFor(() => {
+      expect(mockFetchGitBranch).toHaveBeenCalled();
+    });
+    // StatusLine renders \u00A0 (non-breaking space) when gitBranch is null
+    const statusLine = document.querySelector("[style*='textAlign: center']") ??
+      document.querySelector("[style*='text-align: center']");
+    // Branch info should not appear
+    expect(screen.queryByText(/main.*main-worktree/)).not.toBeInTheDocument();
+    expect(screen.queryByText("[disconnected]")).not.toBeInTheDocument();
   });
 
   // ─── Modal: TODO ────────────────────────────────────────────────
@@ -466,7 +523,7 @@ describe("ActionBar", () => {
 
   // ─── Status message lifecycle ──────────────────────────────────
 
-  it("clears status message after timeout", async () => {
+  it("clears status message after the 2-second handleSendToChat timeout", async () => {
     render(<ActionBar activeTab="files" viewingFile={{ path: "/tmp/test.txt", name: "test.txt" }} />);
     fireEvent.click(screen.getByText("Send to Chat"));
 
@@ -474,8 +531,12 @@ describe("ActionBar", () => {
       expect(screen.getByText("Sent to chat")).toBeInTheDocument();
     });
 
-    // Advance past the 2-second clear timeout for handleSendToChat
-    act(() => { vi.advanceTimersByTime(2500); });
+    // At 1900ms the 2s timeout has NOT yet fired — message must still be present
+    act(() => { vi.advanceTimersByTime(1900); });
+    expect(screen.getByText("Sent to chat")).toBeInTheDocument();
+
+    // Advance past 2000ms — the 2s timeout fires and clears the message
+    act(() => { vi.advanceTimersByTime(200); });
 
     await waitFor(() => {
       expect(screen.queryByText("Sent to chat")).not.toBeInTheDocument();

--- a/apps/web/src/components/action-bar/ActionBar.tsx
+++ b/apps/web/src/components/action-bar/ActionBar.tsx
@@ -14,7 +14,12 @@ import { TldrModal } from "./TldrModal";
 import { AudioGenModal } from "./AudioGenModal";
 import { StatusLine } from "./StatusLine";
 import { btnStyle, type ActionBarProps, type AudioStatus, type GitBranch, type Modal, type SearchResult, type SessionName } from "./types";
-import { checkAudio, deleteSessionName, fetchGitBranch, fetchGitStatus, fetchSessionNames, fetchTodo, generateAudio, postAction, renameSession, restartSession, runGitCommand, searchFiles, sendAudioTelegram, sendCompactCommand, sendFileToChat, sendToTmux } from "./api";
+import {
+  checkAudio, deleteSessionName, fetchGitBranch, fetchGitStatus,
+  fetchSessionNames, fetchTodo, generateAudio, postAction,
+  renameSession, restartSession, runGitCommand, searchFiles,
+  sendAudioTelegram, sendCompactCommand, sendFileToChat, sendToTmux,
+} from "./api";
 import { haptic } from "../../lib/haptic";
 
 const SEARCH_SCOPE_KEY = "cpc:search:currentFolderOnly";
@@ -106,15 +111,52 @@ export function ActionBar({ onReconnect, connected, activeTab, fileShowHidden, s
     setStatus(`Running ${label}...`);
     try {
       const data = await postAction(endpoint);
-      if (!data.ok) { haptic.error(); setStatus(`Failed: ${data.error || "unknown error"}`); }
-      else { haptic.success(); setStatus(data.output || `${label}: OK`); }
-    } catch (err) { haptic.error(); setStatus(`Error: ${err instanceof Error ? err.message : String(err)}`); }
+      if (!data.ok) {
+        haptic.error();
+        setStatus(`Failed: ${data.error || "unknown error"}`);
+      } else {
+        haptic.success();
+        setStatus(data.output || `${label}: OK`);
+      }
+    } catch (err) {
+      haptic.error();
+      setStatus(`Error: ${err instanceof Error ? err.message : String(err)}`);
+    }
   };
-  const loadGitStatus = async () => { try { setGitOutput(await fetchGitStatus()); } catch { setGitOutput("Failed to fetch"); } };
-  const loadTodo = async () => { try { setTodoContent(await fetchTodo()); } catch { setTodoContent("Failed to fetch"); } };
-  const loadSessionNames = async () => { try { setSessionNames(await fetchSessionNames()); } catch { setSessionNames([]); } };
-  const removeSessionName = async (ts: number) => { try { await deleteSessionName(ts); setSessionNames((prev) => prev.filter((s) => s.ts !== ts)); } catch {} setDeleteTarget(null); setModal("resume"); };
-  const handleCompact = async (message: string, label = "Compact") => { setModal(null); setStatus(`${label}...`); try { const data = await sendCompactCommand(message); if (data.ok) { haptic.success(); setStatus(`${label} sent`); } else { haptic.error(); setStatus(`Failed: ${data.error}`); } } catch (err) { haptic.error(); setStatus(`Error: ${err instanceof Error ? err.message : String(err)}`); } };
+  const loadGitStatus = async () => {
+    try { setGitOutput(await fetchGitStatus()); } catch { setGitOutput("Failed to fetch"); }
+  };
+  const loadTodo = async () => {
+    try { setTodoContent(await fetchTodo()); } catch { setTodoContent("Failed to fetch"); }
+  };
+  const loadSessionNames = async () => {
+    try { setSessionNames(await fetchSessionNames()); } catch { setSessionNames([]); }
+  };
+  const removeSessionName = async (ts: number) => {
+    try {
+      await deleteSessionName(ts);
+      setSessionNames((prev) => prev.filter((s) => s.ts !== ts));
+    } catch {}
+    setDeleteTarget(null);
+    setModal("resume");
+  };
+  const handleCompact = async (message: string, label = "Compact") => {
+    setModal(null);
+    setStatus(`${label}...`);
+    try {
+      const data = await sendCompactCommand(message);
+      if (data.ok) {
+        haptic.success();
+        setStatus(`${label} sent`);
+      } else {
+        haptic.error();
+        setStatus(`Failed: ${data.error}`);
+      }
+    } catch (err) {
+      haptic.error();
+      setStatus(`Error: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  };
   const handleRename = async () => {
     if (!renameName.trim()) return;
     setModal(null);
@@ -122,7 +164,13 @@ export function ActionBar({ onReconnect, connected, activeTab, fileShowHidden, s
     void sendToTmux(`/rename ${renameName.trim()}`);
     try {
       const data = await renameSession(renameName.trim());
-      if (data.ok) { haptic.success(); setStatus(`Renamed to "${renameName.trim()}"`); } else { haptic.error(); setStatus(`Failed: ${data.error}`); }
+      if (data.ok) {
+        haptic.success();
+        setStatus(`Renamed to "${renameName.trim()}"`);
+      } else {
+        haptic.error();
+        setStatus(`Failed: ${data.error}`);
+      }
     } catch (err) {
       // Previously this catch swallowed the error and optimistically reported
       // success because the in-tmux /rename side-effect had already happened.
@@ -130,12 +178,23 @@ export function ActionBar({ onReconnect, connected, activeTab, fileShowHidden, s
       // server-side rejections (400/409) land here too, and a false success
       // would hide real failures. Report the error instead. (Codex round-4
       // review re-pass.)
-      haptic.error(); setStatus(`Failed: ${err instanceof Error ? err.message : String(err)}`);
+      haptic.error();
+      setStatus(`Failed: ${err instanceof Error ? err.message : String(err)}`);
     }
     setTimeout(() => setStatus(null), 2000);
   };
-  const handleFork = () => { const name = forkName.trim(); setModal(null); void sendToTmux(name ? `/fork\n/rename ${name}` : "/fork"); setStatus(name ? `Forked as "${name}"` : "Forked"); setTimeout(() => setStatus(null), 2000); };
-  const handleGitAction = async (action: { label: string; command: string }) => { setGitOutput(`Running ${action.label}...`); setModal("git-status"); try { setGitOutput(await runGitCommand(action.command)); } catch { setGitOutput("Failed to run command"); } };
+  const handleFork = () => {
+    const name = forkName.trim();
+    setModal(null);
+    void sendToTmux(name ? `/fork\n/rename ${name}` : "/fork");
+    setStatus(name ? `Forked as "${name}"` : "Forked");
+    setTimeout(() => setStatus(null), 2000);
+  };
+  const handleGitAction = async (action: { label: string; command: string }) => {
+    setGitOutput(`Running ${action.label}...`);
+    setModal("git-status");
+    try { setGitOutput(await runGitCommand(action.command)); } catch { setGitOutput("Failed to run command"); }
+  };
   const resetFileSearch = useCallback(() => {
     // Cancel any pending debounce and abort any in-flight request, then
     // clear query+results. Needed when re-opening the search sheet so a
@@ -235,15 +294,26 @@ export function ActionBar({ onReconnect, connected, activeTab, fileShowHidden, s
       const timeout = setTimeout(() => controller.abort(), 60000);
       try {
         const data = await generateAudio(filePath, controller.signal);
-        if (data.ok) { haptic.success(); setAudioStatus({ exists: true, path: data.path }); setStatus("Audio generated"); }
-        else { haptic.error(); setStatus(`Failed: ${data.error}`); }
+        if (data.ok) {
+          haptic.success();
+          setAudioStatus({ exists: true, path: data.path });
+          setStatus("Audio generated");
+        } else {
+          haptic.error();
+          setStatus(`Failed: ${data.error}`);
+        }
       } finally {
         // clearTimeout in finally so a thrown fetch doesn't leave the
         // 60s timeout dangling and accumulating. (Copilot round-3 review.)
         clearTimeout(timeout);
       }
     } catch (err) {
-      haptic.error(); setStatus(err instanceof DOMException && err.name === "AbortError" ? "Timed out" : `Error: ${err instanceof Error ? err.message : String(err)}`);
+      haptic.error();
+      setStatus(
+        err instanceof DOMException && err.name === "AbortError"
+          ? "Timed out"
+          : `Error: ${err instanceof Error ? err.message : String(err)}`
+      );
     } finally {
       audioInFlightRef.current = false;
       setAudioOp("idle");
@@ -261,14 +331,25 @@ export function ActionBar({ onReconnect, connected, activeTab, fileShowHidden, s
       const timeout = setTimeout(() => controller.abort(), 30000);
       try {
         const data = await sendAudioTelegram(audioPath, controller.signal);
-        if (data.ok) { haptic.success(); setStatus("Sent to Telegram"); } else { haptic.error(); setStatus(`Failed: ${data.error}`); }
+        if (data.ok) {
+          haptic.success();
+          setStatus("Sent to Telegram");
+        } else {
+          haptic.error();
+          setStatus(`Failed: ${data.error}`);
+        }
       } finally {
         // clearTimeout in finally so a thrown fetch doesn't leave the
         // 30s timeout dangling and accumulating. (Copilot round-3 review.)
         clearTimeout(timeout);
       }
     } catch (err) {
-      haptic.error(); setStatus(err instanceof DOMException && err.name === "AbortError" ? "Timed out" : `Error: ${err instanceof Error ? err.message : String(err)}`);
+      haptic.error();
+      setStatus(
+        err instanceof DOMException && err.name === "AbortError"
+          ? "Timed out"
+          : `Error: ${err instanceof Error ? err.message : String(err)}`
+      );
     } finally {
       audioInFlightRef.current = false;
       setAudioOp("idle");
@@ -280,53 +361,295 @@ export function ActionBar({ onReconnect, connected, activeTab, fileShowHidden, s
     setStatus("Restarting session...");
     try {
       const data = await restartSession();
-      if (data.ok) { haptic.success(); setStatus("Session restarted"); } else { haptic.error(); setStatus(`Failed: ${data.error}`); }
+      if (data.ok) {
+        haptic.success();
+        setStatus("Session restarted");
+      } else {
+        haptic.error();
+        setStatus(`Failed: ${data.error}`);
+      }
     } catch (err) {
       // Surface the server error text (now extracted by jsonFetch from a
       // { error } body on non-2xx responses) instead of a generic message.
       // (Codex round-4 review re-pass.)
-      haptic.error(); setStatus(`Restart failed: ${err instanceof Error ? err.message : String(err)}`);
+      haptic.error();
+      setStatus(`Restart failed: ${err instanceof Error ? err.message : String(err)}`);
     }
     setTimeout(() => setStatus(null), 3000);
   };
-  const handleSendToChat = async () => { if (!viewingFile) return; setStatus("Sharing..."); try { const data = await sendFileToChat(viewingFile.path); if (data.ok) { haptic.success(); setStatus("Sent to chat"); } else { haptic.error(); setStatus("Failed"); } } catch { haptic.error(); setStatus("Failed"); } setTimeout(() => setStatus(null), 2000); };
+  const handleSendToChat = async () => {
+    if (!viewingFile) return;
+    setStatus("Sharing...");
+    try {
+      const data = await sendFileToChat(viewingFile.path);
+      if (data.ok) {
+        haptic.success();
+        setStatus("Sent to chat");
+      } else {
+        haptic.error();
+        setStatus("Failed");
+      }
+    } catch {
+      haptic.error();
+      setStatus("Failed");
+    }
+    setTimeout(() => setStatus(null), 2000);
+  };
 
   let modalNode: ReactNode = null;
   switch (modal) {
-    case "commands": modalNode = <CommandsSheet onClose={() => setModal(null)} onEsc={() => { void sendToTmux("Escape", true); setModal(null); setStatus("Sent: Esc"); setTimeout(() => setStatus(null), 1500); }} onDigit={(digit) => { void sendToTmux(String(digit)); setModal(null); setStatus(`Sent: ${digit}`); setTimeout(() => setStatus(null), 1500); }} onShiftTab={() => { void sendToTmux("BTab", true); setModal(null); setStatus("Sent: \u21e7Tab"); setTimeout(() => setStatus(null), 1500); }} onControlB={() => { void sendToTmux("C-b", true); setModal(null); setStatus("Sent: ^B"); setTimeout(() => setStatus(null), 1500); }} onNew={() => setModal("new-confirm")} onResume={() => { void loadSessionNames(); setModal("resume"); }} onFork={() => { setForkName(""); setModal("fork-name"); }} onRename={() => { setRenameName(""); setModal("rename"); }} onCompact={() => setModal("compact-confirm")} onReloadPlugins={() => { setModal(null); void handleAction("/api/terminal/reload-plugins", "Reload plugins"); }} />; break;
-    case "rename": modalNode = <RenameModal value={renameName} onChange={setRenameName} onBack={() => setModal("commands")} onSubmit={() => void handleRename()} />; break;
-    case "fork-name": modalNode = <ForkNameModal value={forkName} onChange={setForkName} onBack={() => setModal("commands")} onSubmit={handleFork} />; break;
-    case "resume": modalNode = <ResumeSheet sessionNames={sessionNames} onClose={() => setModal("commands")} onResume={(session) => { setModal(null); void handleCompact(`/resume ${session.name}`, "Resume"); }} onDelete={(session) => { setDeleteTarget(session); setModal("confirm-delete"); }} />; break;
-    case "confirm-delete": modalNode = deleteTarget ? <ConfirmDeleteSheet deleteTarget={deleteTarget} onCancel={() => { setDeleteTarget(null); setModal("resume"); }} onConfirm={() => void removeSessionName(deleteTarget.ts)} /> : null; break;
-    case "reconnect-menu": modalNode = onReconnect ? <ReconnectMenu onClose={() => setModal(null)} onReconnect={() => { onReconnect(); setModal(null); }} onRestart={() => void handleRestartSession()} /> : null; break;
-    case "new-confirm": modalNode = <NewConfirmModal onCancel={() => setModal("commands")} onConfirm={() => void handleCompact("/new", "New session")} />; break;
-    case "git-status": modalNode = <GitStatusSheet gitOutput={gitOutput} onClose={() => setModal(null)} />; break;
-    case "git-menu": modalNode = <GitMenuSheet onClose={() => setModal(null)} onViewStatus={() => { void loadGitStatus(); setModal("git-status"); }} onAction={(action) => void handleGitAction(action)} />; break;
-    case "todo": modalNode = <TodoSheet todoContent={todoContent} onClose={() => setModal(null)} />; break;
-    case "compact-confirm": modalNode = <CompactConfirmModal onCompactNow={() => { setCompactFocus(""); setModal("compact-focus"); }} onContinuity={() => { setContinuityNotes(""); setModal("continuity-notes"); }} onCancel={() => setModal(null)} />; break;
-    case "compact-focus": modalNode = <CompactFocusModal value={compactFocus} onChange={setCompactFocus} onBack={() => setModal("compact-confirm")} onSubmit={() => void handleCompact(compactFocus.trim() ? `/compact ${compactFocus.trim()}` : "/compact")} />; break;
-    case "continuity-notes": modalNode = <ContinuityNotesModal value={continuityNotes} onChange={setContinuityNotes} onBack={() => setModal("compact-confirm")} onSubmit={() => void handleCompact(`Before compacting, please ensure: 1) README.md is up to date with recent changes. 2) Anything important from this session is saved to the knowledge base or memory. 3) Open work and next steps are captured in NEXT-SESSION.md and TODO.md.${continuityNotes.trim() ? ` Additional context from user: "${continuityNotes.trim()}".` : ""}`)} />; break;
-    case "file-options": modalNode = <FileOptionsSheet fileShowHidden={fileShowHidden} fileSortMode={fileSortMode} setFileShowHidden={setFileShowHidden} setFileSortMode={setFileSortMode} onClose={() => setModal(null)} />; break;
-    case "file-search": modalNode = <FileSearchSheet searchQuery={searchQuery} searchResults={searchResults} currentFolder={currentFolder ?? null} currentFolderOnly={searchCurrentFolderOnly} onToggleCurrentFolderOnly={setSearchCurrentFolderOnly} onClose={() => setModal(null)} onChange={handleSearchInput} onSelect={(result) => { setModal(null); window.location.hash = `files&file=${encodeURIComponent(result.path)}`; window.location.reload(); }} />; break;
-    case "tldr": modalNode = viewingFile ? <TldrModal viewingFile={viewingFile} onClose={() => setModal(null)} /> : null; break;
-    case "audio-gen": modalNode = viewingFile ? <AudioGenModal viewingFile={viewingFile} audioLoading={audioLoading} audioOp={audioOp} audioStatus={audioStatus} onClose={() => setModal(null)} onGenerate={() => void handleGenerateAudio(viewingFile.path)} onSend={() => { if (audioStatus?.path) void handleSendAudio(audioStatus.path); }} /> : null; break;
+    case "commands":
+      modalNode = (
+        <CommandsSheet
+          onClose={() => setModal(null)}
+          onEsc={() => { void sendToTmux("Escape", true); setModal(null); setStatus("Sent: Esc"); setTimeout(() => setStatus(null), 1500); }}
+          onDigit={(digit) => { void sendToTmux(String(digit)); setModal(null); setStatus(`Sent: ${digit}`); setTimeout(() => setStatus(null), 1500); }}
+          onShiftTab={() => { void sendToTmux("BTab", true); setModal(null); setStatus("Sent: \u21e7Tab"); setTimeout(() => setStatus(null), 1500); }}
+          onControlB={() => { void sendToTmux("C-b", true); setModal(null); setStatus("Sent: ^B"); setTimeout(() => setStatus(null), 1500); }}
+          onNew={() => setModal("new-confirm")}
+          onResume={() => { void loadSessionNames(); setModal("resume"); }}
+          onFork={() => { setForkName(""); setModal("fork-name"); }}
+          onRename={() => { setRenameName(""); setModal("rename"); }}
+          onCompact={() => setModal("compact-confirm")}
+          onReloadPlugins={() => { setModal(null); void handleAction("/api/terminal/reload-plugins", "Reload plugins"); }}
+        />
+      );
+      break;
+    case "rename":
+      modalNode = (
+        <RenameModal value={renameName} onChange={setRenameName} onBack={() => setModal("commands")} onSubmit={() => void handleRename()} />
+      );
+      break;
+    case "fork-name":
+      modalNode = (
+        <ForkNameModal value={forkName} onChange={setForkName} onBack={() => setModal("commands")} onSubmit={handleFork} />
+      );
+      break;
+    case "resume":
+      modalNode = (
+        <ResumeSheet
+          sessionNames={sessionNames}
+          onClose={() => setModal("commands")}
+          onResume={(session) => { setModal(null); void handleCompact(`/resume ${session.name}`, "Resume"); }}
+          onDelete={(session) => { setDeleteTarget(session); setModal("confirm-delete"); }}
+        />
+      );
+      break;
+    case "confirm-delete":
+      modalNode = deleteTarget ? (
+        <ConfirmDeleteSheet
+          deleteTarget={deleteTarget}
+          onCancel={() => { setDeleteTarget(null); setModal("resume"); }}
+          onConfirm={() => void removeSessionName(deleteTarget.ts)}
+        />
+      ) : null;
+      break;
+    case "reconnect-menu":
+      modalNode = onReconnect ? (
+        <ReconnectMenu
+          onClose={() => setModal(null)}
+          onReconnect={() => { onReconnect(); setModal(null); }}
+          onRestart={() => void handleRestartSession()}
+        />
+      ) : null;
+      break;
+    case "new-confirm":
+      modalNode = (
+        <NewConfirmModal onCancel={() => setModal("commands")} onConfirm={() => void handleCompact("/new", "New session")} />
+      );
+      break;
+    case "git-status":
+      modalNode = <GitStatusSheet gitOutput={gitOutput} onClose={() => setModal(null)} />;
+      break;
+    case "git-menu":
+      modalNode = (
+        <GitMenuSheet
+          onClose={() => setModal(null)}
+          onViewStatus={() => { void loadGitStatus(); setModal("git-status"); }}
+          onAction={(action) => void handleGitAction(action)}
+        />
+      );
+      break;
+    case "todo":
+      modalNode = <TodoSheet todoContent={todoContent} onClose={() => setModal(null)} />;
+      break;
+    case "compact-confirm":
+      modalNode = (
+        <CompactConfirmModal
+          onCompactNow={() => { setCompactFocus(""); setModal("compact-focus"); }}
+          onContinuity={() => { setContinuityNotes(""); setModal("continuity-notes"); }}
+          onCancel={() => setModal(null)}
+        />
+      );
+      break;
+    case "compact-focus":
+      modalNode = (
+        <CompactFocusModal
+          value={compactFocus}
+          onChange={setCompactFocus}
+          onBack={() => setModal("compact-confirm")}
+          onSubmit={() => void handleCompact(compactFocus.trim() ? `/compact ${compactFocus.trim()}` : "/compact")}
+        />
+      );
+      break;
+    case "continuity-notes": {
+      const continuityMsg = [
+        "Before compacting, please ensure:",
+        "1) README.md is up to date with recent changes.",
+        "2) Anything important from this session is saved to the knowledge base or memory.",
+        "3) Open work and next steps are captured in NEXT-SESSION.md and TODO.md.",
+        continuityNotes.trim() ? `Additional context from user: "${continuityNotes.trim()}".` : "",
+      ].filter(Boolean).join(" ");
+      modalNode = (
+        <ContinuityNotesModal
+          value={continuityNotes}
+          onChange={setContinuityNotes}
+          onBack={() => setModal("compact-confirm")}
+          onSubmit={() => void handleCompact(continuityMsg)}
+        />
+      );
+      break;
+    }
+    case "file-options":
+      modalNode = (
+        <FileOptionsSheet
+          fileShowHidden={fileShowHidden}
+          fileSortMode={fileSortMode}
+          setFileShowHidden={setFileShowHidden}
+          setFileSortMode={setFileSortMode}
+          onClose={() => setModal(null)}
+        />
+      );
+      break;
+    case "file-search":
+      modalNode = (
+        <FileSearchSheet
+          searchQuery={searchQuery}
+          searchResults={searchResults}
+          currentFolder={currentFolder ?? null}
+          currentFolderOnly={searchCurrentFolderOnly}
+          onToggleCurrentFolderOnly={setSearchCurrentFolderOnly}
+          onClose={() => setModal(null)}
+          onChange={handleSearchInput}
+          onSelect={(result) => {
+            setModal(null);
+            window.location.hash = `files&file=${encodeURIComponent(result.path)}`;
+            window.location.reload();
+          }}
+        />
+      );
+      break;
+    case "tldr":
+      modalNode = viewingFile ? <TldrModal viewingFile={viewingFile} onClose={() => setModal(null)} /> : null;
+      break;
+    case "audio-gen":
+      modalNode = viewingFile ? (
+        <AudioGenModal
+          viewingFile={viewingFile}
+          audioLoading={audioLoading}
+          audioOp={audioOp}
+          audioStatus={audioStatus}
+          onClose={() => setModal(null)}
+          onGenerate={() => void handleGenerateAudio(viewingFile.path)}
+          onSend={() => { if (audioStatus?.path) void handleSendAudio(audioStatus.path); }}
+        />
+      ) : null;
+      break;
   }
+
+  const isViewingMd = viewingFile?.name.toLowerCase().endsWith(".md");
 
   return (
     <>
       {modalNode}
       <div style={{ padding: "10px 12px 8px", borderTop: "1px solid var(--color-border)", flexShrink: 0 }}>
         <div style={{ display: "flex", gap: "8px", overflowX: "auto" }}>
-          <button onClick={() => { haptic.impact("light"); setModal("todo"); void loadTodo(); }} style={{ ...btnStyle, background: "#3a3520", color: "var(--color-accent-yellow)", border: "1px solid #5a4a30" }}>TODO</button>
+          <button
+            onClick={() => { haptic.impact("light"); setModal("todo"); void loadTodo(); }}
+            style={{ ...btnStyle, background: "#3a3520", color: "var(--color-accent-yellow)", border: "1px solid #5a4a30" }}
+          >
+            TODO
+          </button>
+
           {activeTab === "terminal" && <>
-            {onReconnect && <div style={{ display: "flex", flexShrink: 0 }}><button onClick={() => { haptic.impact("light"); onReconnect(); }} style={{ ...btnStyle, background: "#1a3a2a", color: "var(--color-accent-green)", border: "1px solid #2d5a3d", borderRadius: "6px 0 0 6px", borderRight: "none" }}>Reconnect</button><button onClick={() => setModal("reconnect-menu")} aria-label="Open reconnect menu" title="Open reconnect menu" style={{ ...btnStyle, background: "#1a3a2a", color: "var(--color-accent-green)", border: "1px solid #2d5a3d", borderRadius: "0 6px 6px 0", padding: "6px 8px", fontSize: 14 }}>&#9652;</button></div>}
-            <div style={{ display: "flex", flexShrink: 0 }}><button onClick={() => { haptic.impact("light"); setModal("git-status"); void loadGitStatus(); }} style={{ ...btnStyle, borderRadius: "6px 0 0 6px", borderRight: "none" }}>Git</button><button onClick={() => setModal("git-menu")} aria-label="Open git menu" title="Open git menu" style={{ ...btnStyle, borderRadius: "0 6px 6px 0", padding: "6px 8px", fontSize: 14 }}>&#9652;</button></div>
-            <button onClick={() => { haptic.impact("light"); setModal("commands"); }} style={{ ...btnStyle, background: "#2d2a3a", color: "var(--color-accent-purple)", border: "1px solid #4a3d6a" }}>/commands</button>
+            {onReconnect && (
+              <div style={{ display: "flex", flexShrink: 0 }}>
+                <button
+                  onClick={() => { haptic.impact("light"); onReconnect(); }}
+                  style={{ ...btnStyle, background: "#1a3a2a", color: "var(--color-accent-green)", border: "1px solid #2d5a3d", borderRadius: "6px 0 0 6px", borderRight: "none" }}
+                >
+                  Reconnect
+                </button>
+                <button
+                  onClick={() => { haptic.impact("light"); setModal("reconnect-menu"); }}
+                  aria-label="Open reconnect menu"
+                  title="Open reconnect menu"
+                  style={{ ...btnStyle, background: "#1a3a2a", color: "var(--color-accent-green)", border: "1px solid #2d5a3d", borderRadius: "0 6px 6px 0", padding: "6px 8px", fontSize: 14 }}
+                >
+                  &#9652;
+                </button>
+              </div>
+            )}
+            <div style={{ display: "flex", flexShrink: 0 }}>
+              <button
+                onClick={() => { haptic.impact("light"); setModal("git-status"); void loadGitStatus(); }}
+                style={{ ...btnStyle, borderRadius: "6px 0 0 6px", borderRight: "none" }}
+              >
+                Git
+              </button>
+              <button
+                onClick={() => { haptic.impact("light"); setModal("git-menu"); }}
+                aria-label="Open git menu"
+                title="Open git menu"
+                style={{ ...btnStyle, borderRadius: "0 6px 6px 0", padding: "6px 8px", fontSize: 14 }}
+              >
+                &#9652;
+              </button>
+            </div>
+            <button
+              onClick={() => { haptic.impact("light"); setModal("commands"); }}
+              style={{ ...btnStyle, background: "#2d2a3a", color: "var(--color-accent-purple)", border: "1px solid #4a3d6a" }}
+            >
+              /commands
+            </button>
           </>}
-          {activeTab === "files" && !viewingFile && <><button onClick={() => { resetFileSearch(); setModal("file-search"); }} style={{ ...btnStyle, background: "#2d3a5a", color: "var(--color-accent-blue)", border: "1px solid #3d4a6a" }}>Search</button><button onClick={() => setModal("file-options")} style={btnStyle}>Options</button></>}
-          {activeTab === "files" && viewingFile && <button onClick={() => { haptic.impact("light"); void handleSendToChat(); }} style={{ ...btnStyle, background: "#1a2a3a", color: "var(--color-accent-cyan)", border: "1px solid #2d4a5a" }}>Send to Chat</button>}
-          {activeTab === "files" && viewingFile?.name.toLowerCase().endsWith(".md") && <button onClick={() => setModal("tldr")} style={{ ...btnStyle, background: "#1a3a3a", color: "var(--color-accent-cyan)", border: "1px solid #2d5a5a" }}>TL;DR</button>}
-          {activeTab === "files" && viewingFile?.name.toLowerCase().endsWith(".md") && <button onClick={() => { void handleCheckAudio(viewingFile.path); setModal("audio-gen"); }} style={{ ...btnStyle, background: "#2d2a3a", color: "var(--color-accent-purple)", border: "1px solid #4a3d6a" }}>Audio</button>}
+
+          {activeTab === "files" && !viewingFile && <>
+            <button
+              onClick={() => { resetFileSearch(); setModal("file-search"); }}
+              style={{ ...btnStyle, background: "#2d3a5a", color: "var(--color-accent-blue)", border: "1px solid #3d4a6a" }}
+            >
+              Search
+            </button>
+            <button onClick={() => setModal("file-options")} style={btnStyle}>Options</button>
+          </>}
+
+          {activeTab === "files" && viewingFile && (
+            <button
+              onClick={() => { haptic.impact("light"); void handleSendToChat(); }}
+              style={{ ...btnStyle, background: "#1a2a3a", color: "var(--color-accent-cyan)", border: "1px solid #2d4a5a" }}
+            >
+              Send to Chat
+            </button>
+          )}
+
+          {activeTab === "files" && isViewingMd && (
+            <button
+              onClick={() => setModal("tldr")}
+              style={{ ...btnStyle, background: "#1a3a3a", color: "var(--color-accent-cyan)", border: "1px solid #2d5a5a" }}
+            >
+              TL;DR
+            </button>
+          )}
+
+          {activeTab === "files" && isViewingMd && viewingFile && (
+            <button
+              onClick={() => { void handleCheckAudio(viewingFile.path); setModal("audio-gen"); }}
+              style={{ ...btnStyle, background: "#2d2a3a", color: "var(--color-accent-purple)", border: "1px solid #4a3d6a" }}
+            >
+              Audio
+            </button>
+          )}
         </div>
         <StatusLine connected={connected} status={status} gitBranch={gitBranch} />
       </div>

--- a/apps/web/src/components/action-bar/ActionBar.tsx
+++ b/apps/web/src/components/action-bar/ActionBar.tsx
@@ -15,6 +15,7 @@ import { AudioGenModal } from "./AudioGenModal";
 import { StatusLine } from "./StatusLine";
 import { btnStyle, type ActionBarProps, type AudioStatus, type GitBranch, type Modal, type SearchResult, type SessionName } from "./types";
 import { checkAudio, deleteSessionName, fetchGitBranch, fetchGitStatus, fetchSessionNames, fetchTodo, generateAudio, postAction, renameSession, restartSession, runGitCommand, searchFiles, sendAudioTelegram, sendCompactCommand, sendFileToChat, sendToTmux } from "./api";
+import { haptic } from "../../lib/haptic";
 
 const SEARCH_SCOPE_KEY = "cpc:search:currentFolderOnly";
 
@@ -105,14 +106,15 @@ export function ActionBar({ onReconnect, connected, activeTab, fileShowHidden, s
     setStatus(`Running ${label}...`);
     try {
       const data = await postAction(endpoint);
-      setStatus(!data.ok ? `Failed: ${data.error || "unknown error"}` : data.output || `${label}: OK`);
-    } catch (err) { setStatus(`Error: ${err instanceof Error ? err.message : String(err)}`); }
+      if (!data.ok) { haptic.error(); setStatus(`Failed: ${data.error || "unknown error"}`); }
+      else { haptic.success(); setStatus(data.output || `${label}: OK`); }
+    } catch (err) { haptic.error(); setStatus(`Error: ${err instanceof Error ? err.message : String(err)}`); }
   };
   const loadGitStatus = async () => { try { setGitOutput(await fetchGitStatus()); } catch { setGitOutput("Failed to fetch"); } };
   const loadTodo = async () => { try { setTodoContent(await fetchTodo()); } catch { setTodoContent("Failed to fetch"); } };
   const loadSessionNames = async () => { try { setSessionNames(await fetchSessionNames()); } catch { setSessionNames([]); } };
   const removeSessionName = async (ts: number) => { try { await deleteSessionName(ts); setSessionNames((prev) => prev.filter((s) => s.ts !== ts)); } catch {} setDeleteTarget(null); setModal("resume"); };
-  const handleCompact = async (message: string, label = "Compact") => { setModal(null); setStatus(`${label}...`); try { const data = await sendCompactCommand(message); setStatus(data.ok ? `${label} sent` : `Failed: ${data.error}`); } catch (err) { setStatus(`Error: ${err instanceof Error ? err.message : String(err)}`); } };
+  const handleCompact = async (message: string, label = "Compact") => { setModal(null); setStatus(`${label}...`); try { const data = await sendCompactCommand(message); if (data.ok) { haptic.success(); setStatus(`${label} sent`); } else { haptic.error(); setStatus(`Failed: ${data.error}`); } } catch (err) { haptic.error(); setStatus(`Error: ${err instanceof Error ? err.message : String(err)}`); } };
   const handleRename = async () => {
     if (!renameName.trim()) return;
     setModal(null);
@@ -120,7 +122,7 @@ export function ActionBar({ onReconnect, connected, activeTab, fileShowHidden, s
     void sendToTmux(`/rename ${renameName.trim()}`);
     try {
       const data = await renameSession(renameName.trim());
-      setStatus(data.ok ? `Renamed to "${renameName.trim()}"` : `Failed: ${data.error}`);
+      if (data.ok) { haptic.success(); setStatus(`Renamed to "${renameName.trim()}"`); } else { haptic.error(); setStatus(`Failed: ${data.error}`); }
     } catch (err) {
       // Previously this catch swallowed the error and optimistically reported
       // success because the in-tmux /rename side-effect had already happened.
@@ -128,7 +130,7 @@ export function ActionBar({ onReconnect, connected, activeTab, fileShowHidden, s
       // server-side rejections (400/409) land here too, and a false success
       // would hide real failures. Report the error instead. (Codex round-4
       // review re-pass.)
-      setStatus(`Failed: ${err instanceof Error ? err.message : String(err)}`);
+      haptic.error(); setStatus(`Failed: ${err instanceof Error ? err.message : String(err)}`);
     }
     setTimeout(() => setStatus(null), 2000);
   };
@@ -233,15 +235,15 @@ export function ActionBar({ onReconnect, connected, activeTab, fileShowHidden, s
       const timeout = setTimeout(() => controller.abort(), 60000);
       try {
         const data = await generateAudio(filePath, controller.signal);
-        if (data.ok) { setAudioStatus({ exists: true, path: data.path }); setStatus("Audio generated"); }
-        else setStatus(`Failed: ${data.error}`);
+        if (data.ok) { haptic.success(); setAudioStatus({ exists: true, path: data.path }); setStatus("Audio generated"); }
+        else { haptic.error(); setStatus(`Failed: ${data.error}`); }
       } finally {
         // clearTimeout in finally so a thrown fetch doesn't leave the
         // 60s timeout dangling and accumulating. (Copilot round-3 review.)
         clearTimeout(timeout);
       }
     } catch (err) {
-      setStatus(err instanceof DOMException && err.name === "AbortError" ? "Timed out" : `Error: ${err instanceof Error ? err.message : String(err)}`);
+      haptic.error(); setStatus(err instanceof DOMException && err.name === "AbortError" ? "Timed out" : `Error: ${err instanceof Error ? err.message : String(err)}`);
     } finally {
       audioInFlightRef.current = false;
       setAudioOp("idle");
@@ -259,14 +261,14 @@ export function ActionBar({ onReconnect, connected, activeTab, fileShowHidden, s
       const timeout = setTimeout(() => controller.abort(), 30000);
       try {
         const data = await sendAudioTelegram(audioPath, controller.signal);
-        setStatus(data.ok ? "Sent to Telegram" : `Failed: ${data.error}`);
+        if (data.ok) { haptic.success(); setStatus("Sent to Telegram"); } else { haptic.error(); setStatus(`Failed: ${data.error}`); }
       } finally {
         // clearTimeout in finally so a thrown fetch doesn't leave the
         // 30s timeout dangling and accumulating. (Copilot round-3 review.)
         clearTimeout(timeout);
       }
     } catch (err) {
-      setStatus(err instanceof DOMException && err.name === "AbortError" ? "Timed out" : `Error: ${err instanceof Error ? err.message : String(err)}`);
+      haptic.error(); setStatus(err instanceof DOMException && err.name === "AbortError" ? "Timed out" : `Error: ${err instanceof Error ? err.message : String(err)}`);
     } finally {
       audioInFlightRef.current = false;
       setAudioOp("idle");
@@ -278,16 +280,16 @@ export function ActionBar({ onReconnect, connected, activeTab, fileShowHidden, s
     setStatus("Restarting session...");
     try {
       const data = await restartSession();
-      setStatus(data.ok ? "Session restarted" : `Failed: ${data.error}`);
+      if (data.ok) { haptic.success(); setStatus("Session restarted"); } else { haptic.error(); setStatus(`Failed: ${data.error}`); }
     } catch (err) {
       // Surface the server error text (now extracted by jsonFetch from a
       // { error } body on non-2xx responses) instead of a generic message.
       // (Codex round-4 review re-pass.)
-      setStatus(`Restart failed: ${err instanceof Error ? err.message : String(err)}`);
+      haptic.error(); setStatus(`Restart failed: ${err instanceof Error ? err.message : String(err)}`);
     }
     setTimeout(() => setStatus(null), 3000);
   };
-  const handleSendToChat = async () => { if (!viewingFile) return; setStatus("Sharing..."); try { const data = await sendFileToChat(viewingFile.path); setStatus(data.ok ? "Sent to chat" : "Failed"); } catch { setStatus("Failed"); } setTimeout(() => setStatus(null), 2000); };
+  const handleSendToChat = async () => { if (!viewingFile) return; setStatus("Sharing..."); try { const data = await sendFileToChat(viewingFile.path); if (data.ok) { haptic.success(); setStatus("Sent to chat"); } else { haptic.error(); setStatus("Failed"); } } catch { haptic.error(); setStatus("Failed"); } setTimeout(() => setStatus(null), 2000); };
 
   let modalNode: ReactNode = null;
   switch (modal) {
@@ -315,14 +317,14 @@ export function ActionBar({ onReconnect, connected, activeTab, fileShowHidden, s
       {modalNode}
       <div style={{ padding: "10px 12px 8px", borderTop: "1px solid var(--color-border)", flexShrink: 0 }}>
         <div style={{ display: "flex", gap: "8px", overflowX: "auto" }}>
-          <button onClick={() => { setModal("todo"); void loadTodo(); }} style={{ ...btnStyle, background: "#3a3520", color: "var(--color-accent-yellow)", border: "1px solid #5a4a30" }}>TODO</button>
+          <button onClick={() => { haptic.impact("light"); setModal("todo"); void loadTodo(); }} style={{ ...btnStyle, background: "#3a3520", color: "var(--color-accent-yellow)", border: "1px solid #5a4a30" }}>TODO</button>
           {activeTab === "terminal" && <>
-            {onReconnect && <div style={{ display: "flex", flexShrink: 0 }}><button onClick={onReconnect} style={{ ...btnStyle, background: "#1a3a2a", color: "var(--color-accent-green)", border: "1px solid #2d5a3d", borderRadius: "6px 0 0 6px", borderRight: "none" }}>Reconnect</button><button onClick={() => setModal("reconnect-menu")} aria-label="Open reconnect menu" title="Open reconnect menu" style={{ ...btnStyle, background: "#1a3a2a", color: "var(--color-accent-green)", border: "1px solid #2d5a3d", borderRadius: "0 6px 6px 0", padding: "6px 8px", fontSize: 14 }}>&#9652;</button></div>}
-            <div style={{ display: "flex", flexShrink: 0 }}><button onClick={() => { setModal("git-status"); void loadGitStatus(); }} style={{ ...btnStyle, borderRadius: "6px 0 0 6px", borderRight: "none" }}>Git</button><button onClick={() => setModal("git-menu")} aria-label="Open git menu" title="Open git menu" style={{ ...btnStyle, borderRadius: "0 6px 6px 0", padding: "6px 8px", fontSize: 14 }}>&#9652;</button></div>
-            <button onClick={() => setModal("commands")} style={{ ...btnStyle, background: "#2d2a3a", color: "var(--color-accent-purple)", border: "1px solid #4a3d6a" }}>/commands</button>
+            {onReconnect && <div style={{ display: "flex", flexShrink: 0 }}><button onClick={() => { haptic.impact("light"); onReconnect(); }} style={{ ...btnStyle, background: "#1a3a2a", color: "var(--color-accent-green)", border: "1px solid #2d5a3d", borderRadius: "6px 0 0 6px", borderRight: "none" }}>Reconnect</button><button onClick={() => setModal("reconnect-menu")} aria-label="Open reconnect menu" title="Open reconnect menu" style={{ ...btnStyle, background: "#1a3a2a", color: "var(--color-accent-green)", border: "1px solid #2d5a3d", borderRadius: "0 6px 6px 0", padding: "6px 8px", fontSize: 14 }}>&#9652;</button></div>}
+            <div style={{ display: "flex", flexShrink: 0 }}><button onClick={() => { haptic.impact("light"); setModal("git-status"); void loadGitStatus(); }} style={{ ...btnStyle, borderRadius: "6px 0 0 6px", borderRight: "none" }}>Git</button><button onClick={() => setModal("git-menu")} aria-label="Open git menu" title="Open git menu" style={{ ...btnStyle, borderRadius: "0 6px 6px 0", padding: "6px 8px", fontSize: 14 }}>&#9652;</button></div>
+            <button onClick={() => { haptic.impact("light"); setModal("commands"); }} style={{ ...btnStyle, background: "#2d2a3a", color: "var(--color-accent-purple)", border: "1px solid #4a3d6a" }}>/commands</button>
           </>}
           {activeTab === "files" && !viewingFile && <><button onClick={() => { resetFileSearch(); setModal("file-search"); }} style={{ ...btnStyle, background: "#2d3a5a", color: "var(--color-accent-blue)", border: "1px solid #3d4a6a" }}>Search</button><button onClick={() => setModal("file-options")} style={btnStyle}>Options</button></>}
-          {activeTab === "files" && viewingFile && <button onClick={() => void handleSendToChat()} style={{ ...btnStyle, background: "#1a2a3a", color: "var(--color-accent-cyan)", border: "1px solid #2d4a5a" }}>Send to Chat</button>}
+          {activeTab === "files" && viewingFile && <button onClick={() => { haptic.impact("light"); void handleSendToChat(); }} style={{ ...btnStyle, background: "#1a2a3a", color: "var(--color-accent-cyan)", border: "1px solid #2d4a5a" }}>Send to Chat</button>}
           {activeTab === "files" && viewingFile?.name.toLowerCase().endsWith(".md") && <button onClick={() => setModal("tldr")} style={{ ...btnStyle, background: "#1a3a3a", color: "var(--color-accent-cyan)", border: "1px solid #2d5a5a" }}>TL;DR</button>}
           {activeTab === "files" && viewingFile?.name.toLowerCase().endsWith(".md") && <button onClick={() => { void handleCheckAudio(viewingFile.path); setModal("audio-gen"); }} style={{ ...btnStyle, background: "#2d2a3a", color: "var(--color-accent-purple)", border: "1px solid #4a3d6a" }}>Audio</button>}
         </div>

--- a/apps/web/src/lib/haptic.ts
+++ b/apps/web/src/lib/haptic.ts
@@ -1,0 +1,23 @@
+import { getTelegramWebApp } from "./telegram";
+
+function hf() {
+  return getTelegramWebApp()?.HapticFeedback;
+}
+
+export const haptic = {
+  impact(style: "light" | "medium" | "heavy" | "rigid" | "soft" = "light") {
+    hf()?.impactOccurred(style);
+  },
+  success() {
+    hf()?.notificationOccurred("success");
+  },
+  error() {
+    hf()?.notificationOccurred("error");
+  },
+  warning() {
+    hf()?.notificationOccurred("warning");
+  },
+  selection() {
+    hf()?.selectionChanged();
+  },
+};

--- a/apps/web/src/lib/telegram.ts
+++ b/apps/web/src/lib/telegram.ts
@@ -34,6 +34,13 @@ interface TelegramWebApp {
   themeParams: Record<string, string>;
   colorScheme: "light" | "dark";
   isExpanded: boolean;
+  checkHomeScreenStatus?(callback: (status: "added" | "missed" | "unknown") => void): void;
+  addToHomeScreen?(): void;
+  HapticFeedback?: {
+    impactOccurred(style: "light" | "medium" | "heavy" | "rigid" | "soft"): void;
+    notificationOccurred(type: "error" | "success" | "warning"): void;
+    selectionChanged(): void;
+  };
 }
 
 export function getTelegramWebApp(): TelegramWebApp | null {

--- a/changelogs/unreleased/233-haptic-feedback.md
+++ b/changelogs/unreleased/233-haptic-feedback.md
@@ -1,0 +1,7 @@
+---
+type: feature
+pr: 233
+issue: 224
+---
+
+Haptic feedback on key events via Telegram Bot API 6.1+ `HapticFeedback`. Selection pulse on tab switches, success/error notifications on async outcomes, light impact on primary button taps and PR row taps. Gracefully skipped on older clients where the API is absent.


### PR DESCRIPTION
## Summary

Implements #224 — adds Telegram Bot API 6.1+ haptic feedback at key interaction points.

**New files:**
- `lib/haptic.ts` — 23-line utility wrapper. All 5 methods (`impact`, `success`, `error`, `warning`, `selection`) are safe no-ops when `HapticFeedback` is absent (older clients). `getTelegramWebApp()` is called lazily on each invocation, not cached at module load.
- `__tests__/haptic.test.ts` — 9 tests: all methods when API present, all no-ops when absent

**Modified files:**
- `lib/telegram.ts` — adds optional `HapticFeedback?` interface (+ `checkHomeScreenStatus?`/`addToHomeScreen?` which are also in PR #232 — minor conflict to resolve on merge, see note below)
- `App.tsx` — `haptic.selection()` on swipe left/right and tab button click (all inside bounds-checked conditionals)
- `components/action-bar/ActionBar.tsx` — `haptic.success()`/`haptic.error()` on all async outcomes (rename, compact, audio gen/send, session restart, send to chat, generic actions); `haptic.impact("light")` on TODO, Reconnect, Git, /commands, Send to Chat buttons
- `components/PrTicker.tsx` — `haptic.impact("light")` on PR row tap

## Event → haptic mapping

| Event | Haptic |
|-------|--------|
| Tab swipe / tab button | `selectionChanged()` |
| Async action success | `notificationOccurred("success")` |
| Async action failure / error | `notificationOccurred("error")` |
| Primary button tap | `impactOccurred("light")` |
| PR row tap | `impactOccurred("light")` |

## Merge note

`lib/telegram.ts` in this branch includes `checkHomeScreenStatus?` and `addToHomeScreen?` additions — these also appear in PR #232. Whichever merges second will have a trivial 2-line conflict to resolve.

## Test results

117 tests passing across 9 test files (0 failures).

## Review trail

Local 3-tier swarm (Claude subagent + Codex + Gemini): **CLEAN**.
- Claude subagent: no findings above threshold
- Codex: 1 finding discarded (hallucinated `TabBar.tsx:19` — file does not exist; actual placement in `App.tsx` is already inside bounds-checked conditionals)

Closes #224