### PR TITLE
fix(mini-app): add PRs tab to navigation array (#244)

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -11,10 +11,7 @@ import { DebugOverlay } from "./debug/DebugOverlay";
 import { PrTicker } from "./components/PrTicker";
 
 type Tab = "terminal" | "files" | "links" | "voice" | "prs";
-const BASE_TABS: Tab[] = ["terminal", "files", "links", "voice"];
-const TABS: Tab[] = import.meta.env.VITE_FEATURE_PR_TICKER
-  ? [...BASE_TABS, "prs"]
-  : BASE_TABS;
+const TABS: Tab[] = ["terminal", "files", "links", "voice", "prs"];
 const SWIPE_THRESHOLD = 120;
 
 // Moving blue underline indicator that tracks the active tab and follows
@@ -400,11 +397,9 @@ export function App() {
           <div style={{ width: `${100 / TABS.length}%`, height: "100%", flexShrink: 0 }}>
             <VoiceRecorder />
           </div>
-          {TABS.includes("prs") && (
-            <div style={{ width: `${100 / TABS.length}%`, height: "100%", flexShrink: 0 }}>
-              <PrTicker />
-            </div>
-          )}
+          <div style={{ width: `${100 / TABS.length}%`, height: "100%", flexShrink: 0 }}>
+            <PrTicker />
+          </div>
         </div>
       </div>
 

--- a/changelogs/unreleased/244-prs-tab-visibility.md
+++ b/changelogs/unreleased/244-prs-tab-visibility.md
@@ -1,0 +1,5 @@
+---
+type: fixes
+issue: 244
+---
+PRs tab now always visible — dropped stale `VITE_FEATURE_PR_TICKER` feature flag so the multi-repo PR dashboard (shipped in v1.11.0–v1.11.2) is reachable in prod without env wiring.


### PR DESCRIPTION
## Summary

Closes #244

The multi-repo PR dashboard (PrTicker component, `/api/prs` route, 30s polling) was shipped in v1.11.0 (#194) and v1.11.2 (#213 org grouping) but the tab was never navigable in prod — it was gated behind `VITE_FEATURE_PR_TICKER`, which is not set in the prod build env.

Result: users saw **Terminal | Files | Links | Voice** but no PRs tab, even though the component, API route, and polling loop were all in the deployed bundle.

## Fix

Drop the feature flag gate:

```diff
-const BASE_TABS: Tab[] = ["terminal", "files", "links", "voice"];
-const TABS: Tab[] = import.meta.env.VITE_FEATURE_PR_TICKER
-  ? [...BASE_TABS, "prs"]
-  : BASE_TABS;
+const TABS: Tab[] = ["terminal", "files", "links", "voice", "prs"];
```

And remove the now-redundant `TABS.includes("prs") &&` wrapper around the `<PrTicker />` render block.

Phase 1 gating was appropriate while the component was being iterated (#194 → #213). Now that it's stable per v1.11.2 release intent, the flag is stale and the user can't reach the feature.

## Verification

- [x] `pnpm install && pnpm run build` clean
- [x] Built bundle now contains `"terminal","files","links","voice","prs"` (verified via grep of `dist/assets/index-*.js`)
- [x] 108 web unit tests pass
- [x] 209 server unit tests pass
- [x] PrTicker test suite still passes (doesn't reference the removed flag)
- [x] Deep-link `#prs` now works via the existing `TABS.includes(initialTab)` check

## Scope guardrails

- No changes to PrTicker component (already shipped and working)
- No changes to `/api/prs` backend route
- No new features (no priority sort, no polling tweaks)
- No version bump (deferred to release-PR time per gitflow-light)

## Local swarm review

3-tier local swarm run pre-push on the 13-line diff:
- Tier 1 (local Claude, full repo context): **CLEAN**
- Tier 2 (local Codex CLI): **CLEAN**
- Tier 3 (local Gemini flash): **CLEAN**

## Test plan

- [ ] Cloud reviewers (Copilot + Gemini Code Assist) land on PR open
- [ ] PRs tab renders in the dev deployment (`cpc.claude.do/dev/`)
- [ ] Tapping PRs tab shows the multi-repo PR dashboard with org grouping
- [ ] Swipe nav between Voice → PRs works
- [ ] Mobile + desktop layout intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)