### PR TITLE
feat(file-viewer): brighten scrollbar against dark theme

### DIFF
--- a/apps/web/src/components/FileViewer.css
+++ b/apps/web/src/components/FileViewer.css
@@ -1,0 +1,55 @@
+/*
+ * FileViewer scrollbar styling.
+ *
+ * The default OS/dark-theme scrollbars disappear against the Tokyo Night
+ * background, making it hard to tell that long files / directory listings
+ * are scrollable at all. These rules paint the thumb in the existing
+ * cyan accent (--color-accent-cyan, #7dcfff) so it reads clearly without
+ * clashing with the rest of the palette.
+ *
+ * Scope: every selector is prefixed with .cpc-file-viewer so this only
+ * affects scrollable regions inside the FileViewer component — MarkdownViewer
+ * body, code <pre> blocks, directory listing, root-shortcut bar, etc. The
+ * rest of the app keeps its native scrollbars.
+ */
+
+.cpc-file-viewer {
+  /* Firefox */
+  scrollbar-color: var(--color-accent-cyan) var(--color-bg-alt);
+  scrollbar-width: thin;
+}
+
+.cpc-file-viewer *,
+.cpc-file-viewer *::before,
+.cpc-file-viewer *::after {
+  scrollbar-color: var(--color-accent-cyan) var(--color-bg-alt);
+  scrollbar-width: thin;
+}
+
+/* WebKit (Safari/Chrome/iOS) */
+.cpc-file-viewer ::-webkit-scrollbar,
+.cpc-file-viewer::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
+.cpc-file-viewer ::-webkit-scrollbar-track,
+.cpc-file-viewer::-webkit-scrollbar-track {
+  background: var(--color-bg-alt);
+}
+
+.cpc-file-viewer ::-webkit-scrollbar-thumb,
+.cpc-file-viewer::-webkit-scrollbar-thumb {
+  background: var(--color-accent-cyan);
+  border-radius: 4px;
+}
+
+.cpc-file-viewer ::-webkit-scrollbar-thumb:hover,
+.cpc-file-viewer::-webkit-scrollbar-thumb:hover {
+  background: var(--color-accent-blue);
+}
+
+.cpc-file-viewer ::-webkit-scrollbar-corner,
+.cpc-file-viewer::-webkit-scrollbar-corner {
+  background: var(--color-bg-alt);
+}

--- a/apps/web/src/components/FileViewer.css
+++ b/apps/web/src/components/FileViewer.css
@@ -19,9 +19,7 @@
   scrollbar-width: thin;
 }
 
-.cpc-file-viewer *,
-.cpc-file-viewer *::before,
-.cpc-file-viewer *::after {
+.cpc-file-viewer * {
   scrollbar-color: var(--color-accent-cyan) var(--color-bg-alt);
   scrollbar-width: thin;
 }

--- a/apps/web/src/components/FileViewer.css
+++ b/apps/web/src/components/FileViewer.css
@@ -13,13 +13,10 @@
  * rest of the app keeps its native scrollbars.
  */
 
-.cpc-file-viewer {
-  /* Firefox */
-  scrollbar-color: var(--color-accent-cyan) var(--color-bg-alt);
-  scrollbar-width: thin;
-}
-
+.cpc-file-viewer,
 .cpc-file-viewer * {
+  /* Firefox — scrollbar-color does not cascade, so both the root element and
+     any scrollable descendants need the declaration explicitly. */
   scrollbar-color: var(--color-accent-cyan) var(--color-bg-alt);
   scrollbar-width: thin;
 }

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -4,6 +4,7 @@ import { getAuthHeaders } from "../lib/telegram";
 import { MarkdownViewer } from "./MarkdownViewer";
 import { BottomSheet } from "./BottomSheet";
 import { getFileIcon } from "./file-icons";
+import "./FileViewer.css";
 
 const PASTE_MAX_BYTES = 1024 * 1024;
 
@@ -552,7 +553,7 @@ export function FileViewer({ onClose, initialFile, showHidden = false, sortMode 
   const shortPath = currentPath.replace("/home/claude/", "~/");
 
   return (
-    <div style={{ display: "flex", flexDirection: "column", height: "100%", width: "100%", maxWidth: "100%", overflowX: "hidden" }}>
+    <div className="cpc-file-viewer" style={{ display: "flex", flexDirection: "column", height: "100%", width: "100%", maxWidth: "100%", overflowX: "hidden" }}>
       {/* Root directory shortcuts */}
       {fileContent === null && (
         <div

--- a/changelogs/unreleased/238-brighter-fileviewer-scrollbar.md
+++ b/changelogs/unreleased/238-brighter-fileviewer-scrollbar.md
@@ -1,0 +1,5 @@
+---
+type: feature
+pr: 238
+---
+Brighten FileViewer scrollbars (cyan `#7dcfff` thumb, blue hover) so long directory listings and file contents are obviously scrollable against the dark theme. Scoped to the FileViewer only — the rest of the app keeps its native scrollbars.


### PR DESCRIPTION
## Summary
- Paint FileViewer scrollbars with the existing Tokyo Night cyan accent (`#7dcfff` = `--color-accent-cyan`) so they read clearly against the dark background instead of disappearing.
- Cover both Firefox (`scrollbar-color` / `scrollbar-width: thin`) and WebKit (`::-webkit-scrollbar*`) engines. Hover state on WebKit swaps to `--color-accent-blue`.
- Scoped to descendants of `.cpc-file-viewer` via a new `apps/web/src/components/FileViewer.css`. The rest of the app keeps native scrollbars.

Closes #237.

## Affects
- New file: `apps/web/src/components/FileViewer.css`
- Modified: `apps/web/src/components/FileViewer.tsx` — add `import "./FileViewer.css"` and `className="cpc-file-viewer"` on the root `<div>`.

## Local swarm review
- **Codex:** no must-fix. Noted `.cpc-file-viewer *` is broad but intentional.
- **Gemini flash:** flagged `*::before` / `*::after` as pointless (scrollbars don't attach to pseudo-elements) — addressed in 2nd commit (`adff7db`).
- **Self pass:** same cleanup, caught independently.

## Test plan
- [x] `pnpm --filter web typecheck` green
- [x] `pnpm --filter web build` green (no new bundle growth)
- [ ] Visual: open FileViewer in CPC, scroll a large directory listing and a long source file — verify cyan thumb appears, hover turns blue on desktop WebKit
- [ ] Visual: open a non-FileViewer scrollable surface (e.g. Links tab) — verify native scrollbars unchanged
- [ ] Mobile Safari sanity: overlay scrollbars may still auto-hide (platform behavior); when they do appear, thumb should be cyan

🤖 Generated with [Claude Code](https://claude.com/claude-code)