### PR TITLE
feat(terminal): auto-reconnect WebSocket on tab switch

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -386,7 +386,7 @@ export function App() {
           onTransitionEnd={() => setIsAnimating(false)}
         >
           <div style={{ width: `${100 / TABS.length}%`, height: "100%", flexShrink: 0 }}>
-            <Terminal key={reconnectKey} onConnectionChange={onConnectionChange} />
+            <Terminal key={reconnectKey} onConnectionChange={onConnectionChange} isActive={activeTab === "terminal"} />
           </div>
           <div style={{ width: `${100 / TABS.length}%`, height: "100%", flexShrink: 0 }}>
             <FileViewer onClose={() => setActiveTab("terminal")} initialFile={initialFilePath} showHidden={fileShowHidden} sortMode={fileSortMode} onSortModeChange={setFileSortMode} onViewChange={setViewingFile} onPathChange={setCurrentFolder} />

--- a/apps/web/src/components/Terminal.tsx
+++ b/apps/web/src/components/Terminal.tsx
@@ -53,11 +53,16 @@ export function Terminal({ onConnectionChange, isActive }: TerminalProps) {
 
     const ws = new WebSocket(buildWsUrl());
 
+    // Guard all handlers against stale sockets: if connectWs is called again
+    // before the previous socket finishes closing, the old socket's events
+    // must not overwrite state belonging to the new connection.
     ws.onopen = () => {
+      if (wsRef.current !== ws) return;
       onConnectionChangeRef.current(true);
     };
 
     ws.onmessage = (event) => {
+      if (wsRef.current !== ws) return;
       try {
         const msg = JSON.parse(event.data);
         if (msg.type === "dimensions") {
@@ -91,10 +96,12 @@ export function Terminal({ onConnectionChange, isActive }: TerminalProps) {
     };
 
     ws.onclose = () => {
+      if (wsRef.current !== ws) return;
       onConnectionChangeRef.current(false);
     };
 
     ws.onerror = () => {
+      if (wsRef.current !== ws) return;
       onConnectionChangeRef.current(false);
     };
 

--- a/apps/web/src/components/Terminal.tsx
+++ b/apps/web/src/components/Terminal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import { Terminal as XTerm } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { WebLinksAddon } from "@xterm/addon-web-links";
@@ -6,74 +6,55 @@ import "@xterm/xterm/css/xterm.css";
 
 interface TerminalProps {
   onConnectionChange: (connected: boolean) => void;
+  isActive?: boolean;
 }
 
-export function Terminal({ onConnectionChange }: TerminalProps) {
+/** Build the WebSocket URL with auth params. */
+function buildWsUrl(): string {
+  const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
+  const initData = window.Telegram?.WebApp?.initData || "";
+  let authParam = "";
+  if (initData) {
+    authParam = `?auth=${encodeURIComponent(initData)}`;
+  } else {
+    // Fallback: URL token from keyboard button, then saved session token
+    const urlParams = new URLSearchParams(window.location.search);
+    const hashParams = new URLSearchParams(window.location.hash.replace(/^#[^&]*&?/, ""));
+    const urlToken = urlParams.get("token") || hashParams.get("token") || "";
+    const savedToken = localStorage.getItem("cpc-session-token") || "";
+    const token = urlToken || savedToken;
+    if (token) authParam = `?token=${encodeURIComponent(token)}`;
+  }
+  return `${protocol}//${window.location.host}/ws/terminal${authParam}`;
+}
+
+export function Terminal({ onConnectionChange, isActive }: TerminalProps) {
   const wrapperRef = useRef<HTMLDivElement>(null);
   const mountRef = useRef<HTMLDivElement>(null);
   const termRef = useRef<XTerm | null>(null);
   const wsRef = useRef<WebSocket | null>(null);
   const fitRef = useRef<FitAddon | null>(null);
 
-  useEffect(() => {
-    if (!wrapperRef.current || !mountRef.current) return;
+  // Stable ref for onConnectionChange so connectWs doesn't need it as a dep
+  const onConnectionChangeRef = useRef(onConnectionChange);
+  onConnectionChangeRef.current = onConnectionChange;
 
-    const term = new XTerm({
-      cursorBlink: false,
-      cursorStyle: "bar",
-      fontSize: 12,
-      fontFamily: "'JetBrains Mono', 'Fira Code', 'Cascadia Code', monospace",
-      theme: {
-        background: "#1a1b26",
-        foreground: "#c0caf5",
-        cursor: "#c0caf5",
-        selectionBackground: "#33467c",
-        black: "#15161e",
-        red: "#f7768e",
-        green: "#9ece6a",
-        yellow: "#e0af68",
-        blue: "#7aa2f7",
-        magenta: "#bb9af7",
-        cyan: "#7dcfff",
-        white: "#a9b1d6",
-      },
-      disableStdin: true,
-      scrollback: 0,
-    });
+  /** Open a WebSocket and wire it to the current xterm instance.
+   *  Closes any existing connection first to prevent duplicates. */
+  const connectWs = useCallback(() => {
+    const term = termRef.current;
+    const fit = fitRef.current;
+    if (!term || !fit) return;
 
-    const fit = new FitAddon();
-    term.loadAddon(fit);
-    term.loadAddon(new WebLinksAddon());
-    term.open(mountRef.current);
-
-    termRef.current = term;
-    fitRef.current = fit;
-
-    // Connect to WebSocket
-    const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
-    const initData = window.Telegram?.WebApp?.initData || "";
-    let authParam = "";
-    if (initData) {
-      authParam = `?auth=${encodeURIComponent(initData)}`;
-    } else {
-      // Fallback: URL token from keyboard button, then saved session token
-      const urlParams = new URLSearchParams(window.location.search);
-      const hashParams = new URLSearchParams(window.location.hash.replace(/^#[^&]*&?/, ""));
-      const urlToken = urlParams.get("token") || hashParams.get("token") || "";
-      const savedToken = localStorage.getItem("cpc-session-token") || "";
-      const token = urlToken || savedToken;
-      if (token) authParam = `?token=${encodeURIComponent(token)}`;
+    // Tear down previous connection if still open
+    if (wsRef.current && wsRef.current.readyState <= WebSocket.OPEN) {
+      wsRef.current.close();
     }
-    const wsUrl = `${protocol}//${window.location.host}/ws/terminal${authParam}`;
-    const ws = new WebSocket(wsUrl);
 
-    fit.fit();
-    const frameId = window.requestAnimationFrame(() => {
-      fit.fit();
-    });
+    const ws = new WebSocket(buildWsUrl());
 
     ws.onopen = () => {
-      onConnectionChange(true);
+      onConnectionChangeRef.current(true);
     };
 
     ws.onmessage = (event) => {
@@ -110,14 +91,58 @@ export function Terminal({ onConnectionChange }: TerminalProps) {
     };
 
     ws.onclose = () => {
-      onConnectionChange(false);
+      onConnectionChangeRef.current(false);
     };
 
     ws.onerror = () => {
-      onConnectionChange(false);
+      onConnectionChangeRef.current(false);
     };
 
     wsRef.current = ws;
+  }, []);
+
+  // Initialize xterm and open the first WS connection on mount
+  useEffect(() => {
+    if (!wrapperRef.current || !mountRef.current) return;
+
+    const term = new XTerm({
+      cursorBlink: false,
+      cursorStyle: "bar",
+      fontSize: 12,
+      fontFamily: "'JetBrains Mono', 'Fira Code', 'Cascadia Code', monospace",
+      theme: {
+        background: "#1a1b26",
+        foreground: "#c0caf5",
+        cursor: "#c0caf5",
+        selectionBackground: "#33467c",
+        black: "#15161e",
+        red: "#f7768e",
+        green: "#9ece6a",
+        yellow: "#e0af68",
+        blue: "#7aa2f7",
+        magenta: "#bb9af7",
+        cyan: "#7dcfff",
+        white: "#a9b1d6",
+      },
+      disableStdin: true,
+      scrollback: 0,
+    });
+
+    const fit = new FitAddon();
+    term.loadAddon(fit);
+    term.loadAddon(new WebLinksAddon());
+    term.open(mountRef.current);
+
+    termRef.current = term;
+    fitRef.current = fit;
+
+    fit.fit();
+    const frameId = window.requestAnimationFrame(() => {
+      fit.fit();
+    });
+
+    // Auto-connect on initial render
+    connectWs();
 
     // Handle viewport resize — just refit xterm to container
     const resizeObserver = new ResizeObserver(() => {
@@ -128,10 +153,19 @@ export function Terminal({ onConnectionChange }: TerminalProps) {
     return () => {
       window.cancelAnimationFrame(frameId);
       resizeObserver.disconnect();
-      ws.close();
+      if (wsRef.current) wsRef.current.close();
       term.dispose();
     };
-  }, [onConnectionChange]);
+  }, [connectWs]);
+
+  // Auto-reconnect when the terminal tab becomes active and WS is disconnected
+  useEffect(() => {
+    if (!isActive) return;
+    const ws = wsRef.current;
+    if (!ws || ws.readyState === WebSocket.CLOSED || ws.readyState === WebSocket.CLOSING) {
+      connectWs();
+    }
+  }, [isActive, connectWs]);
 
   return (
     <div

--- a/changelogs/unreleased/247-terminal-auto-reconnect.md
+++ b/changelogs/unreleased/247-terminal-auto-reconnect.md
@@ -1,0 +1,5 @@
+---
+type: features
+issue: 247
+---
+Terminal WebSocket auto-reconnects on initial open and when switching back to the Terminal tab, eliminating the need to manually tap Reconnect.


### PR DESCRIPTION
## Summary

- Extract WebSocket connection logic into reusable `connectWs` callback so the terminal can reconnect without remounting the xterm instance
- Pass `isActive` prop from App to Terminal to detect tab switches
- Auto-reconnect when tab becomes active and WS is in CLOSED/CLOSING state
- Auto-connect on initial render (existing behavior preserved via extracted function)
- Duplicate connections prevented by closing any existing connection before opening a new one

Closes #247

## Test plan

- [ ] Open the mini app — terminal should auto-connect without tapping Reconnect
- [ ] Switch to Files tab, wait a few seconds, switch back to Terminal — should auto-reconnect if WS dropped
- [ ] While connected, switch tabs and come back — should NOT create duplicate connections
- [ ] Manual Reconnect button still works (key-based remount path unchanged)
- [ ] Build passes: `pnpm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)