### PR TITLE
Release v1.12.0

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,9 @@
 # Telegram bot token (same one used for the channel plugin)
 TELEGRAM_BOT_TOKEN=
 
+# For multi-bot support, use comma-separated list (takes priority over TELEGRAM_BOT_TOKEN)
+TELEGRAM_BOT_TOKENS=
+
 # Comma-separated Telegram user IDs allowed to access the app
 ALLOWED_TELEGRAM_USERS=<YOUR_TELEGRAM_USER_ID>
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,46 @@
 
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.12.0] — 2026-04-18
+
+### Highlights
+
+- Multi-bot token auth — any authorized bot can open the CPC mini app
+- 98 new tests across server routes + 3 React components
+- Terminal auto-reconnect on tab switch and initial open
+- Security hardening for auth + file sharing endpoints
+
+### Security
+
+- Ticket format validation + initData expiry check (closes #225, #227)
+- Auth date clock-skew tolerance + DRY validation helpers
+- Ambiguous ticket+path request guard with empty-key coverage
+- FilePath validation + curl→fetch migration in send-to-chat (closes #226)
+
+### Features
+
+- Multi-bot token support — TELEGRAM_BOT_TOKENS env var for multi-agent mini app access (closes #252)
+- Terminal auto-reconnect WebSocket on tab switch and initial open (closes #247)
+- CloudStorage-backed unified preferences system (#231)
+- Offline PR cache with stale-while-revalidate (closes #223)
+- Add-to-home-screen prompt on first launch (closes #222)
+- Haptic feedback on key UI events (closes #224)
+- Brighter scrollbar against dark theme (#237)
+- PRs tab added to navigation array (#245)
+
+### Tests
+
+- Server route tests — prs, telegram, and utils (47 tests) (#220)
+- ActionBar component tests (47 tests) (#228)
+- MarkdownViewer component tests (29 tests) (#234)
+- Terminal component tests (22 tests) (#235)
+
+### Fixes
+
+- Redundant ambiguous-request check removed from files.ts (closes #250)
+- Manual setTimeout race condition in ActionBar status messages (closes #250)
+- ActionBar test compatibility with haptic feedback integration
+
 ## [1.11.1] — 2026-04-12
 
 ### Highlights

--- a/apps/server/src/auth.ts
+++ b/apps/server/src/auth.ts
@@ -173,12 +173,52 @@ export function validateSession(token: string): { valid: boolean; user?: Telegra
   return { valid: true, user: session.user };
 }
 
+/**
+ * Try initData against each token in order; return first success or { valid: false }.
+ */
+export function validateTelegramInitDataWithTokens(
+  initData: string,
+  tokens: string[],
+): { valid: boolean; user?: TelegramUser } {
+  for (const token of tokens) {
+    const result = validateTelegramInitData(initData, token);
+    if (result.valid) return result;
+  }
+  return { valid: false };
+}
+
+/**
+ * Try a JWT token against each bot token in order; return first success or { valid: false }.
+ */
+export function validateJwtTokenWithTokens(
+  jwtToken: string,
+  tokens: string[],
+): { valid: boolean; user?: TelegramUser } {
+  for (const token of tokens) {
+    const result = validateJwtToken(jwtToken, token);
+    if (result.valid) return result;
+  }
+  return { valid: false };
+}
+
+/** Return the list of bot tokens to validate against.
+ * Prefers TELEGRAM_BOT_TOKENS (comma-separated) over TELEGRAM_BOT_TOKEN. */
+export function getBotTokens(): string[] {
+  const multi = process.env.TELEGRAM_BOT_TOKENS;
+  if (multi) {
+    const tokens = multi.split(",").map((t) => t.trim()).filter(Boolean);
+    if (tokens.length > 0) return tokens;
+  }
+  const single = process.env.TELEGRAM_BOT_TOKEN;
+  return single ? [single] : [];
+}
+
 /** Full auth check: validate initData + check allowlist. Returns user if authorized. */
 export function checkAuth(initData: string): { ok: boolean; user?: TelegramUser; error?: string } {
-  const botToken = process.env.TELEGRAM_BOT_TOKEN;
-  if (!botToken) return { ok: false, error: "Server not configured" };
+  const tokens = getBotTokens();
+  if (tokens.length === 0) return { ok: false, error: "Server not configured" };
 
-  const { valid, user } = validateTelegramInitData(initData, botToken);
+  const { valid, user } = validateTelegramInitDataWithTokens(initData, tokens);
   if (!valid) return { ok: false, error: "Invalid auth" };
 
   const allowed = getAllowedUsers();

--- a/apps/server/src/auth.ts
+++ b/apps/server/src/auth.ts
@@ -1,5 +1,26 @@
 import { createHash, createHmac, randomBytes } from "node:crypto";
 
+// Allow up to 30 seconds of clock skew on the future-timestamp check.
+// Telegram servers and client devices can drift by a few seconds; a hard
+// equality check (authDate > nowSec) would reject legitimate requests that
+// arrive with a timestamp slightly ahead of the server clock.
+const CLOCK_SKEW_TOLERANCE_SEC = 30;
+
+/**
+ * Validate an auth_date unix timestamp.
+ * Rejects NaN, non-positive, more than 30s in the future (clock-skew
+ * tolerance), and older than 24 hours.
+ */
+function validateAuthDate(rawAuthDate: string | undefined): boolean {
+  if (!rawAuthDate) return false;
+  const authDate = parseInt(rawAuthDate, 10);
+  const nowSec = Date.now() / 1000;
+  if (!Number.isFinite(authDate) || authDate <= 0) return false;
+  if (authDate > nowSec + CLOCK_SKEW_TOLERANCE_SEC) return false;
+  if (nowSec - authDate > 86400) return false;
+  return true;
+}
+
 /**
  * Validate Telegram Mini App initData.
  * https://core.telegram.org/bots/webapps#validating-data-received-via-the-mini-app
@@ -28,11 +49,7 @@ export function validateTelegramInitData(
   if (computedHash !== hash) return { valid: false };
 
   // Check auth_date is within 24 hours (guard against NaN, future timestamps)
-  const rawAuthDate = params.get("auth_date");
-  if (!rawAuthDate) return { valid: false };
-  const authDate = parseInt(rawAuthDate, 10);
-  const nowSec = Date.now() / 1000;
-  if (!Number.isFinite(authDate) || authDate <= 0 || authDate > nowSec || nowSec - authDate > 86400) return { valid: false };
+  if (!validateAuthDate(params.get("auth_date") ?? undefined)) return { valid: false };
 
   // Parse user data
   const userStr = params.get("user");
@@ -84,11 +101,7 @@ export function validateTelegramLoginWidget(
   if (computedHash !== hash) return { valid: false };
 
   // Check auth_date is within 24 hours (guard against NaN, future timestamps)
-  const rawAuthDateWidget = rest.auth_date;
-  if (!rawAuthDateWidget) return { valid: false };
-  const authDate = parseInt(rawAuthDateWidget, 10);
-  const nowSecWidget = Date.now() / 1000;
-  if (!Number.isFinite(authDate) || authDate <= 0 || authDate > nowSecWidget || nowSecWidget - authDate > 86400) return { valid: false };
+  if (!validateAuthDate(rest.auth_date)) return { valid: false };
 
   return {
     valid: true,

--- a/apps/server/src/auth.ts
+++ b/apps/server/src/auth.ts
@@ -27,6 +27,10 @@ export function validateTelegramInitData(
 
   if (computedHash !== hash) return { valid: false };
 
+  // Check auth_date is within 24 hours
+  const authDate = parseInt(params.get("auth_date") || "0");
+  if (Date.now() / 1000 - authDate > 86400) return { valid: false };
+
   // Parse user data
   const userStr = params.get("user");
   if (!userStr) return { valid: true };

--- a/apps/server/src/auth.ts
+++ b/apps/server/src/auth.ts
@@ -27,9 +27,12 @@ export function validateTelegramInitData(
 
   if (computedHash !== hash) return { valid: false };
 
-  // Check auth_date is within 24 hours
-  const authDate = parseInt(params.get("auth_date") || "0");
-  if (Date.now() / 1000 - authDate > 86400) return { valid: false };
+  // Check auth_date is within 24 hours (guard against NaN, future timestamps)
+  const rawAuthDate = params.get("auth_date");
+  if (!rawAuthDate) return { valid: false };
+  const authDate = parseInt(rawAuthDate, 10);
+  const nowSec = Date.now() / 1000;
+  if (!Number.isFinite(authDate) || authDate <= 0 || authDate > nowSec || nowSec - authDate > 86400) return { valid: false };
 
   // Parse user data
   const userStr = params.get("user");
@@ -80,9 +83,12 @@ export function validateTelegramLoginWidget(
 
   if (computedHash !== hash) return { valid: false };
 
-  // Check auth_date is within 24 hours
-  const authDate = parseInt(rest.auth_date || "0");
-  if (Date.now() / 1000 - authDate > 86400) return { valid: false };
+  // Check auth_date is within 24 hours (guard against NaN, future timestamps)
+  const rawAuthDateWidget = rest.auth_date;
+  if (!rawAuthDateWidget) return { valid: false };
+  const authDate = parseInt(rawAuthDateWidget, 10);
+  const nowSecWidget = Date.now() / 1000;
+  if (!Number.isFinite(authDate) || authDate <= 0 || authDate > nowSecWidget || nowSecWidget - authDate > 86400) return { valid: false };
 
   return {
     valid: true,

--- a/apps/server/src/middleware.ts
+++ b/apps/server/src/middleware.ts
@@ -1,5 +1,10 @@
 import type { Context, Next } from "hono";
-import { validateTelegramInitData, validateSession, validateJwtToken } from "./auth.js";
+import {
+  validateSession,
+  getBotTokens,
+  validateTelegramInitDataWithTokens,
+  validateJwtTokenWithTokens,
+} from "./auth.js";
 import { isAllowedUser } from "./lib/allowed-users.js";
 
 /**
@@ -36,8 +41,8 @@ export async function telegramAuth(c: Context, next: Next) {
     return;
   }
 
-  const botToken = process.env.TELEGRAM_BOT_TOKEN;
-  if (!botToken) {
+  const botTokens = getBotTokens();
+  if (botTokens.length === 0) {
     return c.json({ error: "Server not configured: missing bot token" }, 500);
   }
 
@@ -46,7 +51,7 @@ export async function telegramAuth(c: Context, next: Next) {
   // Primary: Telegram Mini App initData
   if (authHeader?.startsWith("tma ")) {
     const initData = authHeader.slice(4);
-    const { valid, user } = validateTelegramInitData(initData, botToken);
+    const { valid, user } = validateTelegramInitDataWithTokens(initData, botTokens);
 
     if (!valid) {
       return c.json({ error: "Invalid Telegram auth" }, 401);
@@ -83,8 +88,8 @@ export async function telegramAuth(c: Context, next: Next) {
       return;
     }
 
-    // Try JWT token validation (keyboard button auth)
-    const jwtResult = validateJwtToken(token, botToken);
+    // Try JWT token validation (keyboard button auth) — try each configured bot token
+    const jwtResult = validateJwtTokenWithTokens(token, botTokens);
     if (jwtResult.valid) {
       if (!isAllowedUser(jwtResult.user?.id)) {
         return c.json({ error: "User not authorized" }, 403);
@@ -104,7 +109,7 @@ export async function telegramAuth(c: Context, next: Next) {
   // Fallback: JWT token in query param (keyboard button auth)
   const urlToken = c.req.query("token");
   if (urlToken) {
-    const { valid, user } = validateJwtToken(urlToken, botToken);
+    const { valid, user } = validateJwtTokenWithTokens(urlToken, botTokens);
     if (valid) {
       if (!isAllowedUser(user?.id)) {
         return c.json({ error: "User not authorized" }, 403);

--- a/apps/server/src/middleware.ts
+++ b/apps/server/src/middleware.ts
@@ -10,11 +10,17 @@ export async function telegramAuth(c: Context, next: Next) {
   const ticket = c.req.query("ticket");
   const filePath = c.req.query("path");
 
+  // Use key presence (not value truthiness) so ?ticket=&path=foo is still
+  // caught — an empty-string value is a valid key that signals intent.
+  const url = new URL(c.req.url);
+  const hasTicketKey = url.searchParams.has("ticket");
+  const hasPathKey = url.searchParams.has("path");
+
   if (
     c.req.method === "GET" &&
     c.req.path === "/api/files/download" &&
-    ticket &&
-    filePath
+    hasTicketKey &&
+    hasPathKey
   ) {
     return c.json({ error: "Ambiguous request: use ticket OR path, not both" }, 400);
   }

--- a/apps/server/src/middleware.ts
+++ b/apps/server/src/middleware.ts
@@ -7,10 +7,12 @@ import { isAllowedUser } from "./lib/allowed-users.js";
  * Expects initData in the Authorization header as: tma <initData>
  */
 export async function telegramAuth(c: Context, next: Next) {
+  const ticket = c.req.query("ticket");
   if (
     c.req.method === "GET" &&
     c.req.path === "/api/files/download" &&
-    c.req.query("ticket")
+    ticket &&
+    /^[0-9a-f]{32}$/.test(ticket)
   ) {
     await next();
     return;

--- a/apps/server/src/middleware.ts
+++ b/apps/server/src/middleware.ts
@@ -8,10 +8,22 @@ import { isAllowedUser } from "./lib/allowed-users.js";
  */
 export async function telegramAuth(c: Context, next: Next) {
   const ticket = c.req.query("ticket");
+  const filePath = c.req.query("path");
+
   if (
     c.req.method === "GET" &&
     c.req.path === "/api/files/download" &&
     ticket &&
+    filePath
+  ) {
+    return c.json({ error: "Ambiguous request: use ticket OR path, not both" }, 400);
+  }
+
+  if (
+    c.req.method === "GET" &&
+    c.req.path === "/api/files/download" &&
+    ticket &&
+    ticket.length === 32 &&
     /^[0-9a-f]{32}$/.test(ticket)
   ) {
     await next();

--- a/apps/server/src/routes/__tests__/auth.test.ts
+++ b/apps/server/src/routes/__tests__/auth.test.ts
@@ -310,5 +310,71 @@ describe("telegramAuth middleware", () => {
       });
       expect(res.status).toBe(200);
     });
+
+    it("rejects initData with auth_date=notanumber (NaN bypass)", async () => {
+      const initData = makeInitData(TEST_USER, {
+        extraParams: { auth_date: "notanumber" },
+      });
+      const res = await app.request("/api/test", {
+        headers: { Authorization: `tma ${initData}` },
+      });
+      expect(res.status).toBe(401);
+      const body = (await res.json()) as { error: string };
+      expect(body.error).toBe("Invalid Telegram auth");
+    });
+
+    it("rejects initData with auth_date absent (missing field)", async () => {
+      // Build initData manually without auth_date
+      const token = TEST_BOT_TOKEN;
+      const params = new URLSearchParams();
+      params.set("user", JSON.stringify(TEST_USER));
+      // auth_date intentionally omitted
+      const dataCheckString = Array.from(params.entries())
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([key, val]) => `${key}=${val}`)
+        .join("\n");
+      const { createHmac: hmac } = await import("node:crypto");
+      const secretKey = hmac("sha256", "WebAppData").update(token).digest();
+      const hash = hmac("sha256", secretKey).update(dataCheckString).digest("hex");
+      params.set("hash", hash);
+      const res = await app.request("/api/test", {
+        headers: { Authorization: `tma ${params.toString()}` },
+      });
+      expect(res.status).toBe(401);
+    });
+
+    it("rejects initData with a far-future auth_date (year 2099)", async () => {
+      // 2099-01-01T00:00:00Z as unix timestamp
+      const futureAuthDate = String(4070908800);
+      const initData = makeInitData(TEST_USER, {
+        extraParams: { auth_date: futureAuthDate },
+      });
+      const res = await app.request("/api/test", {
+        headers: { Authorization: `tma ${initData}` },
+      });
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe("ticket newline bypass (security hardening)", () => {
+    it("rejects a ticket with a trailing newline (URL-encoded %0A)", async () => {
+      // ticket is 32 valid hex chars + a newline — middleware must reject it
+      const res = await app.request(
+        "/api/files/download?ticket=deadbeef00000000deadbeef00000000%0A",
+      );
+      // Middleware does NOT bypass — requires auth → 401
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe("ambiguous ticket+path requests", () => {
+    it("returns 400 when both ?ticket= and ?path= are present", async () => {
+      const res = await app.request(
+        "/api/files/download?ticket=deadbeef00000000deadbeef00000000&path=/some/file.txt",
+      );
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as { error: string };
+      expect(body.error).toMatch(/ambiguous/i);
+    });
   });
 });

--- a/apps/server/src/routes/__tests__/auth.test.ts
+++ b/apps/server/src/routes/__tests__/auth.test.ts
@@ -42,6 +42,8 @@ function buildApp(): Hono {
   app.use("/api/*", telegramAuth);
   // Protected test endpoint
   app.get("/api/test", (c) => c.json({ ok: true }));
+  // Download endpoint — ticket bypass tested here
+  app.get("/api/files/download", (c) => c.json({ download: true }));
   return app;
 }
 
@@ -241,6 +243,72 @@ describe("telegramAuth middleware", () => {
       } finally {
         process.env.TELEGRAM_BOT_TOKEN = original;
       }
+    });
+  });
+
+  describe("ticket format bypass (issue #225)", () => {
+    it("bypasses auth for a valid hex-32 ticket on /api/files/download", async () => {
+      const res = await app.request(
+        "/api/files/download?ticket=deadbeef00000000deadbeef00000000",
+      );
+      // Middleware lets it through — route responds 200
+      expect(res.status).toBe(200);
+    });
+
+    it("rejects non-hex-32 ticket values (too short)", async () => {
+      const res = await app.request("/api/files/download?ticket=abc123");
+      // Middleware does NOT bypass — requires auth → 401
+      expect(res.status).toBe(401);
+    });
+
+    it("rejects non-hex-32 ticket values (uppercase hex)", async () => {
+      const res = await app.request(
+        "/api/files/download?ticket=DEADBEEF00000000DEADBEEF00000000",
+      );
+      expect(res.status).toBe(401);
+    });
+
+    it("rejects non-hex-32 ticket values (contains non-hex chars)", async () => {
+      const res = await app.request(
+        "/api/files/download?ticket=zzzzzzzz00000000zzzzzzzz00000000",
+      );
+      expect(res.status).toBe(401);
+    });
+
+    it("rejects non-hex-32 ticket values (too long)", async () => {
+      const res = await app.request(
+        "/api/files/download?ticket=deadbeef00000000deadbeef00000000extra",
+      );
+      expect(res.status).toBe(401);
+    });
+
+    it("rejects empty ticket parameter", async () => {
+      const res = await app.request("/api/files/download?ticket=");
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe("initData auth_date expiry (issue #227)", () => {
+    it("rejects initData with auth_date older than 24 hours", async () => {
+      const staleAuthDate = String(Math.floor(Date.now() / 1000) - 86401);
+      const initData = makeInitData(TEST_USER, {
+        extraParams: { auth_date: staleAuthDate },
+      });
+      const res = await app.request("/api/test", {
+        headers: { Authorization: `tma ${initData}` },
+      });
+      expect(res.status).toBe(401);
+      const body = (await res.json()) as { error: string };
+      expect(body.error).toBe("Invalid Telegram auth");
+    });
+
+    it("accepts initData with auth_date within 24 hours", async () => {
+      // makeInitData already sets auth_date to now — just verify it works
+      const initData = makeInitData(TEST_USER);
+      const res = await app.request("/api/test", {
+        headers: { Authorization: `tma ${initData}` },
+      });
+      expect(res.status).toBe(200);
     });
   });
 });

--- a/apps/server/src/routes/__tests__/auth.test.ts
+++ b/apps/server/src/routes/__tests__/auth.test.ts
@@ -246,6 +246,69 @@ describe("telegramAuth middleware", () => {
     });
   });
 
+  describe("multi-bot token support (TELEGRAM_BOT_TOKENS)", () => {
+    const SECOND_BOT_TOKEN = "654321:XYZ-TOKEN2ndBot-abcdef";
+
+    it("accepts initData signed by the second token in TELEGRAM_BOT_TOKENS list", async () => {
+      const originalSingle = process.env.TELEGRAM_BOT_TOKEN;
+      const hadMulti = "TELEGRAM_BOT_TOKENS" in process.env;
+      const originalMulti = process.env.TELEGRAM_BOT_TOKENS;
+      process.env.TELEGRAM_BOT_TOKENS = `${TEST_BOT_TOKEN},${SECOND_BOT_TOKEN}`;
+      delete process.env.TELEGRAM_BOT_TOKEN;
+      try {
+        const initData = makeInitData(TEST_USER, { botToken: SECOND_BOT_TOKEN });
+        const res = await app.request("/api/test", {
+          headers: { Authorization: `tma ${initData}` },
+        });
+        expect(res.status).toBe(200);
+      } finally {
+        if (originalSingle !== undefined) {
+          process.env.TELEGRAM_BOT_TOKEN = originalSingle;
+        }
+        if (hadMulti) {
+          process.env.TELEGRAM_BOT_TOKENS = originalMulti;
+        } else {
+          delete process.env.TELEGRAM_BOT_TOKENS;
+        }
+      }
+    });
+
+    it("rejects initData when no token in TELEGRAM_BOT_TOKENS matches", async () => {
+      const originalSingle = process.env.TELEGRAM_BOT_TOKEN;
+      const hadMulti = "TELEGRAM_BOT_TOKENS" in process.env;
+      const originalMulti = process.env.TELEGRAM_BOT_TOKENS;
+      process.env.TELEGRAM_BOT_TOKENS = `${TEST_BOT_TOKEN},${SECOND_BOT_TOKEN}`;
+      delete process.env.TELEGRAM_BOT_TOKEN;
+      try {
+        const initData = makeInitData(TEST_USER, { botToken: "999999:UNREGISTERED-TOKEN" });
+        const res = await app.request("/api/test", {
+          headers: { Authorization: `tma ${initData}` },
+        });
+        expect(res.status).toBe(401);
+        const body = (await res.json()) as { error: string };
+        expect(body.error).toBe("Invalid Telegram auth");
+      } finally {
+        if (originalSingle !== undefined) {
+          process.env.TELEGRAM_BOT_TOKEN = originalSingle;
+        }
+        if (hadMulti) {
+          process.env.TELEGRAM_BOT_TOKENS = originalMulti;
+        } else {
+          delete process.env.TELEGRAM_BOT_TOKENS;
+        }
+      }
+    });
+
+    it("falls back to TELEGRAM_BOT_TOKEN when TELEGRAM_BOT_TOKENS is not set", async () => {
+      // Default test env already has TELEGRAM_BOT_TOKEN set — just verify existing behavior
+      const initData = makeInitData(TEST_USER);
+      const res = await app.request("/api/test", {
+        headers: { Authorization: `tma ${initData}` },
+      });
+      expect(res.status).toBe(200);
+    });
+  });
+
   describe("ticket format bypass (issue #225)", () => {
     it("bypasses auth for a valid hex-32 ticket on /api/files/download", async () => {
       const res = await app.request(

--- a/apps/server/src/routes/__tests__/auth.test.ts
+++ b/apps/server/src/routes/__tests__/auth.test.ts
@@ -376,5 +376,25 @@ describe("telegramAuth middleware", () => {
       const body = (await res.json()) as { error: string };
       expect(body.error).toMatch(/ambiguous/i);
     });
+
+    it("returns 400 when ?ticket= is empty string but ?path= is present", async () => {
+      // Empty-string ticket value: key is present so the guard must fire.
+      // A truthiness check (ticket && filePath) would miss this case.
+      const res = await app.request(
+        "/api/files/download?ticket=&path=/some/file.txt",
+      );
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as { error: string };
+      expect(body.error).toMatch(/ambiguous/i);
+    });
+
+    it("returns 400 when ?ticket= is present but ?path= is empty string", async () => {
+      const res = await app.request(
+        "/api/files/download?ticket=deadbeef00000000deadbeef00000000&path=",
+      );
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as { error: string };
+      expect(body.error).toMatch(/ambiguous/i);
+    });
   });
 });

--- a/apps/server/src/routes/__tests__/prs-routes.test.ts
+++ b/apps/server/src/routes/__tests__/prs-routes.test.ts
@@ -1,0 +1,316 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { execFile, execFileSync } from "node:child_process";
+import { existsSync, readdirSync } from "node:fs";
+import type { PrRow, RepoInfo } from "../prs.js";
+
+/**
+ * Tests for the HTTP route handlers in `prs.ts`:
+ *   - GET /           — snapshot of PRs + repo summary
+ *   - POST /refresh   — force-poll and return diff counts
+ *   - GET /current-branch-scope — list active branches
+ *
+ * The pure-logic tests (parseGitRemote, diffSnapshots, PrPoller backoff,
+ * getSnapshot sorting) already live in pr-poller.test.ts. This file covers
+ * the Hono HTTP layer exclusively.
+ *
+ * Strategy:
+ *   - Use the exported __setPollerForTests() to inject a mock PrPoller so
+ *     no real `gh` CLI or `git` commands run.
+ *   - Use __resetScopeCacheForTests() to clear the scope cache between tests.
+ *   - Drive routes via Hono `app.request()`.
+ */
+
+// --- Helpers ---
+
+function makePr(overrides: Partial<PrRow> = {}): PrRow {
+  const num = overrides.number ?? 1;
+  return {
+    key: overrides.key ?? `claudes-world/claude-pocket-console#${num}`,
+    repo: overrides.repo ?? "claudes-world/claude-pocket-console",
+    number: num,
+    title: `PR #${num}`,
+    state: "OPEN",
+    isDraft: false,
+    headRefName: "feat/test",
+    author: "claude-do",
+    reviewDecision: null,
+    ciStatus: null,
+    url: `https://github.com/claudes-world/claude-pocket-console/pull/${num}`,
+    updatedAt: new Date().toISOString(),
+    firstSeen: Date.now(),
+    lastChanged: Date.now(),
+    ...overrides,
+  };
+}
+
+function makeRepoInfo(overrides: Partial<RepoInfo> = {}): RepoInfo {
+  // Use DISTINCT values for `name` (filesystem dir name) vs `repoName`
+  // (GitHub repo name) so the repo-shape test can assert the field mapping
+  // is correct and not passing by coincidence (same value in both fields).
+  return {
+    path: "/home/claude/code/tryinbox-sh",
+    name: "tryinbox-sh",          // filesystem dir name
+    owner: "claudes-world",
+    repoName: "inbox",            // GitHub repo name — intentionally different
+    fullName: "claudes-world/inbox",
+    branch: "dev",
+    ...overrides,
+  };
+}
+
+// We need to mock discoverRepos and currentBranchScope to avoid real git calls
+// from the /current-branch-scope route. Mock the module-level functions.
+vi.mock("node:fs", async () => {
+  const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+  return {
+    ...actual,
+    existsSync: vi.fn(actual.existsSync),
+    readdirSync: vi.fn(actual.readdirSync),
+  };
+});
+
+vi.mock("node:child_process", async () => {
+  const actual = await vi.importActual<typeof import("node:child_process")>(
+    "node:child_process",
+  );
+  return {
+    ...actual,
+    execFile: vi.fn((_cmd: string, _args: string[], _opts: any, cb?: any) => {
+      if (cb) cb(new Error("mocked"), "", "");
+      return { on: vi.fn() };
+    }),
+    execFileSync: vi.fn(() => {
+      throw new Error("mocked");
+    }),
+  };
+});
+
+const {
+  prsRoute,
+  PrPoller,
+  __setPollerForTests,
+  __resetScopeCacheForTests,
+  __resetRepoCacheForTests,
+} = await import("../prs.js");
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+let mockPoller: InstanceType<typeof PrPoller>;
+
+beforeEach(() => {
+  __resetScopeCacheForTests();
+  __resetRepoCacheForTests();
+  // Create a poller in static mode (empty repos = no network calls)
+  mockPoller = new PrPoller([], 999_999);
+  __setPollerForTests(mockPoller);
+});
+
+afterEach(() => {
+  __setPollerForTests(null);
+  vi.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// GET /
+// ---------------------------------------------------------------------------
+describe("GET /", () => {
+  it("returns ok:true with empty prs when poller has no data", async () => {
+    const res = await prsRoute.request("/");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      ok: boolean;
+      prs: PrRow[];
+      repos: any[];
+      lastPollOk: number;
+      lastPollErr: string | null;
+    };
+    expect(body.ok).toBe(true);
+    expect(body.prs).toEqual([]);
+    expect(body.repos).toEqual([]);
+    expect(body.lastPollErr).toBeNull();
+  });
+
+  it("returns PRs from the poller snapshot", async () => {
+    const pr1 = makePr({ number: 10, updatedAt: "2026-04-01T00:00:00Z" });
+    const pr2 = makePr({ number: 20, updatedAt: "2026-04-10T00:00:00Z" });
+    mockPoller.snapshot.set(pr1.key, pr1);
+    mockPoller.snapshot.set(pr2.key, pr2);
+
+    const res = await prsRoute.request("/");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ok: boolean; prs: PrRow[] };
+    expect(body.ok).toBe(true);
+    expect(body.prs).toHaveLength(2);
+    // Sorted by updatedAt descending
+    expect(body.prs[0].number).toBe(20);
+    expect(body.prs[1].number).toBe(10);
+  });
+
+  it("includes repos summary with correct field mapping and prCount", async () => {
+    // makeRepoInfo() uses DISTINCT name ("tryinbox-sh") vs repoName ("inbox")
+    // so we can prove the route maps them to the right response fields.
+    // The PR's repo must match the RepoInfo fullName so prCount === 1.
+    const pr = makePr({ number: 42, repo: "claudes-world/inbox", key: "claudes-world/inbox#42" });
+    mockPoller.snapshot.set(pr.key, pr);
+    mockPoller.discoveredRepos = [makeRepoInfo()];
+
+    const res = await prsRoute.request("/");
+    const body = (await res.json()) as {
+      repos: Array<{
+        name: string;
+        dirName: string;
+        org: string;
+        fullName: string;
+        branch: string;
+        prCount: number;
+      }>;
+    };
+    expect(body.repos).toHaveLength(1);
+    // name in the response = repoName (GitHub name), NOT the filesystem dir name
+    expect(body.repos[0].name).toBe("inbox");
+    // dirName = the filesystem directory name, different from name
+    expect(body.repos[0].dirName).toBe("tryinbox-sh");
+    expect(body.repos[0].org).toBe("claudes-world");
+    expect(body.repos[0].fullName).toBe("claudes-world/inbox");
+    expect(body.repos[0].branch).toBe("dev");
+    // PR.repo matches fullName → prCount must be 1
+    expect(body.repos[0].prCount).toBe(1);
+  });
+
+  it("shows prCount=0 for repos with no open PRs", async () => {
+    // No PRs in snapshot — prCount must be 0 regardless of repo identity
+    mockPoller.discoveredRepos = [makeRepoInfo()];
+
+    const res = await prsRoute.request("/");
+    const body = (await res.json()) as { repos: Array<{ prCount: number }> };
+    expect(body.repos[0].prCount).toBe(0);
+  });
+
+  it("exposes lastPollOk and lastPollErr", async () => {
+    mockPoller.lastPollOk = 1_700_000_000_000;
+    mockPoller.lastPollErr = "rate limited";
+
+    const res = await prsRoute.request("/");
+    const body = (await res.json()) as {
+      lastPollOk: number;
+      lastPollErr: string | null;
+    };
+    expect(body.lastPollOk).toBe(1_700_000_000_000);
+    expect(body.lastPollErr).toBe("rate limited");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /refresh
+// ---------------------------------------------------------------------------
+describe("POST /refresh", () => {
+  it("returns ok:true with diff counts after polling", async () => {
+    const res = await prsRoute.request("/refresh", { method: "POST" });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      ok: boolean;
+      prs: PrRow[];
+      repos: any[];
+      diff: { added: number; removed: number; changed: number };
+    };
+    expect(body.ok).toBe(true);
+    expect(body.diff).toEqual({ added: 0, removed: 0, changed: 0 });
+  });
+
+  it("reports diff counts when snapshot changes", async () => {
+    // Pre-populate snapshot with a PR that will be "removed" after poll
+    // (since static poller with empty repos produces empty snapshot)
+    const pr = makePr({ number: 99 });
+    mockPoller.snapshot.set(pr.key, pr);
+
+    const res = await prsRoute.request("/refresh", { method: "POST" });
+    const body = (await res.json()) as {
+      diff: { added: number; removed: number; changed: number };
+    };
+    // The old PR should be reported as removed since empty static repos
+    // yield an empty next snapshot
+    expect(body.diff.removed).toBe(1);
+  });
+
+  it("includes repos in response when discoveredRepos is set", async () => {
+    // pollOnce() in static mode clears discoveredRepos to [].
+    // The GET / route reads discoveredRepos without calling pollOnce,
+    // so test via GET / instead where we control the state directly.
+    // For POST /refresh, verify the repos key exists (even if empty in
+    // static mode since discoveredRepos is cleared by pollOnce).
+    const res = await prsRoute.request("/refresh", { method: "POST" });
+    const body = (await res.json()) as { repos: any[] };
+    expect(Array.isArray(body.repos)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /current-branch-scope
+// ---------------------------------------------------------------------------
+describe("GET /current-branch-scope", () => {
+  it("returns ok:true with branches array (empty when all git calls fail)", async () => {
+    // With child_process mocked to fail, discoverRepos returns [] (no repos found),
+    // so branches will be empty — the route must still return ok:true.
+    const res = await prsRoute.request("/current-branch-scope");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ok: boolean; branches: string[] };
+    expect(body.ok).toBe(true);
+    expect(Array.isArray(body.branches)).toBe(true);
+  });
+
+  it("returns branch names when discoverRepos and git worktree list succeed", async () => {
+    const mockExistsSync = vi.mocked(existsSync);
+    const mockReaddirSync = vi.mocked(readdirSync);
+    // Make codeDir exist and contain one repo dir
+    mockExistsSync.mockReturnValueOnce(true);  // existsSync(codeDir)
+    mockReaddirSync.mockReturnValueOnce(["claude-pocket-console"] as any);
+    // Make .git check pass for that repo
+    mockExistsSync.mockReturnValueOnce(true);  // existsSync(join(repoPath, '.git'))
+
+    // Override execFileSync for the two discoverRepos git calls:
+    //   1st call: git remote get-url origin → GitHub SSH URL
+    //   2nd call: git rev-parse --abbrev-ref HEAD → branch name
+    // Override execFile for the currentBranchScope worktree list call.
+    // The real readdirSync will iterate ~/code/* — the first directory with
+    // a .git dir will trigger both execFileSync calls.
+    const mockExecFileSync = vi.mocked(execFileSync);
+    // remote URL call
+    mockExecFileSync.mockImplementationOnce(() => "git@github.com:claudes-world/claude-pocket-console.git" as any);
+    // branch call
+    mockExecFileSync.mockImplementationOnce(() => "feat/server-route-tests\n" as any);
+
+    const mockExecFile = vi.mocked(execFile);
+    // worktree list call — return a porcelain block with two worktrees
+    mockExecFile.mockImplementationOnce((_cmd: any, _args: any, _opts: any, cb?: any) => {
+      const worktreeOutput = [
+        "worktree /home/claude/code/claude-pocket-console",
+        "HEAD abc123",
+        "branch refs/heads/feat/server-route-tests",
+        "",
+        "worktree /home/claude/code/claude-pocket-console-feat-test",
+        "HEAD def456",
+        "branch refs/heads/feat/another-branch",
+        "",
+      ].join("\n");
+      if (cb) cb(null, worktreeOutput, "");
+      return { on: vi.fn() } as any;
+    });
+
+    const res = await prsRoute.request("/current-branch-scope");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ok: boolean; branches: string[] };
+    expect(body.ok).toBe(true);
+    expect(Array.isArray(body.branches)).toBe(true);
+    // Must include the branch names returned by the mocked git calls
+    expect(body.branches).toContain("feat/server-route-tests");
+    expect(body.branches).toContain("feat/another-branch");
+    // Must not have duplicates for the same branch seen in both HEAD and worktree
+    const seen = new Set<string>();
+    for (const b of body.branches) {
+      expect(seen.has(b)).toBe(false);
+      seen.add(b);
+    }
+  });
+});

--- a/apps/server/src/routes/__tests__/telegram.test.ts
+++ b/apps/server/src/routes/__tests__/telegram.test.ts
@@ -1,0 +1,140 @@
+import { resolve } from "node:path";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+/**
+ * Tests for the /send-to-chat endpoint in telegram.ts.
+ *
+ * Covers:
+ *   1. Missing filePath returns 400
+ *   2. Disallowed filePath returns 403 (path validation)
+ *   3. Happy path: allowed path triggers fetch to Telegram API, returns messageId
+ *   4. Telegram API failure surfaces as 500
+ */
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+// Mock path-allowed: allow only paths starting with /home/claude/code
+// Uses resolve() to normalize traversals (e.g. /../..) like the real impl.
+vi.mock("../../lib/path-allowed.js", () => ({
+  ALLOWED_FILE_ROOTS: ["/home/claude/code"],
+  isPathAllowed: async (candidate: string, _roots: string[]) => {
+    const resolved = resolve(candidate);
+    return resolved.startsWith("/home/claude/code/");
+  },
+}));
+
+// Mock getTelegramCreds so we don't need real secrets
+vi.mock("../utils.js", async () => {
+  const real = await vi.importActual<typeof import("../utils.js")>("../utils.js");
+  return {
+    ...real,
+    getTelegramCreds: async () => ({
+      botToken: "test-bot-token",
+      chatId: "12345",
+    }),
+  };
+});
+
+// We need to mock global fetch
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+const { telegramRoute } = await import("../telegram.js");
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+// ---------------------------------------------------------------------------
+// POST /send-to-chat
+// ---------------------------------------------------------------------------
+describe("POST /send-to-chat", () => {
+  it("returns 400 when filePath is missing", async () => {
+    const res = await telegramRoute.request("/send-to-chat", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { ok: boolean; error: string };
+    expect(body.ok).toBe(false);
+    expect(body.error).toBe("filePath required");
+  });
+
+  it("returns 403 for a disallowed filePath", async () => {
+    const res = await telegramRoute.request("/send-to-chat", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ filePath: "/etc/passwd" }),
+    });
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { ok: boolean; error: string };
+    expect(body.ok).toBe(false);
+    expect(body.error).toBe("Access denied");
+  });
+
+  it("returns 403 for path traversal attempt", async () => {
+    const res = await telegramRoute.request("/send-to-chat", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ filePath: "/home/claude/code/../../../etc/shadow" }),
+    });
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { ok: boolean; error: string };
+    expect(body.ok).toBe(false);
+    expect(body.error).toBe("Access denied");
+  });
+
+  it("sends message via fetch and returns messageId on success", async () => {
+    mockFetch.mockResolvedValueOnce({
+      json: async () => ({ ok: true, result: { message_id: 42 } }),
+    });
+
+    const res = await telegramRoute.request("/send-to-chat", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ filePath: "/home/claude/code/test-file.ts" }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ok: boolean; messageId: number };
+    expect(body.ok).toBe(true);
+    expect(body.messageId).toBe(42);
+
+    // Verify fetch was called with the right URL and payload
+    expect(mockFetch).toHaveBeenCalledOnce();
+    const [url, opts] = mockFetch.mock.calls[0];
+    expect(url).toBe("https://api.telegram.org/bottest-bot-token/sendMessage");
+    expect(opts.method).toBe("POST");
+    expect(opts.headers["Content-Type"]).toBe("application/json");
+    const payload = JSON.parse(opts.body);
+    expect(payload.chat_id).toBe("12345");
+    expect(payload.parse_mode).toBe("MarkdownV2");
+    // The text should contain the shortened path
+    expect(payload.text).toContain("~/code/test\\-file\\.ts");
+  });
+
+  it("does not call fetch when path is disallowed", async () => {
+    await telegramRoute.request("/send-to-chat", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ filePath: "/tmp/evil" }),
+    });
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("returns 500 when fetch throws", async () => {
+    mockFetch.mockRejectedValueOnce(new Error("network failure"));
+
+    const res = await telegramRoute.request("/send-to-chat", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ filePath: "/home/claude/code/test-file.ts" }),
+    });
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as { ok: boolean; error: string };
+    expect(body.ok).toBe(false);
+    expect(body.error).toBe("network failure");
+  });
+});

--- a/apps/server/src/routes/__tests__/telegram.test.ts
+++ b/apps/server/src/routes/__tests__/telegram.test.ts
@@ -89,6 +89,7 @@ describe("POST /send-to-chat", () => {
 
   it("sends message via fetch and returns messageId on success", async () => {
     mockFetch.mockResolvedValueOnce({
+      ok: true,
       json: async () => ({ ok: true, result: { message_id: 42 } }),
     });
 
@@ -136,5 +137,22 @@ describe("POST /send-to-chat", () => {
     const body = (await res.json()) as { ok: boolean; error: string };
     expect(body.ok).toBe(false);
     expect(body.error).toBe("network failure");
+  });
+
+  it("returns 502 when Telegram returns ok:false", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ ok: false, description: "Bad Request: chat not found" }),
+    });
+
+    const res = await telegramRoute.request("/send-to-chat", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ filePath: "/home/claude/code/test-file.ts" }),
+    });
+    expect(res.status).toBe(502);
+    const body = (await res.json()) as { ok: boolean; error: string };
+    expect(body.ok).toBe(false);
+    expect(body.error).toBe("Bad Request: chat not found");
   });
 });

--- a/apps/server/src/routes/__tests__/utils.test.ts
+++ b/apps/server/src/routes/__tests__/utils.test.ts
@@ -1,0 +1,375 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Tests for `utils.ts` — shared utility functions and constants.
+ *
+ * Coverage:
+ *   - TMUX_SESSION validation (module-load-time regex guard)
+ *   - sendToTmux — calls execFile with correct args, literal flag, and --
+ *   - tgRaw / tgSanitize — Telegram MarkdownV2 escaping
+ *   - loadOpenAIEnv / loadAnthropicEnv — secrets file loading
+ *   - Exported constants (HOME, CLAUDES_WORLD, SESSION_NAMES_FILE)
+ *
+ * NOT covered here (see rationale in the getTelegramCreds section below):
+ *   - getTelegramCreds — parsing logic not unit-tested; see section comment
+ *
+ * Strategy:
+ *   - Mock `node:child_process` to spy on execFile without running real tmux/bash.
+ *   - Mock `node:fs` readFileSync for secrets file loading.
+ *   - Use real tgRaw/tgSanitize (pure functions, no side effects).
+ */
+
+// ---------------------------------------------------------------------------
+// Mocks — must be declared before dynamic imports
+// ---------------------------------------------------------------------------
+
+const execFileSpy = vi.fn(
+  (_cmd: string, _args: string[], _opts: any, cb?: (err: Error | null, stdout: string, stderr: string) => void) => {
+    if (cb) cb(null, "", "");
+  },
+);
+
+vi.mock("node:child_process", async () => {
+  const actual = await vi.importActual<typeof import("node:child_process")>(
+    "node:child_process",
+  );
+  return {
+    ...actual,
+    exec: vi.fn(
+      (_cmd: string, _opts: any, cb?: (err: Error | null, stdout: string, stderr: string) => void) => {
+        if (cb) cb(null, "", "");
+      },
+    ),
+    execFile: execFileSpy,
+  };
+});
+
+// Mock readFileSync for secrets loading tests. Keep a reference to control
+// per-test behavior.
+const readFileSyncSpy = vi.fn((_path: string, _enc?: string) => "");
+
+vi.mock("node:fs", async () => {
+  const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+  return {
+    ...actual,
+    readFileSync: (...args: any[]) => readFileSyncSpy(...args),
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Import AFTER mocks
+// ---------------------------------------------------------------------------
+
+const {
+  TMUX_SESSION,
+  HOME,
+  CLAUDES_WORLD,
+  SESSION_NAMES_FILE,
+  tgRaw,
+  tgSanitize,
+  sendToTmux,
+  loadOpenAIEnv,
+  loadAnthropicEnv,
+  execAsync,
+} = await import("../utils.js");
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+let savedEnv: NodeJS.ProcessEnv;
+
+beforeEach(() => {
+  execFileSpy.mockClear();
+  readFileSyncSpy.mockClear();
+  // Snapshot env to prevent cross-test state bleed from loadOpenAIEnv / loadAnthropicEnv
+  savedEnv = { ...process.env };
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+  // Restore full env snapshot
+  for (const key of Object.keys(process.env)) {
+    if (!(key in savedEnv)) delete process.env[key];
+  }
+  Object.assign(process.env, savedEnv);
+});
+
+// ---------------------------------------------------------------------------
+// Exported constants
+// ---------------------------------------------------------------------------
+describe("exported constants", () => {
+  it("TMUX_SESSION is a valid identifier (alphanumerics, hyphens, underscores, dots)", () => {
+    expect(TMUX_SESSION).toMatch(/^[A-Za-z0-9_.-]+$/);
+  });
+
+  it("HOME is set", () => {
+    expect(typeof HOME).toBe("string");
+    expect(HOME.length).toBeGreaterThan(0);
+  });
+
+  it("CLAUDES_WORLD is HOME/claudes-world", () => {
+    expect(CLAUDES_WORLD).toBe(`${HOME}/claudes-world`);
+  });
+
+  it("SESSION_NAMES_FILE is under CLAUDES_WORLD", () => {
+    expect(SESSION_NAMES_FILE).toBe(`${CLAUDES_WORLD}/.cpc-session-names`);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// tgRaw
+// ---------------------------------------------------------------------------
+describe("tgRaw", () => {
+  it("escapes each Telegram MarkdownV2 special character individually", () => {
+    // Use exact toBe assertions on single chars to catch double-escape bugs.
+    // toContain on a full string would pass even if output is "\\__" etc.
+    expect(tgRaw("_")).toBe("\\_");
+    expect(tgRaw("*")).toBe("\\*");
+    expect(tgRaw("[")).toBe("\\[");
+    expect(tgRaw("]")).toBe("\\]");
+    expect(tgRaw("(")).toBe("\\(");
+    expect(tgRaw(")")).toBe("\\)");
+    expect(tgRaw("~")).toBe("\\~");
+    expect(tgRaw("`")).toBe("\\`");
+    expect(tgRaw(">")).toBe("\\>");
+    expect(tgRaw("#")).toBe("\\#");
+    expect(tgRaw("+")).toBe("\\+");
+    expect(tgRaw("-")).toBe("\\-");
+    expect(tgRaw("=")).toBe("\\=");
+    expect(tgRaw("|")).toBe("\\|");
+    expect(tgRaw("{")).toBe("\\{");
+    expect(tgRaw("}")).toBe("\\}");
+    expect(tgRaw(".")).toBe("\\.");
+    expect(tgRaw("!")).toBe("\\!");
+    expect(tgRaw("\\")).toBe("\\\\");
+  });
+
+  it("leaves plain alphanumeric text unchanged", () => {
+    expect(tgRaw("hello123")).toBe("hello123");
+  });
+
+  it("escapes dots, tildes, and exclamation marks in strings", () => {
+    // ~ is a MarkdownV2 special character, so it gets escaped too
+    expect(tgRaw("~/code/test.ts")).toBe("\\~/code/test\\.ts");
+    expect(tgRaw("Done!")).toBe("Done\\!");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// tgSanitize
+// ---------------------------------------------------------------------------
+describe("tgSanitize", () => {
+  it("preserves *bold* markers while escaping outer text AND inner special chars", () => {
+    // Input has special chars both outside ("!") and inside ("." in "5.00") the
+    // bold markers. A no-op identity function would return the raw string — these
+    // assertions would fail because "!" and "." would be unescaped.
+    const result = tgSanitize("Price: *$5.00* today!");
+    // The asterisk markers must survive intact
+    expect(result).toMatch(/\*/);
+    // The dot inside bold must be escaped: *$5\.00*
+    expect(result).toContain("*$5\\.00*");
+    // The "!" outside bold must be escaped
+    expect(result).toContain("\\!");
+    // Identity function returns "Price: *$5.00* today!" — raw dot, unescaped "!"
+    expect(result).not.toBe("Price: *$5.00* today!");
+  });
+
+  it("preserves _italic_ markers while escaping inner special chars", () => {
+    // Dot inside italic must be escaped; dot after "details" (outside) also escaped.
+    const result = tgSanitize("See _v1.2_ for details.");
+    // Italic markers must survive
+    expect(result).toMatch(/_/);
+    // The dot inside italic must be escaped
+    expect(result).toContain("_v1\\.2_");
+    // The dot after "details" (outside italic) must also be escaped
+    expect(result).toContain("details\\.");
+    // Identity function would return raw input, which this test must reject
+    expect(result).not.toBe("See _v1.2_ for details.");
+  });
+
+  it("preserves `code` markers with inner content verbatim (no escaping inside code)", () => {
+    // tgSanitize holds code spans as placeholders, so raw content inside backticks
+    // survives unchanged. Special chars OUTSIDE backticks are still escaped.
+    const result = tgSanitize("Run `npm install` now!");
+    expect(result).toContain("`npm install`");
+    // The "!" outside code must still be escaped
+    expect(result).toContain("\\!");
+    // Identity function fails because "!" is unescaped in the raw input
+    expect(result).not.toBe("Run `npm install` now!");
+  });
+
+  it("escapes special characters outside of format markers", () => {
+    const result = tgSanitize("Hello. World!");
+    expect(result).toContain("\\.");
+    expect(result).toContain("\\!");
+  });
+
+  it("handles text with no special characters", () => {
+    expect(tgSanitize("plain text")).toBe("plain text");
+  });
+
+  it("handles text with only special characters", () => {
+    const result = tgSanitize("...");
+    expect(result).toBe("\\.\\.\\.");
+  });
+
+  it("escapes special chars inside *bold* content", () => {
+    const result = tgSanitize("*hello.world*");
+    // The dot inside bold should be escaped
+    expect(result).toContain("*hello\\.world*");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sendToTmux
+// ---------------------------------------------------------------------------
+describe("sendToTmux", () => {
+  it("calls execFile twice (send-keys with -l, then Enter)", async () => {
+    await sendToTmux("hello");
+    expect(execFileSpy).toHaveBeenCalledTimes(2);
+
+    // First call: literal text
+    const [cmd1, args1] = execFileSpy.mock.calls[0];
+    expect(cmd1).toBe("tmux");
+    expect(args1).toContain("send-keys");
+    expect(args1).toContain("-l");
+    expect(args1).toContain("-t");
+    expect(args1).toContain(TMUX_SESSION);
+    expect(args1).toContain("--");
+    expect(args1).toContain("hello");
+
+    // Second call: Enter key
+    const [cmd2, args2] = execFileSpy.mock.calls[1];
+    expect(cmd2).toBe("tmux");
+    expect(args2).toContain("send-keys");
+    expect(args2).toContain("Enter");
+    expect(args2).toContain("-t");
+    expect(args2).toContain(TMUX_SESSION);
+  });
+
+  it("passes timeout option to both execFile calls", async () => {
+    await sendToTmux("test");
+    // Both calls should have a timeout option
+    const [, , opts1] = execFileSpy.mock.calls[0];
+    const [, , opts2] = execFileSpy.mock.calls[1];
+    expect(opts1.timeout).toBe(5_000);
+    expect(opts2.timeout).toBe(5_000);
+  });
+
+  it("uses -- separator to prevent tmux from interpreting keys as options", async () => {
+    await sendToTmux("-dangerous-flag");
+    const [, args] = execFileSpy.mock.calls[0];
+    // The -- should appear before the key text
+    const dashDashIdx = args.indexOf("--");
+    const keyIdx = args.indexOf("-dangerous-flag");
+    expect(dashDashIdx).toBeGreaterThan(-1);
+    expect(keyIdx).toBeGreaterThan(dashDashIdx);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// loadOpenAIEnv / loadAnthropicEnv
+// ---------------------------------------------------------------------------
+describe("loadOpenAIEnv", () => {
+  it("reads the secrets file and sets env vars", () => {
+    const original = process.env.OPENAI_API_KEY;
+    delete process.env.OPENAI_API_KEY;
+    try {
+      readFileSyncSpy.mockReturnValueOnce("OPENAI_API_KEY=sk-test-key\n");
+      loadOpenAIEnv();
+      expect(readFileSyncSpy).toHaveBeenCalledTimes(1);
+      const [path] = readFileSyncSpy.mock.calls[0];
+      expect(path).toContain(".secrets/openai.env");
+      expect(process.env.OPENAI_API_KEY).toBe("sk-test-key");
+    } finally {
+      if (original === undefined) delete process.env.OPENAI_API_KEY;
+      else process.env.OPENAI_API_KEY = original;
+    }
+  });
+
+  it("does not overwrite existing env vars", () => {
+    const original = process.env.OPENAI_API_KEY;
+    process.env.OPENAI_API_KEY = "existing-key";
+    try {
+      readFileSyncSpy.mockReturnValueOnce("OPENAI_API_KEY=new-key\n");
+      loadOpenAIEnv();
+      expect(process.env.OPENAI_API_KEY).toBe("existing-key");
+    } finally {
+      if (original === undefined) delete process.env.OPENAI_API_KEY;
+      else process.env.OPENAI_API_KEY = original;
+    }
+  });
+
+  it("skips comment lines and blank lines", () => {
+    delete process.env.SOME_TEST_VAR;
+    try {
+      readFileSyncSpy.mockReturnValueOnce(
+        "# This is a comment\n\nSOME_TEST_VAR=value\n  \n",
+      );
+      loadOpenAIEnv();
+      expect(process.env.SOME_TEST_VAR).toBe("value");
+    } finally {
+      delete process.env.SOME_TEST_VAR;
+    }
+  });
+
+  it("gracefully handles missing secrets file", () => {
+    readFileSyncSpy.mockImplementationOnce(() => {
+      throw new Error("ENOENT");
+    });
+    // Should not throw
+    expect(() => loadOpenAIEnv()).not.toThrow();
+  });
+});
+
+describe("loadAnthropicEnv", () => {
+  it("reads the anthropic secrets file", () => {
+    const original = process.env.ANTHROPIC_API_KEY;
+    delete process.env.ANTHROPIC_API_KEY;
+    try {
+      readFileSyncSpy.mockReturnValueOnce("ANTHROPIC_API_KEY=sk-ant-test\n");
+      loadAnthropicEnv();
+      expect(readFileSyncSpy).toHaveBeenCalledTimes(1);
+      const [path] = readFileSyncSpy.mock.calls[0];
+      expect(path).toContain(".secrets/anthropic.env");
+      expect(process.env.ANTHROPIC_API_KEY).toBe("sk-ant-test");
+    } finally {
+      if (original === undefined) delete process.env.ANTHROPIC_API_KEY;
+      else process.env.ANTHROPIC_API_KEY = original;
+    }
+  });
+
+  it("gracefully handles missing secrets file", () => {
+    readFileSyncSpy.mockImplementationOnce(() => {
+      throw new Error("ENOENT");
+    });
+    expect(() => loadAnthropicEnv()).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getTelegramCreds
+// ---------------------------------------------------------------------------
+// getTelegramCreds is intentionally NOT unit-tested here.
+//
+// getTelegramCreds calls execAsync (the module-level `promisify(exec)` export).
+// To mock that at this level, we would need to mock `node:child_process` exec
+// AND ensure `execAsync` re-evaluates — but `execAsync` is a module-level
+// constant, not looked up fresh per-call. The correct seam is to mock
+// `../utils.js` as a whole (replacing execAsync directly), which is what
+// telegram.test.ts does. Note: telegram.test.ts stubs getTelegramCreds itself,
+// so the "botToken|||chatId" parsing logic in getTelegramCreds is not currently
+// covered by any unit test. It is exercised only through real integration runs.
+//
+// If a future refactor makes execAsync injectable (e.g. a parameter or DI),
+// add a focused unit test here at that point.
+
+// ---------------------------------------------------------------------------
+// execAsync
+// ---------------------------------------------------------------------------
+describe("execAsync", () => {
+  it("is exported and is a function", () => {
+    expect(typeof execAsync).toBe("function");
+  });
+});

--- a/apps/server/src/routes/files.ts
+++ b/apps/server/src/routes/files.ts
@@ -294,6 +294,14 @@ app.post("/download-ticket", async (c) => {
 
 app.get("/download", async (c) => {
   const ticket = c.req.query("ticket");
+  const filePath = c.req.query("path");
+
+  // Reject ambiguous requests that supply both ticket and path — the two auth
+  // modes are mutually exclusive and mixing them could mask logic errors.
+  if (ticket && filePath) {
+    return c.json({ error: "Ambiguous request: use ticket OR path, not both" }, 400);
+  }
+
   if (ticket) {
     // Pruning happens in the POST handler so the map doesn't grow unbounded;
     // the per-request expiry check below handles correctness on GET.
@@ -318,7 +326,6 @@ app.get("/download", async (c) => {
     return createDownloadResponse(file);
   }
 
-  const filePath = c.req.query("path");
   if (!filePath) {
     return c.json({ error: "path parameter required" }, 400);
   }

--- a/apps/server/src/routes/files.ts
+++ b/apps/server/src/routes/files.ts
@@ -296,12 +296,6 @@ app.get("/download", async (c) => {
   const ticket = c.req.query("ticket");
   const filePath = c.req.query("path");
 
-  // Reject ambiguous requests that supply both ticket and path — the two auth
-  // modes are mutually exclusive and mixing them could mask logic errors.
-  if (ticket && filePath) {
-    return c.json({ error: "Ambiguous request: use ticket OR path, not both" }, 400);
-  }
-
   if (ticket) {
     // Pruning happens in the POST handler so the map doesn't grow unbounded;
     // the per-request expiry check below handles correctness on GET.

--- a/apps/server/src/routes/telegram.ts
+++ b/apps/server/src/routes/telegram.ts
@@ -1,3 +1,4 @@
+import { resolve as resolvePath } from "node:path";
 import { Hono } from "hono";
 import { getTelegramCreds, tgRaw, tgSanitize } from "./utils.js";
 import { isPathAllowed, ALLOWED_FILE_ROOTS } from "../lib/path-allowed.js";
@@ -14,7 +15,8 @@ app.post("/send-to-chat", async (c) => {
 
   try {
     const { botToken, chatId } = await getTelegramCreds();
-    const shortPath = filePath.replace(/^\/home\/claude\//, "~/");
+    const normalizedPath = resolvePath(filePath);
+    const shortPath = normalizedPath.replace(/^\/home\/claude\//, "~/");
     const message = [
       `📄 *Shared from Pocket Console*`,
       ``,
@@ -30,6 +32,9 @@ app.post("/send-to-chat", async (c) => {
       body: JSON.stringify({ chat_id: chatId, text: message, parse_mode: "MarkdownV2" }),
     });
     const result = await response.json();
+    if (!response.ok || !result.ok) {
+      return c.json({ ok: false, error: result.description || "Telegram API error" }, 502);
+    }
     return c.json({ ok: true, messageId: result?.result?.message_id });
   } catch (err: any) {
     return c.json({ ok: false, error: err.message }, 500);

--- a/apps/server/src/routes/telegram.ts
+++ b/apps/server/src/routes/telegram.ts
@@ -1,11 +1,16 @@
 import { Hono } from "hono";
-import { getTelegramCreds, tgRaw, tgSanitize, execAsync } from "./utils.js";
+import { getTelegramCreds, tgRaw, tgSanitize } from "./utils.js";
+import { isPathAllowed, ALLOWED_FILE_ROOTS } from "../lib/path-allowed.js";
 
 const app = new Hono();
 
 app.post("/send-to-chat", async (c) => {
   const { filePath } = await c.req.json<{ filePath: string }>();
   if (!filePath) return c.json({ ok: false, error: "filePath required" }, 400);
+
+  if (!(await isPathAllowed(filePath, ALLOWED_FILE_ROOTS))) {
+    return c.json({ ok: false, error: "Access denied" }, 403);
+  }
 
   try {
     const { botToken, chatId } = await getTelegramCreds();
@@ -18,10 +23,13 @@ app.post("/send-to-chat", async (c) => {
       tgSanitize(`_User is sharing this file with you. Read it and consider how it relates to our current work. If you can infer the intent, act on it. If you need slight clarification, offer 2-3 multiple choice options so the user can respond quickly. Only ask an open-ended question if you truly cannot guess._`),
     ].join("\n");
 
-    const payload = JSON.stringify({ chat_id: chatId, text: message, parse_mode: "MarkdownV2" });
-    const curlCmd = `curl -s -X POST "https://api.telegram.org/bot${botToken}/sendMessage" -H "Content-Type: application/json" -d '${payload.replace(/'/g, "'\\''")}'`;
-    const { stdout } = await execAsync(curlCmd, { shell: "/bin/bash" });
-    const result = JSON.parse(stdout);
+    const url = `https://api.telegram.org/bot${botToken}/sendMessage`;
+    const response = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ chat_id: chatId, text: message, parse_mode: "MarkdownV2" }),
+    });
+    const result = await response.json();
     return c.json({ ok: true, messageId: result?.result?.message_id });
   } catch (err: any) {
     return c.json({ ok: false, error: err.message }, 500);

--- a/apps/server/src/routes/terminal-ws.ts
+++ b/apps/server/src/routes/terminal-ws.ts
@@ -1,6 +1,6 @@
 import { spawn, execSync } from "node:child_process";
 import type { WSContext } from "hono/ws";
-import { checkAuth, validateSession, validateJwtToken } from "../auth.js";
+import { checkAuth, validateSession, validateJwtTokenWithTokens, getBotTokens } from "../auth.js";
 import { isAllowedUser } from "../lib/allowed-users.js";
 // Import the validated TMUX_SESSION from routes/utils so we inherit the
 // `/^[A-Za-z0-9_.-]+$/` character-set check that runs once at module load.
@@ -61,15 +61,12 @@ export function terminalWsRoute(c: any) {
       }
 
       // Fallback: JWT token validation (keyboard button auth)
+      // Iterates all configured bot tokens (TELEGRAM_BOT_TOKENS or TELEGRAM_BOT_TOKEN)
+      // so multi-bot deployments work over WebSocket the same as over HTTP.
       if (!authResult.ok) {
-        const botToken = process.env.TELEGRAM_BOT_TOKEN;
-        if (botToken) {
-          const { valid: jwtValid, user: jwtUser } = validateJwtToken(token, botToken);
-          if (jwtValid && jwtUser) {
-            if (isAllowedUser(jwtUser.id)) {
-              authResult = { ok: true, user: jwtUser };
-            }
-          }
+        const { valid: jwtValid, user: jwtUser } = validateJwtTokenWithTokens(token, getBotTokens());
+        if (jwtValid && jwtUser && isAllowedUser(jwtUser.id)) {
+          authResult = { ok: true, user: jwtUser };
         }
       }
     }

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -9,6 +9,7 @@ import { VoiceRecorder } from "./components/VoiceRecorder";
 import { getTelegramWebApp, getAuthHeaders, hasAuth, setSessionToken } from "./lib/telegram";
 import { DebugOverlay } from "./debug/DebugOverlay";
 import { PrTicker } from "./components/PrTicker";
+import { HomeScreenPrompt } from "./components/HomeScreenPrompt";
 
 type Tab = "terminal" | "files" | "links" | "voice" | "prs";
 const TABS: Tab[] = ["terminal", "files", "links", "voice", "prs"];
@@ -88,6 +89,7 @@ function TabUnderline({
 
 const SORT_KEY = "cpc-file-sort-mode";
 const HIDDEN_KEY = "cpc-file-show-hidden";
+const HOME_SCREEN_PROMPT_KEY = "cpc:home-screen-prompted";
 const VALID_SORTS: SortMode[] = ["name-asc", "name-desc", "date-asc", "date-desc"];
 
 export function App() {
@@ -121,6 +123,7 @@ export function App() {
   const [viewingFile, setViewingFile] = useState<{ path: string; name: string } | null>(null);
   const [currentFolder, setCurrentFolder] = useState<string | null>(null);
   const [cpcBranch, setCpcBranch] = useState<string | null>(null);
+  const [showHomeScreenPrompt, setShowHomeScreenPrompt] = useState(false);
 
   const onConnectionChange = useCallback((c: boolean) => setConnected(c), []);
   const onReconnect = useCallback(() => {
@@ -232,6 +235,40 @@ export function App() {
     fetchCpcBranch();
     const interval = setInterval(fetchCpcBranch, 30000);
     return () => clearInterval(interval);
+  }, []);
+
+  // Home screen prompt — show once if not already added (Bot API 8.0+)
+  useEffect(() => {
+    try {
+      if (localStorage.getItem(HOME_SCREEN_PROMPT_KEY)) return;
+    } catch {
+      return; // storage blocked (private browsing, etc.) — skip silently
+    }
+
+    let active = true;
+    const timer = setTimeout(() => {
+      const twa = getTelegramWebApp();
+      if (!twa?.checkHomeScreenStatus) return; // older client — skip silently
+      twa.checkHomeScreenStatus((status) => {
+        if (active && status !== "added") {
+          setShowHomeScreenPrompt(true);
+        }
+      });
+    }, 3000);
+
+    return () => {
+      active = false;
+      clearTimeout(timer);
+    };
+  }, []);
+
+  const handleHomeScreenDismiss = useCallback(() => {
+    try {
+      localStorage.setItem(HOME_SCREEN_PROMPT_KEY, "1");
+    } catch {
+      // storage blocked — suppress silently, prompt won't re-appear this session
+    }
+    setShowHomeScreenPrompt(false);
   }, []);
 
   // The strip is (TABS.length * 100vw) wide. To show tab N we shift by -(N * 100vw).
@@ -417,6 +454,9 @@ export function App() {
           currentFolder={currentFolder}
         />
       </div>
+
+      {/* Home screen prompt — rendered once, dismissed to localStorage */}
+      {showHomeScreenPrompt && <HomeScreenPrompt onDismiss={handleHomeScreenDismiss} />}
 
       {/* Dev-only debug overlay — renders nothing on production hostnames */}
       <DebugOverlay />

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -11,10 +11,7 @@ import { DebugOverlay } from "./debug/DebugOverlay";
 import { PrTicker } from "./components/PrTicker";
 
 type Tab = "terminal" | "files" | "links" | "voice" | "prs";
-const BASE_TABS: Tab[] = ["terminal", "files", "links", "voice"];
-const TABS: Tab[] = import.meta.env.VITE_FEATURE_PR_TICKER
-  ? [...BASE_TABS, "prs"]
-  : BASE_TABS;
+const TABS: Tab[] = ["terminal", "files", "links", "voice", "prs"];
 const SWIPE_THRESHOLD = 120;
 
 // Moving blue underline indicator that tracks the active tab and follows
@@ -400,11 +397,9 @@ export function App() {
           <div style={{ width: `${100 / TABS.length}%`, height: "100%", flexShrink: 0 }}>
             <VoiceRecorder />
           </div>
-          {TABS.includes("prs") && (
-            <div style={{ width: `${100 / TABS.length}%`, height: "100%", flexShrink: 0 }}>
-              <PrTicker />
-            </div>
-          )}
+          <div style={{ width: `${100 / TABS.length}%`, height: "100%", flexShrink: 0 }}>
+            <PrTicker />
+          </div>
         </div>
       </div>
 

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -7,6 +7,7 @@ import { Links } from "./components/Links";
 import { ActionBar } from "./components/action-bar";
 import { VoiceRecorder } from "./components/VoiceRecorder";
 import { getTelegramWebApp, getAuthHeaders, hasAuth, setSessionToken } from "./lib/telegram";
+import { haptic } from "./lib/haptic";
 import { DebugOverlay } from "./debug/DebugOverlay";
 import { PrTicker } from "./components/PrTicker";
 import { HomeScreenPrompt } from "./components/HomeScreenPrompt";
@@ -181,8 +182,10 @@ export function App() {
     if (isDragging.current && Math.abs(dx) > SWIPE_THRESHOLD && Math.abs(dx) > Math.abs(dy) * 1.5) {
       const currentIdx = TABS.indexOf(activeTab);
       if (dx < 0 && currentIdx < TABS.length - 1) {
+        haptic.selection();
         setActiveTab(TABS[currentIdx + 1]);
       } else if (dx > 0 && currentIdx > 0) {
+        haptic.selection();
         setActiveTab(TABS[currentIdx - 1]);
       }
     }
@@ -340,7 +343,7 @@ export function App() {
             <button
               ref={(el) => { tabRefs.current[i] = el; }}
               key={tab}
-              onClick={() => { setIsAnimating(true); setActiveTab(tab); }}
+              onClick={() => { haptic.selection(); setIsAnimating(true); setActiveTab(tab); }}
               style={{
                 padding: "8px 14px",
                 fontSize: 13,

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -423,7 +423,7 @@ export function App() {
           onTransitionEnd={() => setIsAnimating(false)}
         >
           <div style={{ width: `${100 / TABS.length}%`, height: "100%", flexShrink: 0 }}>
-            <Terminal key={reconnectKey} onConnectionChange={onConnectionChange} />
+            <Terminal key={reconnectKey} onConnectionChange={onConnectionChange} isActive={activeTab === "terminal"} />
           </div>
           <div style={{ width: `${100 / TABS.length}%`, height: "100%", flexShrink: 0 }}>
             <FileViewer onClose={() => setActiveTab("terminal")} initialFile={initialFilePath} showHidden={fileShowHidden} sortMode={fileSortMode} onSortModeChange={setFileSortMode} onViewChange={setViewingFile} onPathChange={setCurrentFolder} />

--- a/apps/web/src/__tests__/HomeScreenPrompt.test.tsx
+++ b/apps/web/src/__tests__/HomeScreenPrompt.test.tsx
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import { HomeScreenPrompt } from "../components/HomeScreenPrompt";
+
+// --- Mocks ---
+
+// Mock getTelegramWebApp so we control addToHomeScreen
+let mockAddToHomeScreen: ReturnType<typeof vi.fn>;
+let mockCheckHomeScreenStatus: ReturnType<typeof vi.fn> | undefined;
+
+vi.mock("../lib/telegram", () => ({
+  getTelegramWebApp: () => ({
+    addToHomeScreen: mockAddToHomeScreen,
+    checkHomeScreenStatus: mockCheckHomeScreenStatus,
+  }),
+  getAuthHeaders: () => ({}),
+  hasAuth: () => true,
+  setSessionToken: vi.fn(),
+}));
+
+// Mock localStorage
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: vi.fn((key: string) => store[key] ?? null),
+    setItem: vi.fn((key: string, val: string) => { store[key] = val; }),
+    removeItem: vi.fn((key: string) => { delete store[key]; }),
+    clear: vi.fn(() => { store = {}; }),
+  };
+})();
+Object.defineProperty(window, "localStorage", { value: localStorageMock, writable: true });
+
+beforeEach(() => {
+  localStorageMock.clear();
+  localStorageMock.getItem.mockClear();
+  localStorageMock.setItem.mockClear();
+  mockAddToHomeScreen = vi.fn();
+  mockCheckHomeScreenStatus = vi.fn();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// --- Component tests ---
+
+describe("HomeScreenPrompt", () => {
+  it("renders the prompt with Add and Not now buttons", () => {
+    const onDismiss = vi.fn();
+    render(<HomeScreenPrompt onDismiss={onDismiss} />);
+
+    expect(screen.getByText("Add to Home Screen")).toBeInTheDocument();
+    expect(screen.getByText("Add")).toBeInTheDocument();
+    expect(screen.getByText("Not now")).toBeInTheDocument();
+  });
+
+  it("calls onDismiss when 'Not now' is clicked", () => {
+    const onDismiss = vi.fn();
+    render(<HomeScreenPrompt onDismiss={onDismiss} />);
+
+    fireEvent.click(screen.getByText("Not now"));
+
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+    expect(mockAddToHomeScreen).not.toHaveBeenCalled();
+  });
+
+  it("calls addToHomeScreen and then onDismiss when 'Add' is clicked", () => {
+    const onDismiss = vi.fn();
+    render(<HomeScreenPrompt onDismiss={onDismiss} />);
+
+    fireEvent.click(screen.getByText("Add"));
+
+    expect(mockAddToHomeScreen).toHaveBeenCalledTimes(1);
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+});
+
+// --- Hook logic tests (localStorage flag gate) ---
+
+describe("home screen prompt localStorage gate", () => {
+  it("does not show prompt when localStorage flag is already set", () => {
+    // Pre-set the flag — the useEffect in App.tsx would bail early
+    localStorageMock.getItem.mockImplementation((key: string) => {
+      if (key === "cpc:home-screen-prompted") return "1";
+      return "";
+    });
+
+    // Verify the gate condition directly: if getItem returns truthy, skip
+    const flagSet = !!localStorageMock.getItem("cpc:home-screen-prompted");
+    expect(flagSet).toBe(true);
+  });
+
+  it("handleHomeScreenDismiss sets the localStorage flag and hides the prompt", () => {
+    const onDismiss = vi.fn(() => {
+      // Simulate what handleHomeScreenDismiss does in App.tsx
+      localStorageMock.setItem("cpc:home-screen-prompted", "1");
+    });
+
+    render(<HomeScreenPrompt onDismiss={onDismiss} />);
+    fireEvent.click(screen.getByText("Not now"));
+
+    expect(localStorageMock.setItem).toHaveBeenCalledWith("cpc:home-screen-prompted", "1");
+  });
+
+  it("skips prompt silently when checkHomeScreenStatus is not available (older client)", () => {
+    // Simulate older Bot API: checkHomeScreenStatus is undefined
+    mockCheckHomeScreenStatus = undefined;
+
+    // The gate in App.tsx: if (!twa?.checkHomeScreenStatus) return
+    // Validate the mock reflects the absence correctly
+    const twa = { addToHomeScreen: mockAddToHomeScreen, checkHomeScreenStatus: mockCheckHomeScreenStatus };
+    expect(twa.checkHomeScreenStatus).toBeUndefined();
+  });
+
+  it("sets localStorage flag when Add is clicked via the prompt", async () => {
+    const onDismiss = vi.fn(() => {
+      localStorageMock.setItem("cpc:home-screen-prompted", "1");
+    });
+
+    render(<HomeScreenPrompt onDismiss={onDismiss} />);
+    await act(async () => {
+      fireEvent.click(screen.getByText("Add"));
+    });
+
+    expect(mockAddToHomeScreen).toHaveBeenCalledTimes(1);
+    expect(localStorageMock.setItem).toHaveBeenCalledWith("cpc:home-screen-prompted", "1");
+  });
+});

--- a/apps/web/src/__tests__/MarkdownViewer.test.tsx
+++ b/apps/web/src/__tests__/MarkdownViewer.test.tsx
@@ -1,0 +1,387 @@
+/**
+ * Tests for MarkdownViewer component.
+ *
+ * Covers: rendering basics, code blocks, tables, collapsible headings,
+ * external/internal link handling, and pre-block touch event plumbing.
+ */
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, createEvent } from "@testing-library/react";
+import { MarkdownViewer } from "../components/MarkdownViewer";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock("../components/MermaidDiagram", () => ({
+  MermaidDiagram: ({ source }: { source: string }) => (
+    <div className="mermaid-mount" data-testid="mermaid-diagram">
+      {source}
+    </div>
+  ),
+}));
+
+// Mock CSS imports pulled in by MarkdownViewer (highlight.js theme)
+vi.mock("highlight.js/styles/tokyo-night-dark.css", () => ({}));
+
+const mockOpenLink = vi.fn();
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function renderMd(content: string) {
+  return render(
+    <MarkdownViewer content={content} fileName="test.md" />,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Rendering basics
+// ---------------------------------------------------------------------------
+
+describe("MarkdownViewer — rendering basics", () => {
+  it("renders without crashing when content is empty string", () => {
+    const { container } = renderMd("");
+    expect(container.querySelector(".md-viewer-scroll")).toBeTruthy();
+    expect(container.querySelector(".md-content")).toBeTruthy();
+  });
+
+  it("renders .md-viewer-scroll outer container", () => {
+    const { container } = renderMd("hello");
+    expect(container.querySelector(".md-viewer-scroll")).toBeTruthy();
+  });
+
+  it("renders .md-content inner wrapper", () => {
+    const { container } = renderMd("hello");
+    expect(container.querySelector(".md-content")).toBeTruthy();
+  });
+
+  it("renders h1 heading from markdown", () => {
+    renderMd("# Title");
+    expect(screen.getByRole("heading", { level: 1 })).toBeTruthy();
+  });
+
+  it("renders h2 heading from markdown", () => {
+    renderMd("## Section\n\nsome content here");
+    expect(screen.getByRole("heading", { level: 2 })).toBeTruthy();
+  });
+
+  it("renders h3 heading from markdown", () => {
+    renderMd("### Sub-section\n\nsome content");
+    expect(screen.getByRole("heading", { level: 3 })).toBeTruthy();
+  });
+
+  it("renders bold text", () => {
+    const { container } = renderMd("**bold text**");
+    const strong = container.querySelector("strong");
+    expect(strong).toBeTruthy();
+    expect(strong!.textContent).toBe("bold text");
+  });
+
+  it("renders italic text", () => {
+    const { container } = renderMd("_italic text_");
+    const em = container.querySelector("em");
+    expect(em).toBeTruthy();
+    expect(em!.textContent).toBe("italic text");
+  });
+
+  it("renders unordered list", () => {
+    const { container } = renderMd("- alpha\n- beta\n- gamma");
+    const ul = container.querySelector("ul");
+    expect(ul).toBeTruthy();
+    const items = ul!.querySelectorAll("li");
+    expect(items.length).toBe(3);
+  });
+
+  it("renders ordered list", () => {
+    const { container } = renderMd("1. first\n2. second\n3. third");
+    const ol = container.querySelector("ol");
+    expect(ol).toBeTruthy();
+    const items = ol!.querySelectorAll("li");
+    expect(items.length).toBe(3);
+  });
+
+  it("renders inline code", () => {
+    const { container } = renderMd("use `console.log` here");
+    // Inline code renders as <code> not inside a <pre>
+    const codes = container.querySelectorAll("code");
+    const inlineCode = Array.from(codes).find(
+      (c) => c.closest("pre") === null,
+    );
+    expect(inlineCode).toBeTruthy();
+    expect(inlineCode!.textContent).toBe("console.log");
+  });
+
+  it("renders a blockquote", () => {
+    const { container } = renderMd("> This is a quote");
+    const bq = container.querySelector("blockquote");
+    expect(bq).toBeTruthy();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Code blocks
+// ---------------------------------------------------------------------------
+
+describe("MarkdownViewer — code blocks", () => {
+  it("renders fenced code block inside <pre><code>", () => {
+    const { container } = renderMd("```\nsome code\n```");
+    const pre = container.querySelector("pre");
+    expect(pre).toBeTruthy();
+    const code = pre!.querySelector("code");
+    expect(code).toBeTruthy();
+  });
+
+  it("fenced code block with language gets a language class", () => {
+    const { container } = renderMd("```typescript\nconst x = 1;\n```");
+    const pre = container.querySelector("pre");
+    expect(pre).toBeTruthy();
+    const code = pre!.querySelector("code");
+    expect(code).toBeTruthy();
+    // rehype-highlight may add hljs class; react-markdown sets language- class
+    expect(
+      code!.className.includes("language-typescript") ||
+        code!.className.includes("typescript"),
+    ).toBe(true);
+  });
+
+  it("mermaid code block renders via MermaidDiagram mock with .mermaid-mount", () => {
+    const { container } = renderMd("```mermaid\ngraph TD\nA-->B\n```");
+    const mount = container.querySelector(".mermaid-mount");
+    expect(mount).toBeTruthy();
+    // The mock renders the source text as content
+    expect(mount!.textContent).toContain("graph TD");
+    // Should NOT render a <pre> wrapping it
+    expect(mount!.closest("pre")).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tables
+// ---------------------------------------------------------------------------
+
+describe("MarkdownViewer — tables", () => {
+  const TABLE_MD =
+    "| Name | Age |\n| ---- | --- |\n| Alice | 30 |\n| Bob | 25 |";
+
+  it("GFM table is wrapped in .md-table-scroll div", () => {
+    const { container } = renderMd(TABLE_MD);
+    const scroll = container.querySelector(".md-table-scroll");
+    expect(scroll).toBeTruthy();
+    const table = scroll!.querySelector("table");
+    expect(table).toBeTruthy();
+  });
+
+  it("table contains <thead> and <tbody>", () => {
+    const { container } = renderMd(TABLE_MD);
+    const table = container.querySelector("table");
+    expect(table!.querySelector("thead")).toBeTruthy();
+    expect(table!.querySelector("tbody")).toBeTruthy();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Collapsible sections
+// ---------------------------------------------------------------------------
+
+describe("MarkdownViewer — collapsible sections", () => {
+  // h2 with following content so rehypeCollapsibleSections wraps it
+  const H2_MD = "## My Section\n\nSome paragraph text under this heading.";
+  const H1_MD = "# Document Title\n\nIntro paragraph.";
+
+  it("h2 heading renders with .cpc-collapsible-heading class", () => {
+    const { container } = renderMd(H2_MD);
+    const h2 = container.querySelector("h2");
+    expect(h2).toBeTruthy();
+    expect(h2!.className).toContain("cpc-collapsible-heading");
+  });
+
+  it("h2 heading contains a .cpc-fold-btn button", () => {
+    const { container } = renderMd(H2_MD);
+    const btn = container.querySelector(".cpc-fold-btn");
+    expect(btn).toBeTruthy();
+  });
+
+  it("h1 heading does NOT render .cpc-fold-btn (h1 is never collapsible)", () => {
+    const { container } = renderMd(H1_MD);
+    // h1 should exist
+    const h1 = container.querySelector("h1");
+    expect(h1).toBeTruthy();
+    // but it must not contain a fold button
+    const btn = h1!.querySelector(".cpc-fold-btn");
+    expect(btn).toBeNull();
+  });
+
+  it("clicking .cpc-fold-btn folds the section — adds .cpc-folded", () => {
+    const { container } = renderMd(H2_MD);
+    const btn = container.querySelector(".cpc-fold-btn") as HTMLElement;
+    expect(btn).toBeTruthy();
+
+    fireEvent.click(btn);
+
+    const folded = container.querySelector(".cpc-folded");
+    expect(folded).toBeTruthy();
+  });
+
+  it("folded section has aria-hidden='true'", () => {
+    const { container } = renderMd(H2_MD);
+    const btn = container.querySelector(".cpc-fold-btn") as HTMLElement;
+    fireEvent.click(btn);
+
+    const folded = container.querySelector("[aria-hidden='true']");
+    expect(folded).toBeTruthy();
+  });
+
+  it("clicking fold button again unfolds — .cpc-folded is removed", () => {
+    const { container } = renderMd(H2_MD);
+
+    // First click — fold
+    fireEvent.click(container.querySelector(".cpc-fold-btn") as HTMLElement);
+    expect(container.querySelector(".cpc-folded")).toBeTruthy();
+
+    // Re-query after React re-render, then unfold
+    fireEvent.click(container.querySelector(".cpc-fold-btn") as HTMLElement);
+    expect(container.querySelector(".cpc-folded")).toBeNull();
+  });
+
+  it("data-folded attribute on chevron reflects fold state", () => {
+    const { container } = renderMd(H2_MD);
+    const chevron = container.querySelector(".cpc-toggle-chevron") as HTMLElement;
+    expect(chevron).toBeTruthy();
+    // initially unfolded
+    expect(chevron.getAttribute("data-folded")).toBe("false");
+
+    const btn = container.querySelector(".cpc-fold-btn") as HTMLElement;
+    fireEvent.click(btn);
+
+    // After fold, the button re-renders — re-query the chevron
+    const chevronAfter = container.querySelector(
+      ".cpc-toggle-chevron",
+    ) as HTMLElement;
+    expect(chevronAfter.getAttribute("data-folded")).toBe("true");
+  });
+
+  // computeEffectiveHidden: hierarchical folding
+  it("folding a parent h2 also hides a child h3 section (hierarchical fold)", () => {
+    // Document with h2 parent and h3 child — folding the h2 must cascade to h3
+    const NESTED_MD =
+      "## Parent Section\n\n### Child Section\n\nChild paragraph.";
+    const { container } = renderMd(NESTED_MD);
+
+    // Both sections should start visible (no .cpc-folded)
+    const sections = container.querySelectorAll("section[data-fold-slug]");
+    expect(sections.length).toBeGreaterThanOrEqual(2);
+    sections.forEach((s) => expect(s.classList.contains("cpc-folded")).toBe(false));
+
+    // Click the h2 fold button (first button in document order)
+    const buttons = container.querySelectorAll(".cpc-fold-btn");
+    expect(buttons.length).toBeGreaterThanOrEqual(1);
+    fireEvent.click(buttons[0] as HTMLElement);
+
+    // After folding the h2, all .cpc-folded sections should be >= 1
+    // and the child h3 section must also be folded (cascaded via computeEffectiveHidden)
+    const foldedSections = container.querySelectorAll(".cpc-folded");
+    expect(foldedSections.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("sibling h2 section is not folded when only the first h2 is folded", () => {
+    // Two independent h2 sections — folding the first must not affect the second
+    const TWO_H2_MD =
+      "## Section A\n\nParagraph A.\n\n## Section B\n\nParagraph B.";
+    const { container } = renderMd(TWO_H2_MD);
+
+    const buttons = container.querySelectorAll(".cpc-fold-btn");
+    expect(buttons.length).toBeGreaterThanOrEqual(2);
+
+    // Fold only Section A (first button)
+    fireEvent.click(buttons[0] as HTMLElement);
+
+    const foldedSections = container.querySelectorAll(".cpc-folded");
+    // Only one section should be folded (Section A), not Section B
+    expect(foldedSections.length).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// External links
+// ---------------------------------------------------------------------------
+
+describe("MarkdownViewer — external links", () => {
+  beforeEach(() => {
+    mockOpenLink.mockReset();
+    Object.defineProperty(window, "Telegram", {
+      value: { WebApp: { openLink: mockOpenLink } },
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  it("external http link calls window.Telegram.WebApp.openLink on click", () => {
+    renderMd("[Visit](https://example.com)");
+    const link = screen.getByRole("link", { name: "Visit" });
+    fireEvent.click(link);
+    expect(mockOpenLink).toHaveBeenCalledWith("https://example.com");
+  });
+
+  it("external link click prevents default navigation", () => {
+    renderMd("[Visit](https://example.com)");
+    const link = screen.getByRole("link", { name: "Visit" });
+    // Use createEvent so we can spy on preventDefault directly.
+    const clickEvent = createEvent.click(link);
+    const preventDefaultSpy = vi.spyOn(clickEvent, "preventDefault");
+    fireEvent(link, clickEvent);
+    // Mechanism: default must be prevented
+    expect(preventDefaultSpy).toHaveBeenCalled();
+    // Behavior: Telegram's openLink must still have been invoked
+    expect(mockOpenLink).toHaveBeenCalledWith("https://example.com");
+  });
+
+  it("falls back to window.open when Telegram is unavailable", () => {
+    // Remove Telegram
+    Object.defineProperty(window, "Telegram", {
+      value: undefined,
+      writable: true,
+      configurable: true,
+    });
+    const openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
+
+    renderMd("[Open](https://external.io/page)");
+    const link = screen.getByRole("link", { name: "Open" });
+    fireEvent.click(link);
+
+    expect(openSpy).toHaveBeenCalledWith(
+      "https://external.io/page",
+      "_blank",
+      "noopener,noreferrer",
+    );
+    openSpy.mockRestore();
+  });
+
+  it("internal link does NOT call openLink", () => {
+    renderMd("[Internal](/some/path)");
+    const link = screen.getByRole("link", { name: "Internal" });
+    fireEvent.click(link);
+    expect(mockOpenLink).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Pre block touch handling
+// ---------------------------------------------------------------------------
+
+describe("MarkdownViewer — pre block touch handling", () => {
+  it("<pre> element stops touchmove propagation (parent handler not called)", () => {
+    const parentHandler = vi.fn();
+    const { container } = render(
+      // eslint-disable-next-line react/no-unknown-property
+      <div onTouchMove={parentHandler}>
+        <MarkdownViewer content={"```\nsome code here\n```"} fileName="test.md" />
+      </div>,
+    );
+    const pre = container.querySelector("pre") as HTMLElement;
+    expect(pre).toBeTruthy();
+    fireEvent.touchMove(pre);
+    expect(parentHandler).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/__tests__/Terminal.test.tsx
+++ b/apps/web/src/__tests__/Terminal.test.tsx
@@ -1,0 +1,382 @@
+/**
+ * Tests for Terminal component.
+ *
+ * Covers: DOM rendering, xterm initialization, WebSocket URL construction,
+ * auth fallback chain, connection state callbacks, message handling,
+ * cleanup on unmount, and ResizeObserver wiring.
+ */
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render } from "@testing-library/react";
+import { Terminal } from "../components/Terminal";
+
+// ---------------------------------------------------------------------------
+// WebSocket mock
+// ---------------------------------------------------------------------------
+
+class MockWebSocket {
+  static instances: MockWebSocket[] = [];
+  url: string;
+  onopen: (() => void) | null = null;
+  onmessage: ((e: { data: string }) => void) | null = null;
+  onclose: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  readyState = 0; // CONNECTING
+  close = vi.fn(() => {
+    this.readyState = 3;
+  });
+
+  constructor(url: string) {
+    this.url = url;
+    MockWebSocket.instances.push(this);
+  }
+
+  simulateOpen() {
+    this.readyState = 1;
+    this.onopen?.();
+  }
+  simulateMessage(data: unknown) {
+    this.onmessage?.({ data: JSON.stringify(data) });
+  }
+  simulateRawMessage(data: string) {
+    this.onmessage?.({ data });
+  }
+  simulateClose() {
+    this.readyState = 3;
+    this.onclose?.();
+  }
+  simulateError() {
+    this.onerror?.();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// XTerm mock
+// ---------------------------------------------------------------------------
+
+const mockTermWrite = vi.fn();
+const mockTermResize = vi.fn();
+const mockTermDispose = vi.fn();
+const mockTermOpen = vi.fn();
+const mockTermLoadAddon = vi.fn();
+const mockFitFit = vi.fn();
+
+vi.mock("@xterm/xterm", () => {
+  function MockXTerm() {
+    return {
+      loadAddon: mockTermLoadAddon,
+      open: mockTermOpen,
+      write: mockTermWrite,
+      resize: mockTermResize,
+      dispose: mockTermDispose,
+      cols: 80,
+      rows: 24,
+    };
+  }
+  return { Terminal: MockXTerm };
+});
+
+vi.mock("@xterm/addon-fit", () => {
+  function MockFitAddon() {
+    return { fit: mockFitFit };
+  }
+  return { FitAddon: MockFitAddon };
+});
+
+vi.mock("@xterm/addon-web-links", () => {
+  function MockWebLinksAddon() {
+    return {};
+  }
+  return { WebLinksAddon: MockWebLinksAddon };
+});
+
+// Mock CSS imported by Terminal.tsx
+vi.mock("@xterm/xterm/css/xterm.css", () => ({}));
+
+// ---------------------------------------------------------------------------
+// ResizeObserver mock
+// ---------------------------------------------------------------------------
+
+const mockResizeObserve = vi.fn();
+const mockResizeDisconnect = vi.fn();
+let resizeObserverCallback: ((entries: unknown[]) => void) | null = null;
+
+function MockResizeObserver(cb: (entries: unknown[]) => void) {
+  resizeObserverCallback = cb;
+  return {
+    observe: mockResizeObserve,
+    disconnect: mockResizeDisconnect,
+    _fire: () => cb([]),
+  };
+}
+
+global.ResizeObserver = MockResizeObserver as unknown as typeof ResizeObserver;
+
+// ---------------------------------------------------------------------------
+// beforeEach / afterEach
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  MockWebSocket.instances = [];
+  resizeObserverCallback = null;
+  vi.useFakeTimers();
+
+  mockTermWrite.mockClear();
+  mockTermResize.mockClear();
+  mockTermDispose.mockClear();
+  mockTermOpen.mockClear();
+  mockTermLoadAddon.mockClear();
+  mockFitFit.mockClear();
+  mockResizeObserve.mockClear();
+  mockResizeDisconnect.mockClear();
+
+  global.WebSocket = MockWebSocket as unknown as typeof WebSocket;
+  global.ResizeObserver = MockResizeObserver as unknown as typeof ResizeObserver;
+
+  Object.defineProperty(window, "location", {
+    value: {
+      protocol: "https:",
+      host: "cpc.claude.do",
+      search: "",
+      hash: "",
+    },
+    writable: true,
+    configurable: true,
+  });
+
+  // Clear Telegram WebApp stub
+  delete (window as unknown as Record<string, unknown>).Telegram;
+
+  localStorage.clear();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function renderTerminal(onConnectionChange = vi.fn()) {
+  return render(<Terminal onConnectionChange={onConnectionChange} />);
+}
+
+function getWs(): MockWebSocket {
+  expect(MockWebSocket.instances.length).toBeGreaterThan(0);
+  return MockWebSocket.instances[MockWebSocket.instances.length - 1];
+}
+
+// ---------------------------------------------------------------------------
+// DOM rendering
+// ---------------------------------------------------------------------------
+
+describe("DOM rendering", () => {
+  it("renders terminal-wrapper", () => {
+    const { getByTestId } = renderTerminal();
+    expect(getByTestId("terminal-wrapper")).toBeInTheDocument();
+  });
+
+  it("renders terminal-mount", () => {
+    const { getByTestId } = renderTerminal();
+    expect(getByTestId("terminal-mount")).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// xterm initialization
+// ---------------------------------------------------------------------------
+
+describe("xterm initialization", () => {
+  it("calls XTerm constructor on mount — term.open and loadAddon are invoked", () => {
+    // XTerm constructor is confirmed indirectly: open() is only reachable
+    // if a Terminal instance was successfully constructed.
+    renderTerminal();
+    expect(mockTermOpen).toHaveBeenCalledTimes(1);
+    // Two addons must be loaded: FitAddon and WebLinksAddon
+    expect(mockTermLoadAddon).toHaveBeenCalledTimes(2);
+  });
+
+  it("opens xterm to the mount div", () => {
+    const { getByTestId } = renderTerminal();
+    const mountDiv = getByTestId("terminal-mount");
+    expect(mockTermOpen).toHaveBeenCalledWith(mountDiv);
+  });
+
+  it("calls fit.fit() immediately and once more via rAF", () => {
+    renderTerminal();
+    // Immediate call from fit.fit() before rAF
+    expect(mockFitFit).toHaveBeenCalledTimes(1);
+    // Advance timers to flush the rAF
+    vi.runAllTimers();
+    expect(mockFitFit).toHaveBeenCalledTimes(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// WebSocket URL construction
+// ---------------------------------------------------------------------------
+
+describe("WebSocket URL construction", () => {
+  it("uses wss: when window.location.protocol is https:", () => {
+    renderTerminal();
+    const ws = getWs();
+    expect(ws.url).toMatch(/^wss:\/\//);
+  });
+
+  it("uses ws: when window.location.protocol is http:", () => {
+    Object.defineProperty(window, "location", {
+      value: { protocol: "http:", host: "localhost:5173", search: "", hash: "" },
+      writable: true,
+      configurable: true,
+    });
+    renderTerminal();
+    const ws = getWs();
+    expect(ws.url).toMatch(/^ws:\/\//);
+  });
+
+  it("uses ?auth= param when window.Telegram.WebApp.initData is set", () => {
+    // @ts-expect-error window.Telegram is not in lib types
+    window.Telegram = { WebApp: { initData: "tg-init-data-value" } };
+    renderTerminal();
+    const ws = getWs();
+    expect(ws.url).toContain("?auth=");
+    expect(ws.url).toContain(encodeURIComponent("tg-init-data-value"));
+    expect(ws.url).not.toContain("?token=");
+  });
+
+  it("falls back to ?token= from localStorage when no Telegram initData", () => {
+    localStorage.setItem("cpc-session-token", "saved-token-abc");
+    renderTerminal();
+    const ws = getWs();
+    expect(ws.url).toContain("?token=");
+    expect(ws.url).toContain(encodeURIComponent("saved-token-abc"));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Connection state callbacks
+// ---------------------------------------------------------------------------
+
+describe("connection state callbacks", () => {
+  it("calls onConnectionChange(true) when WS onopen fires", () => {
+    const onConnectionChange = vi.fn();
+    renderTerminal(onConnectionChange);
+    getWs().simulateOpen();
+    expect(onConnectionChange).toHaveBeenCalledWith(true);
+  });
+
+  it("calls onConnectionChange(false) when WS onclose fires", () => {
+    const onConnectionChange = vi.fn();
+    renderTerminal(onConnectionChange);
+    getWs().simulateClose();
+    expect(onConnectionChange).toHaveBeenCalledWith(false);
+  });
+
+  it("calls onConnectionChange(false) when WS onerror fires", () => {
+    const onConnectionChange = vi.fn();
+    renderTerminal(onConnectionChange);
+    getWs().simulateError();
+    expect(onConnectionChange).toHaveBeenCalledWith(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Message handling
+// ---------------------------------------------------------------------------
+
+describe("message handling", () => {
+  it("dimensions message calls term.resize(cols, rows) when smaller than viewport", () => {
+    renderTerminal();
+    // Mock terminal reports cols=80 rows=24; send a smaller pane
+    getWs().simulateMessage({ type: "dimensions", cols: 60, rows: 20 });
+    expect(mockTermResize).toHaveBeenCalledWith(60, 20);
+  });
+
+  it("dimensions message clips to viewport when pane is larger", () => {
+    renderTerminal();
+    // Terminal mock cols=80 rows=24; send a pane bigger than the viewport
+    getWs().simulateMessage({ type: "dimensions", cols: 200, rows: 50 });
+    // Math.min(200, 80) = 80, Math.min(50, 24) = 24 — same as viewport, no resize call
+    // The component only calls resize when the result differs from current dims
+    expect(mockFitFit).toHaveBeenCalled();
+    expect(mockTermResize).not.toHaveBeenCalled();
+  });
+
+  it("pane message writes screen-clear sequence followed by content with line endings", () => {
+    renderTerminal();
+    getWs().simulateMessage({ type: "pane", content: "hello\nworld" });
+    // First write must be the clear sequence
+    expect(mockTermWrite.mock.calls[0][0]).toBe("\x1b[2J\x1b[H");
+    // Content lines should be written individually with \r\n separators
+    expect(mockTermWrite).toHaveBeenCalledWith("hello");
+    expect(mockTermWrite).toHaveBeenCalledWith("\r\n");
+    expect(mockTermWrite).toHaveBeenCalledWith("world");
+  });
+
+  it("pane message trims trailing whitespace from each line", () => {
+    renderTerminal();
+    getWs().simulateMessage({ type: "pane", content: "line1   \nline2\t\n" });
+    const writtenArgs = mockTermWrite.mock.calls.map((c) => c[0]);
+    // No call should contain trailing spaces or tabs in line content
+    const lineWrites = writtenArgs.filter((a) => a !== "\x1b[2J\x1b[H" && a !== "\r\n");
+    for (const line of lineWrites) {
+      expect(line).toBe(line.trimEnd());
+    }
+  });
+
+  it("unparseable message writes raw data to terminal", () => {
+    renderTerminal();
+    getWs().simulateRawMessage("not-json{{{{");
+    expect(mockTermWrite).toHaveBeenCalledWith("not-json{{{{");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cleanup on unmount
+// ---------------------------------------------------------------------------
+
+describe("cleanup on unmount", () => {
+  it("calls ws.close() on unmount", () => {
+    const { unmount } = renderTerminal();
+    const ws = getWs();
+    unmount();
+    expect(ws.close).toHaveBeenCalled();
+  });
+
+  it("calls term.dispose() on unmount", () => {
+    const { unmount } = renderTerminal();
+    unmount();
+    expect(mockTermDispose).toHaveBeenCalled();
+  });
+
+  it("disconnects ResizeObserver on unmount", () => {
+    const { unmount } = renderTerminal();
+    unmount();
+    expect(mockResizeDisconnect).toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ResizeObserver
+// ---------------------------------------------------------------------------
+
+describe("ResizeObserver", () => {
+  it("observes mount div and calls fit.fit() when fired", () => {
+    const { getByTestId } = renderTerminal();
+    const mountDiv = getByTestId("terminal-mount");
+
+    // ResizeObserver should have been set up to observe the mount div
+    expect(mockResizeObserve).toHaveBeenCalledWith(mountDiv);
+
+    // Clear fit calls from init so we only count resize-triggered ones
+    mockFitFit.mockClear();
+
+    // Simulate a resize event by firing the captured callback
+    expect(resizeObserverCallback).not.toBeNull();
+    resizeObserverCallback!([]);
+
+    expect(mockFitFit).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/__tests__/haptic.test.ts
+++ b/apps/web/src/__tests__/haptic.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { haptic } from "../lib/haptic";
+
+// Mock getTelegramWebApp
+let mockHapticFeedback: {
+  impactOccurred: ReturnType<typeof vi.fn>;
+  notificationOccurred: ReturnType<typeof vi.fn>;
+  selectionChanged: ReturnType<typeof vi.fn>;
+} | undefined;
+
+vi.mock("../lib/telegram", () => ({
+  getTelegramWebApp: () =>
+    mockHapticFeedback
+      ? { HapticFeedback: mockHapticFeedback }
+      : { HapticFeedback: undefined },
+}));
+
+beforeEach(() => {
+  mockHapticFeedback = {
+    impactOccurred: vi.fn(),
+    notificationOccurred: vi.fn(),
+    selectionChanged: vi.fn(),
+  };
+});
+
+describe("haptic — HapticFeedback present", () => {
+  it("success() calls notificationOccurred('success')", () => {
+    haptic.success();
+    expect(mockHapticFeedback!.notificationOccurred).toHaveBeenCalledWith("success");
+  });
+
+  it("error() calls notificationOccurred('error')", () => {
+    haptic.error();
+    expect(mockHapticFeedback!.notificationOccurred).toHaveBeenCalledWith("error");
+  });
+
+  it("selection() calls selectionChanged()", () => {
+    haptic.selection();
+    expect(mockHapticFeedback!.selectionChanged).toHaveBeenCalled();
+  });
+
+  it("impact('medium') calls impactOccurred('medium')", () => {
+    haptic.impact("medium");
+    expect(mockHapticFeedback!.impactOccurred).toHaveBeenCalledWith("medium");
+  });
+
+  it("impact() defaults to 'light'", () => {
+    haptic.impact();
+    expect(mockHapticFeedback!.impactOccurred).toHaveBeenCalledWith("light");
+  });
+});
+
+describe("haptic — HapticFeedback absent (older client)", () => {
+  beforeEach(() => {
+    mockHapticFeedback = undefined;
+  });
+
+  it("success() is a no-op", () => {
+    expect(() => haptic.success()).not.toThrow();
+  });
+
+  it("error() is a no-op", () => {
+    expect(() => haptic.error()).not.toThrow();
+  });
+
+  it("selection() is a no-op", () => {
+    expect(() => haptic.selection()).not.toThrow();
+  });
+
+  it("impact() is a no-op", () => {
+    expect(() => haptic.impact("medium")).not.toThrow();
+  });
+});

--- a/apps/web/src/components/FileViewer.css
+++ b/apps/web/src/components/FileViewer.css
@@ -1,0 +1,50 @@
+/*
+ * FileViewer scrollbar styling.
+ *
+ * The default OS/dark-theme scrollbars disappear against the Tokyo Night
+ * background, making it hard to tell that long files / directory listings
+ * are scrollable at all. These rules paint the thumb in the existing
+ * cyan accent (--color-accent-cyan, #7dcfff) so it reads clearly without
+ * clashing with the rest of the palette.
+ *
+ * Scope: every selector is prefixed with .cpc-file-viewer so this only
+ * affects scrollable regions inside the FileViewer component — MarkdownViewer
+ * body, code <pre> blocks, directory listing, root-shortcut bar, etc. The
+ * rest of the app keeps its native scrollbars.
+ */
+
+.cpc-file-viewer,
+.cpc-file-viewer * {
+  /* Firefox — scrollbar-color does not cascade, so both the root element and
+     any scrollable descendants need the declaration explicitly. */
+  scrollbar-color: var(--color-accent-cyan) var(--color-bg-alt);
+  scrollbar-width: thin;
+}
+
+/* WebKit (Safari/Chrome/iOS) */
+.cpc-file-viewer ::-webkit-scrollbar,
+.cpc-file-viewer::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
+.cpc-file-viewer ::-webkit-scrollbar-track,
+.cpc-file-viewer::-webkit-scrollbar-track {
+  background: var(--color-bg-alt);
+}
+
+.cpc-file-viewer ::-webkit-scrollbar-thumb,
+.cpc-file-viewer::-webkit-scrollbar-thumb {
+  background: var(--color-accent-cyan);
+  border-radius: 4px;
+}
+
+.cpc-file-viewer ::-webkit-scrollbar-thumb:hover,
+.cpc-file-viewer::-webkit-scrollbar-thumb:hover {
+  background: var(--color-accent-blue);
+}
+
+.cpc-file-viewer ::-webkit-scrollbar-corner,
+.cpc-file-viewer::-webkit-scrollbar-corner {
+  background: var(--color-bg-alt);
+}

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -4,6 +4,7 @@ import { getAuthHeaders } from "../lib/telegram";
 import { MarkdownViewer } from "./MarkdownViewer";
 import { BottomSheet } from "./BottomSheet";
 import { getFileIcon } from "./file-icons";
+import "./FileViewer.css";
 
 const PASTE_MAX_BYTES = 1024 * 1024;
 
@@ -552,7 +553,7 @@ export function FileViewer({ onClose, initialFile, showHidden = false, sortMode 
   const shortPath = currentPath.replace("/home/claude/", "~/");
 
   return (
-    <div style={{ display: "flex", flexDirection: "column", height: "100%", width: "100%", maxWidth: "100%", overflowX: "hidden" }}>
+    <div className="cpc-file-viewer" style={{ display: "flex", flexDirection: "column", height: "100%", width: "100%", maxWidth: "100%", overflowX: "hidden" }}>
       {/* Root directory shortcuts */}
       {fileContent === null && (
         <div

--- a/apps/web/src/components/HomeScreenPrompt.tsx
+++ b/apps/web/src/components/HomeScreenPrompt.tsx
@@ -1,0 +1,71 @@
+import { getTelegramWebApp } from "../lib/telegram";
+
+interface HomeScreenPromptProps {
+  onDismiss: () => void;
+}
+
+export function HomeScreenPrompt({ onDismiss }: HomeScreenPromptProps) {
+  const handleAdd = () => {
+    getTelegramWebApp()?.addToHomeScreen?.();
+    onDismiss();
+  };
+
+  return (
+    <div
+      style={{
+        position: "fixed",
+        bottom: 64,
+        left: 12,
+        right: 12,
+        background: "var(--color-surface)",
+        border: "1px solid var(--color-border)",
+        borderRadius: 10,
+        padding: "12px 14px",
+        display: "flex",
+        alignItems: "center",
+        gap: 10,
+        zIndex: 100,
+        boxShadow: "0 4px 16px rgba(0,0,0,0.25)",
+      }}
+    >
+      <div style={{ flex: 1 }}>
+        <div style={{ fontSize: 13, fontWeight: 600, color: "var(--color-fg)", marginBottom: 2 }}>
+          Add to Home Screen
+        </div>
+        <div style={{ fontSize: 12, color: "var(--color-muted)" }}>
+          Quick access to Claude Pocket Console
+        </div>
+      </div>
+      <button
+        onClick={onDismiss}
+        style={{
+          background: "none",
+          border: "none",
+          color: "var(--color-muted)",
+          fontSize: 12,
+          cursor: "pointer",
+          padding: "4px 8px",
+          borderRadius: 6,
+        }}
+      >
+        Not now
+      </button>
+      <button
+        onClick={handleAdd}
+        style={{
+          background: "var(--color-accent-blue)",
+          border: "none",
+          color: "#fff",
+          fontSize: 12,
+          fontWeight: 600,
+          cursor: "pointer",
+          padding: "6px 12px",
+          borderRadius: 6,
+          whiteSpace: "nowrap",
+        }}
+      >
+        Add
+      </button>
+    </div>
+  );
+}

--- a/apps/web/src/components/PrTicker.tsx
+++ b/apps/web/src/components/PrTicker.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import { getAuthHeaders } from "../lib/telegram";
+import { haptic } from "../lib/haptic";
 
 // --- Types matching server PrRow ---
 
@@ -515,7 +516,7 @@ function PrRowItem({
 
   return (
     <div
-      onClick={() => onTap(pr.url)}
+      onClick={() => { haptic.impact("light"); onTap(pr.url); }}
       style={{
         padding: "10px 12px 10px 36px",
         borderBottom: `1px solid ${COLORS.border}`,

--- a/apps/web/src/components/Terminal.tsx
+++ b/apps/web/src/components/Terminal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import { Terminal as XTerm } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { WebLinksAddon } from "@xterm/addon-web-links";
@@ -6,15 +6,109 @@ import "@xterm/xterm/css/xterm.css";
 
 interface TerminalProps {
   onConnectionChange: (connected: boolean) => void;
+  isActive?: boolean;
 }
 
-export function Terminal({ onConnectionChange }: TerminalProps) {
+/** Build the WebSocket URL with auth params. */
+function buildWsUrl(): string {
+  const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
+  const initData = window.Telegram?.WebApp?.initData || "";
+  let authParam = "";
+  if (initData) {
+    authParam = `?auth=${encodeURIComponent(initData)}`;
+  } else {
+    // Fallback: URL token from keyboard button, then saved session token
+    const urlParams = new URLSearchParams(window.location.search);
+    const hashParams = new URLSearchParams(window.location.hash.replace(/^#[^&]*&?/, ""));
+    const urlToken = urlParams.get("token") || hashParams.get("token") || "";
+    const savedToken = localStorage.getItem("cpc-session-token") || "";
+    const token = urlToken || savedToken;
+    if (token) authParam = `?token=${encodeURIComponent(token)}`;
+  }
+  return `${protocol}//${window.location.host}/ws/terminal${authParam}`;
+}
+
+export function Terminal({ onConnectionChange, isActive }: TerminalProps) {
   const wrapperRef = useRef<HTMLDivElement>(null);
   const mountRef = useRef<HTMLDivElement>(null);
   const termRef = useRef<XTerm | null>(null);
   const wsRef = useRef<WebSocket | null>(null);
   const fitRef = useRef<FitAddon | null>(null);
 
+  // Stable ref for onConnectionChange so connectWs doesn't need it as a dep
+  const onConnectionChangeRef = useRef(onConnectionChange);
+  onConnectionChangeRef.current = onConnectionChange;
+
+  /** Open a WebSocket and wire it to the current xterm instance.
+   *  Closes any existing connection first to prevent duplicates. */
+  const connectWs = useCallback(() => {
+    const term = termRef.current;
+    const fit = fitRef.current;
+    if (!term || !fit) return;
+
+    // Tear down previous connection if still open
+    if (wsRef.current && wsRef.current.readyState <= WebSocket.OPEN) {
+      wsRef.current.close();
+    }
+
+    const ws = new WebSocket(buildWsUrl());
+
+    // Guard all handlers against stale sockets: if connectWs is called again
+    // before the previous socket finishes closing, the old socket's events
+    // must not overwrite state belonging to the new connection.
+    ws.onopen = () => {
+      if (wsRef.current !== ws) return;
+      onConnectionChangeRef.current(true);
+    };
+
+    ws.onmessage = (event) => {
+      if (wsRef.current !== ws) return;
+      try {
+        const msg = JSON.parse(event.data);
+        if (msg.type === "dimensions") {
+          // Use the SMALLER of tmux pane width and what fits in the viewport.
+          // This prevents text being cut off on narrow screens while still
+          // aligning correctly when the viewport is wider than the pane.
+          console.log(`[tmux pane] ${msg.cols}x${msg.rows}`);
+          if (msg.cols > 0 && msg.rows > 0) {
+            fit.fit(); // Calculate what fits in the viewport
+            const viewCols = term.cols;
+            const viewRows = term.rows;
+            const cols = Math.min(msg.cols, viewCols);
+            const rows = Math.min(msg.rows, viewRows);
+            if (cols !== viewCols || rows !== viewRows) {
+              term.resize(cols, rows);
+            }
+          }
+        } else if (msg.type === "pane") {
+          // Clear screen and write from top
+          term.write("\x1b[2J\x1b[H");
+          // Write each line, trimming trailing whitespace
+          const lines = msg.content.split("\n");
+          for (let i = 0; i < lines.length; i++) {
+            term.write(lines[i].trimEnd());
+            if (i < lines.length - 1) term.write("\r\n");
+          }
+        }
+      } catch {
+        term.write(event.data);
+      }
+    };
+
+    ws.onclose = () => {
+      if (wsRef.current !== ws) return;
+      onConnectionChangeRef.current(false);
+    };
+
+    ws.onerror = () => {
+      if (wsRef.current !== ws) return;
+      onConnectionChangeRef.current(false);
+    };
+
+    wsRef.current = ws;
+  }, []);
+
+  // Initialize xterm and open the first WS connection on mount
   useEffect(() => {
     if (!wrapperRef.current || !mountRef.current) return;
 
@@ -49,75 +143,13 @@ export function Terminal({ onConnectionChange }: TerminalProps) {
     termRef.current = term;
     fitRef.current = fit;
 
-    // Connect to WebSocket
-    const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
-    const initData = window.Telegram?.WebApp?.initData || "";
-    let authParam = "";
-    if (initData) {
-      authParam = `?auth=${encodeURIComponent(initData)}`;
-    } else {
-      // Fallback: URL token from keyboard button, then saved session token
-      const urlParams = new URLSearchParams(window.location.search);
-      const hashParams = new URLSearchParams(window.location.hash.replace(/^#[^&]*&?/, ""));
-      const urlToken = urlParams.get("token") || hashParams.get("token") || "";
-      const savedToken = localStorage.getItem("cpc-session-token") || "";
-      const token = urlToken || savedToken;
-      if (token) authParam = `?token=${encodeURIComponent(token)}`;
-    }
-    const wsUrl = `${protocol}//${window.location.host}/ws/terminal${authParam}`;
-    const ws = new WebSocket(wsUrl);
-
     fit.fit();
     const frameId = window.requestAnimationFrame(() => {
       fit.fit();
     });
 
-    ws.onopen = () => {
-      onConnectionChange(true);
-    };
-
-    ws.onmessage = (event) => {
-      try {
-        const msg = JSON.parse(event.data);
-        if (msg.type === "dimensions") {
-          // Use the SMALLER of tmux pane width and what fits in the viewport.
-          // This prevents text being cut off on narrow screens while still
-          // aligning correctly when the viewport is wider than the pane.
-          console.log(`[tmux pane] ${msg.cols}x${msg.rows}`);
-          if (msg.cols > 0 && msg.rows > 0) {
-            fit.fit(); // Calculate what fits in the viewport
-            const viewCols = term.cols;
-            const viewRows = term.rows;
-            const cols = Math.min(msg.cols, viewCols);
-            const rows = Math.min(msg.rows, viewRows);
-            if (cols !== viewCols || rows !== viewRows) {
-              term.resize(cols, rows);
-            }
-          }
-        } else if (msg.type === "pane") {
-          // Clear screen and write from top
-          term.write("\x1b[2J\x1b[H");
-          // Write each line, trimming trailing whitespace
-          const lines = msg.content.split("\n");
-          for (let i = 0; i < lines.length; i++) {
-            term.write(lines[i].trimEnd());
-            if (i < lines.length - 1) term.write("\r\n");
-          }
-        }
-      } catch {
-        term.write(event.data);
-      }
-    };
-
-    ws.onclose = () => {
-      onConnectionChange(false);
-    };
-
-    ws.onerror = () => {
-      onConnectionChange(false);
-    };
-
-    wsRef.current = ws;
+    // Auto-connect on initial render
+    connectWs();
 
     // Handle viewport resize — just refit xterm to container
     const resizeObserver = new ResizeObserver(() => {
@@ -128,10 +160,19 @@ export function Terminal({ onConnectionChange }: TerminalProps) {
     return () => {
       window.cancelAnimationFrame(frameId);
       resizeObserver.disconnect();
-      ws.close();
+      if (wsRef.current) wsRef.current.close();
       term.dispose();
     };
-  }, [onConnectionChange]);
+  }, [connectWs]);
+
+  // Auto-reconnect when the terminal tab becomes active and WS is disconnected
+  useEffect(() => {
+    if (!isActive) return;
+    const ws = wsRef.current;
+    if (!ws || ws.readyState === WebSocket.CLOSED || ws.readyState === WebSocket.CLOSING) {
+      connectWs();
+    }
+  }, [isActive, connectWs]);
 
   return (
     <div

--- a/apps/web/src/components/__tests__/ActionBar.test.tsx
+++ b/apps/web/src/components/__tests__/ActionBar.test.tsx
@@ -1,0 +1,594 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
+
+// --- Mocks (must be declared before importing ActionBar) ---
+
+vi.mock("../../lib/telegram", () => ({
+  getAuthHeaders: () => ({ Authorization: "tma test" }),
+}));
+
+// Stub BottomSheet to render children directly
+vi.mock("../BottomSheet", () => ({
+  BottomSheet: ({ children, title }: { children: React.ReactNode; title?: string }) => (
+    <div data-testid="bottom-sheet">
+      {title && <div data-testid="bottom-sheet-title">{title}</div>}
+      {children}
+    </div>
+  ),
+}));
+
+// Stub file-icons (used by FileSearchSheet)
+vi.mock("../file-icons", () => ({
+  getFileIcon: () => null,
+}));
+
+// Stub FileViewer's SORT_OPTIONS (used by FileOptionsSheet)
+vi.mock("../FileViewer", () => ({
+  SORT_OPTIONS: [
+    { value: "name-asc", short: "A-Z", long: "Name (A-Z)" },
+    { value: "name-desc", short: "Z-A", long: "Name (Z-A)" },
+    { value: "date-asc", short: "Old", long: "Date (oldest)" },
+    { value: "date-desc", short: "New", long: "Date (newest)" },
+  ],
+}));
+
+// Mock the entire API module so no real fetches happen
+const mockPostAction = vi.fn();
+const mockFetchGitBranch = vi.fn();
+const mockFetchGitStatus = vi.fn();
+const mockFetchTodo = vi.fn();
+const mockFetchSessionNames = vi.fn();
+const mockDeleteSessionName = vi.fn();
+const mockSendToTmux = vi.fn();
+const mockSendCompactCommand = vi.fn();
+const mockRenameSession = vi.fn();
+const mockRunGitCommand = vi.fn();
+const mockSearchFiles = vi.fn();
+const mockCheckAudio = vi.fn();
+const mockGenerateAudio = vi.fn();
+const mockSendAudioTelegram = vi.fn();
+const mockRestartSession = vi.fn();
+const mockSendFileToChat = vi.fn();
+
+vi.mock("../action-bar/api", () => ({
+  postAction: (...args: unknown[]) => mockPostAction(...args),
+  fetchGitBranch: (...args: unknown[]) => mockFetchGitBranch(...args),
+  fetchGitStatus: (...args: unknown[]) => mockFetchGitStatus(...args),
+  fetchTodo: (...args: unknown[]) => mockFetchTodo(...args),
+  fetchSessionNames: (...args: unknown[]) => mockFetchSessionNames(...args),
+  deleteSessionName: (...args: unknown[]) => mockDeleteSessionName(...args),
+  sendToTmux: (...args: unknown[]) => mockSendToTmux(...args),
+  sendCompactCommand: (...args: unknown[]) => mockSendCompactCommand(...args),
+  renameSession: (...args: unknown[]) => mockRenameSession(...args),
+  runGitCommand: (...args: unknown[]) => mockRunGitCommand(...args),
+  searchFiles: (...args: unknown[]) => mockSearchFiles(...args),
+  checkAudio: (...args: unknown[]) => mockCheckAudio(...args),
+  generateAudio: (...args: unknown[]) => mockGenerateAudio(...args),
+  sendAudioTelegram: (...args: unknown[]) => mockSendAudioTelegram(...args),
+  restartSession: (...args: unknown[]) => mockRestartSession(...args),
+  sendFileToChat: (...args: unknown[]) => mockSendFileToChat(...args),
+  summarizeMarkdown: vi.fn().mockResolvedValue({ ok: true, summary: "Test summary", cached: false, ms: 100 }),
+}));
+
+import { ActionBar } from "../action-bar";
+
+beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+  vi.clearAllMocks();
+  // Default: fetchGitBranch resolves (called on mount)
+  mockFetchGitBranch.mockResolvedValue({ branch: "main", treeType: "main-worktree" });
+  mockFetchTodo.mockResolvedValue("- [ ] Write tests");
+  mockFetchGitStatus.mockResolvedValue("On branch main\nnothing to commit");
+  mockFetchSessionNames.mockResolvedValue([]);
+  mockPostAction.mockResolvedValue({ ok: true, output: "Done" });
+  mockSendToTmux.mockResolvedValue(undefined);
+  mockSendCompactCommand.mockResolvedValue({ ok: true });
+  mockRenameSession.mockResolvedValue({ ok: true });
+  mockRunGitCommand.mockResolvedValue("branch output");
+  mockSearchFiles.mockResolvedValue([]);
+  mockCheckAudio.mockResolvedValue({ exists: false });
+  mockGenerateAudio.mockResolvedValue({ ok: true, path: "/tmp/audio.ogg" });
+  mockSendAudioTelegram.mockResolvedValue({ ok: true });
+  mockRestartSession.mockResolvedValue({ ok: true });
+  mockSendFileToChat.mockResolvedValue({ ok: true });
+  mockDeleteSessionName.mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe("ActionBar", () => {
+  // ─── Rendering basics ───────────────────────────────────────────
+
+  it("renders without crashing with no props", async () => {
+    render(<ActionBar />);
+    // The TODO button is always present
+    expect(screen.getByText("TODO")).toBeInTheDocument();
+  });
+
+  it("shows TODO button regardless of active tab", () => {
+    const { rerender } = render(<ActionBar activeTab="terminal" />);
+    expect(screen.getByText("TODO")).toBeInTheDocument();
+
+    rerender(<ActionBar activeTab="files" />);
+    expect(screen.getByText("TODO")).toBeInTheDocument();
+  });
+
+  it("shows terminal-specific buttons when activeTab is terminal", () => {
+    render(<ActionBar activeTab="terminal" onReconnect={() => {}} />);
+    expect(screen.getByText("Git")).toBeInTheDocument();
+    expect(screen.getByText("/commands")).toBeInTheDocument();
+    expect(screen.getByText("Reconnect")).toBeInTheDocument();
+  });
+
+  it("hides terminal buttons when activeTab is files", () => {
+    render(<ActionBar activeTab="files" />);
+    expect(screen.queryByText("Git")).not.toBeInTheDocument();
+    expect(screen.queryByText("/commands")).not.toBeInTheDocument();
+    expect(screen.queryByText("Reconnect")).not.toBeInTheDocument();
+  });
+
+  it("shows Search and Options buttons in files tab without viewingFile", () => {
+    render(<ActionBar activeTab="files" />);
+    expect(screen.getByText("Search")).toBeInTheDocument();
+    expect(screen.getByText("Options")).toBeInTheDocument();
+  });
+
+  it("shows Send to Chat button when viewing a file", () => {
+    render(<ActionBar activeTab="files" viewingFile={{ path: "/tmp/test.txt", name: "test.txt" }} />);
+    expect(screen.getByText("Send to Chat")).toBeInTheDocument();
+    // Search and Options should be hidden when viewing a file
+    expect(screen.queryByText("Search")).not.toBeInTheDocument();
+    expect(screen.queryByText("Options")).not.toBeInTheDocument();
+  });
+
+  it("shows TL;DR and Audio buttons for markdown files", () => {
+    render(<ActionBar activeTab="files" viewingFile={{ path: "/tmp/README.md", name: "README.md" }} />);
+    expect(screen.getByText("TL;DR")).toBeInTheDocument();
+    expect(screen.getByText("Audio")).toBeInTheDocument();
+  });
+
+  it("hides TL;DR and Audio buttons for non-markdown files", () => {
+    render(<ActionBar activeTab="files" viewingFile={{ path: "/tmp/app.ts", name: "app.ts" }} />);
+    expect(screen.queryByText("TL;DR")).not.toBeInTheDocument();
+    expect(screen.queryByText("Audio")).not.toBeInTheDocument();
+    // But Send to Chat is still present
+    expect(screen.getByText("Send to Chat")).toBeInTheDocument();
+  });
+
+  it("opens TL;DR modal when TL;DR button is clicked", async () => {
+    render(<ActionBar activeTab="files" viewingFile={{ path: "/tmp/README.md", name: "README.md" }} />);
+    fireEvent.click(screen.getByText("TL;DR"));
+
+    await waitFor(() => {
+      // TldrModal renders inside a BottomSheet stub — the sheet should be present
+      expect(screen.getByTestId("bottom-sheet")).toBeInTheDocument();
+    });
+  });
+
+  it("calls checkAudio when Audio button is clicked", async () => {
+    render(<ActionBar activeTab="files" viewingFile={{ path: "/tmp/README.md", name: "README.md" }} />);
+    fireEvent.click(screen.getByText("Audio"));
+
+    await waitFor(() => {
+      expect(mockCheckAudio).toHaveBeenCalledWith("/tmp/README.md");
+    });
+  });
+
+  it("calls generateAudio when audio does not exist and generate is triggered", async () => {
+    // checkAudio reports no cached audio → AudioGenModal shows a Generate button
+    mockCheckAudio.mockResolvedValue({ exists: false });
+
+    render(<ActionBar activeTab="files" viewingFile={{ path: "/tmp/README.md", name: "README.md" }} />);
+    fireEvent.click(screen.getByText("Audio"));
+
+    // Wait for modal to open and checkAudio to resolve
+    await waitFor(() => {
+      expect(mockCheckAudio).toHaveBeenCalledWith("/tmp/README.md");
+      expect(screen.getByTestId("bottom-sheet")).toBeInTheDocument();
+    });
+
+    // Find and click the Generate Audio button inside the AudioGenModal
+    const generateBtn = screen.queryByText("Generate Audio");
+    if (generateBtn) {
+      fireEvent.click(generateBtn);
+      await waitFor(() => {
+        expect(mockGenerateAudio).toHaveBeenCalledWith("/tmp/README.md", expect.any(AbortSignal));
+      });
+    }
+  });
+
+  it("hides Reconnect button when onReconnect is not provided", () => {
+    render(<ActionBar activeTab="terminal" />);
+    expect(screen.queryByText("Reconnect")).not.toBeInTheDocument();
+    // Git and /commands should still appear
+    expect(screen.getByText("Git")).toBeInTheDocument();
+    expect(screen.getByText("/commands")).toBeInTheDocument();
+  });
+
+  // ─── StatusLine ─────────────────────────────────────────────────
+
+  it("shows disconnected status when connected is false", async () => {
+    render(<ActionBar connected={false} />);
+    await waitFor(() => {
+      expect(screen.getByText("[disconnected]")).toBeInTheDocument();
+    });
+  });
+
+  it("shows git branch info when connected", async () => {
+    render(<ActionBar connected={true} />);
+    await waitFor(() => {
+      expect(screen.getByText(/main.*main-worktree/)).toBeInTheDocument();
+    });
+  });
+
+  it("shows idle state (non-breaking space) when fetchGitBranch returns null", async () => {
+    mockFetchGitBranch.mockResolvedValue(null);
+    render(<ActionBar connected={true} />);
+    await waitFor(() => {
+      expect(mockFetchGitBranch).toHaveBeenCalled();
+    });
+    // StatusLine renders \u00A0 (non-breaking space) when gitBranch is null
+    const statusLine = document.querySelector("[style*='textAlign: center']") ??
+      document.querySelector("[style*='text-align: center']");
+    // Branch info should not appear
+    expect(screen.queryByText(/main.*main-worktree/)).not.toBeInTheDocument();
+    expect(screen.queryByText("[disconnected]")).not.toBeInTheDocument();
+  });
+
+  // ─── Modal: TODO ────────────────────────────────────────────────
+
+  it("opens TODO sheet when TODO button is clicked", async () => {
+    render(<ActionBar activeTab="terminal" />);
+    fireEvent.click(screen.getByText("TODO"));
+
+    await waitFor(() => {
+      expect(mockFetchTodo).toHaveBeenCalled();
+      expect(screen.getByTestId("bottom-sheet-title")).toHaveTextContent("TODO");
+    });
+  });
+
+  // ─── Modal: /commands ───────────────────────────────────────────
+
+  it("opens commands sheet and shows command buttons", async () => {
+    render(<ActionBar activeTab="terminal" />);
+    fireEvent.click(screen.getByText("/commands"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("bottom-sheet-title")).toHaveTextContent("/commands");
+    });
+    expect(screen.getByText("/new")).toBeInTheDocument();
+    expect(screen.getByText("/resume")).toBeInTheDocument();
+    expect(screen.getByText("/rename")).toBeInTheDocument();
+    expect(screen.getByText("/compact")).toBeInTheDocument();
+    expect(screen.getByText("/reload-plugins")).toBeInTheDocument();
+  });
+
+  it("navigates from /commands to rename modal", async () => {
+    render(<ActionBar activeTab="terminal" />);
+    fireEvent.click(screen.getByText("/commands"));
+
+    await waitFor(() => {
+      expect(screen.getByText("/rename")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText("/rename"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Rename Session")).toBeInTheDocument();
+      expect(screen.getByPlaceholderText("Session name...")).toBeInTheDocument();
+    });
+  });
+
+  it("navigates from /commands to new-confirm modal", async () => {
+    render(<ActionBar activeTab="terminal" />);
+    fireEvent.click(screen.getByText("/commands"));
+
+    await waitFor(() => {
+      expect(screen.getByText("/new")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText("/new"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Start new session?")).toBeInTheDocument();
+      expect(screen.getByText("Cancel")).toBeInTheDocument();
+      expect(screen.getByText("New")).toBeInTheDocument();
+    });
+  });
+
+  it("navigates from /commands to compact-confirm modal", async () => {
+    render(<ActionBar activeTab="terminal" />);
+    fireEvent.click(screen.getByText("/commands"));
+
+    await waitFor(() => {
+      expect(screen.getByText("/compact")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText("/compact"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Compact Context")).toBeInTheDocument();
+      expect(screen.getByText("Compact Now")).toBeInTheDocument();
+      expect(screen.getByText("Prompt for Continuity")).toBeInTheDocument();
+    });
+  });
+
+  // ─── Modal: Rename flow ─────────────────────────────────────────
+
+  it("submits rename and calls renameSession API", async () => {
+    render(<ActionBar activeTab="terminal" />);
+    fireEvent.click(screen.getByText("/commands"));
+    await waitFor(() => expect(screen.getByText("/rename")).toBeInTheDocument());
+    fireEvent.click(screen.getByText("/rename"));
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText("Session name...")).toBeInTheDocument();
+    });
+
+    const input = screen.getByPlaceholderText("Session name...");
+    fireEvent.change(input, { target: { value: "my-session" } });
+    fireEvent.click(screen.getByText("Rename"));
+
+    await waitFor(() => {
+      expect(mockRenameSession).toHaveBeenCalledWith("my-session");
+      expect(mockSendToTmux).toHaveBeenCalledWith("/rename my-session");
+    });
+  });
+
+  it("does not submit rename when name is empty", async () => {
+    render(<ActionBar activeTab="terminal" />);
+    fireEvent.click(screen.getByText("/commands"));
+    await waitFor(() => expect(screen.getByText("/rename")).toBeInTheDocument());
+    fireEvent.click(screen.getByText("/rename"));
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText("Session name...")).toBeInTheDocument();
+    });
+
+    // Leave input empty, click Rename
+    fireEvent.click(screen.getByText("Rename"));
+
+    expect(mockRenameSession).not.toHaveBeenCalled();
+  });
+
+  // ─── Modal: Git ─────────────────────────────────────────────────
+
+  it("opens git status sheet when Git button is clicked", async () => {
+    render(<ActionBar activeTab="terminal" />);
+    fireEvent.click(screen.getByText("Git"));
+
+    await waitFor(() => {
+      expect(mockFetchGitStatus).toHaveBeenCalled();
+      expect(screen.getByTestId("bottom-sheet-title")).toHaveTextContent("Git Status");
+    });
+  });
+
+  it("opens git menu via dropdown arrow button", async () => {
+    render(<ActionBar activeTab="terminal" />);
+    const gitMenuBtn = screen.getByLabelText("Open git menu");
+    fireEvent.click(gitMenuBtn);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("bottom-sheet-title")).toHaveTextContent("Git");
+      expect(screen.getByText("View Status")).toBeInTheDocument();
+      expect(screen.getByText("Check Branch")).toBeInTheDocument();
+      expect(screen.getByText("View Log")).toBeInTheDocument();
+      expect(screen.getByText("Pull")).toBeInTheDocument();
+    });
+  });
+
+  it("runs a git command from the git menu", async () => {
+    render(<ActionBar activeTab="terminal" />);
+    fireEvent.click(screen.getByLabelText("Open git menu"));
+    await waitFor(() => expect(screen.getByText("Pull")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByText("Pull"));
+
+    await waitFor(() => {
+      expect(mockRunGitCommand).toHaveBeenCalledWith("pull");
+    });
+  });
+
+  // ─── Modal: Reconnect menu ─────────────────────────────────────
+
+  it("opens reconnect menu and shows restart option", async () => {
+    const onReconnect = vi.fn();
+    render(<ActionBar activeTab="terminal" onReconnect={onReconnect} />);
+    fireEvent.click(screen.getByLabelText("Open reconnect menu"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("bottom-sheet-title")).toHaveTextContent("Session Controls");
+      expect(screen.getByText("Reconnect Terminal")).toBeInTheDocument();
+      expect(screen.getByText("Restart Claude Session")).toBeInTheDocument();
+    });
+  });
+
+  it("calls onReconnect when reconnect terminal is clicked in menu", async () => {
+    const onReconnect = vi.fn();
+    render(<ActionBar activeTab="terminal" onReconnect={onReconnect} />);
+    fireEvent.click(screen.getByLabelText("Open reconnect menu"));
+    await waitFor(() => expect(screen.getByText("Reconnect Terminal")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByText("Reconnect Terminal"));
+
+    expect(onReconnect).toHaveBeenCalledOnce();
+  });
+
+  it("calls restartSession when restart button is clicked", async () => {
+    const onReconnect = vi.fn();
+    render(<ActionBar activeTab="terminal" onReconnect={onReconnect} />);
+    fireEvent.click(screen.getByLabelText("Open reconnect menu"));
+    await waitFor(() => expect(screen.getByText("Restart Claude Session")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByText("Restart Claude Session"));
+
+    await waitFor(() => {
+      expect(mockRestartSession).toHaveBeenCalled();
+    });
+  });
+
+  // ─── Modal: New session confirm ────────────────────────────────
+
+  it("sends /new command when new session is confirmed", async () => {
+    render(<ActionBar activeTab="terminal" />);
+    fireEvent.click(screen.getByText("/commands"));
+    await waitFor(() => expect(screen.getByText("/new")).toBeInTheDocument());
+    fireEvent.click(screen.getByText("/new"));
+    await waitFor(() => expect(screen.getByText("New")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByText("New"));
+
+    await waitFor(() => {
+      expect(mockSendCompactCommand).toHaveBeenCalledWith("/new");
+    });
+  });
+
+  // ─── Modal: Compact flow ───────────────────────────────────────
+
+  it("opens compact focus from compact-confirm and submits", async () => {
+    render(<ActionBar activeTab="terminal" />);
+    fireEvent.click(screen.getByText("/commands"));
+    await waitFor(() => expect(screen.getByText("/compact")).toBeInTheDocument());
+    fireEvent.click(screen.getByText("/compact"));
+    await waitFor(() => expect(screen.getByText("Compact Now")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByText("Compact Now"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Compact Focus")).toBeInTheDocument();
+    });
+
+    // Submit without focus text should send plain /compact
+    fireEvent.click(screen.getByText("Compact"));
+
+    await waitFor(() => {
+      expect(mockSendCompactCommand).toHaveBeenCalledWith("/compact");
+    });
+  });
+
+  it("sends compact with focus text when provided", async () => {
+    render(<ActionBar activeTab="terminal" />);
+    fireEvent.click(screen.getByText("/commands"));
+    await waitFor(() => expect(screen.getByText("/compact")).toBeInTheDocument());
+    fireEvent.click(screen.getByText("/compact"));
+    await waitFor(() => expect(screen.getByText("Compact Now")).toBeInTheDocument());
+    fireEvent.click(screen.getByText("Compact Now"));
+    await waitFor(() => expect(screen.getByText("Compact Focus")).toBeInTheDocument());
+
+    const textarea = screen.getByPlaceholderText(/Focus on/);
+    fireEvent.change(textarea, { target: { value: "auth refactor" } });
+    fireEvent.click(screen.getByText("Compact"));
+
+    await waitFor(() => {
+      expect(mockSendCompactCommand).toHaveBeenCalledWith("/compact auth refactor");
+    });
+  });
+
+  // ─── Modal: File Search ─────────────────────────────────────────
+
+  it("opens file search sheet when Search button is clicked", async () => {
+    render(<ActionBar activeTab="files" />);
+    fireEvent.click(screen.getByText("Search"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("bottom-sheet-title")).toHaveTextContent("Search Files");
+      expect(screen.getByPlaceholderText("Search files...")).toBeInTheDocument();
+    });
+  });
+
+  // ─── Modal: File Options ────────────────────────────────────────
+
+  it("opens file options sheet when Options button is clicked", async () => {
+    render(<ActionBar activeTab="files" />);
+    fireEvent.click(screen.getByText("Options"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("bottom-sheet-title")).toHaveTextContent("File Options");
+    });
+  });
+
+  // ─── Send to Chat ──────────────────────────────────────────────
+
+  it("sends file to chat when Send to Chat is clicked", async () => {
+    render(<ActionBar activeTab="files" viewingFile={{ path: "/tmp/test.txt", name: "test.txt" }} />);
+    fireEvent.click(screen.getByText("Send to Chat"));
+
+    await waitFor(() => {
+      expect(mockSendFileToChat).toHaveBeenCalledWith("/tmp/test.txt");
+    });
+  });
+
+  // ─── Status message lifecycle ──────────────────────────────────
+
+  it("clears status message after the 2-second handleSendToChat timeout", async () => {
+    render(<ActionBar activeTab="files" viewingFile={{ path: "/tmp/test.txt", name: "test.txt" }} />);
+    fireEvent.click(screen.getByText("Send to Chat"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Sent to chat")).toBeInTheDocument();
+    });
+
+    // At 1900ms the 2s timeout has NOT yet fired — message must still be present
+    act(() => { vi.advanceTimersByTime(1900); });
+    expect(screen.getByText("Sent to chat")).toBeInTheDocument();
+
+    // Advance past 2000ms — the 2s timeout fires and clears the message
+    act(() => { vi.advanceTimersByTime(200); });
+
+    await waitFor(() => {
+      expect(screen.queryByText("Sent to chat")).not.toBeInTheDocument();
+    });
+  });
+
+  // ─── Error handling ─────────────────────────────────────────────
+
+  it("shows error status when rename fails", async () => {
+    mockRenameSession.mockRejectedValue(new Error("Server error"));
+
+    render(<ActionBar activeTab="terminal" />);
+    fireEvent.click(screen.getByText("/commands"));
+    await waitFor(() => expect(screen.getByText("/rename")).toBeInTheDocument());
+    fireEvent.click(screen.getByText("/rename"));
+    await waitFor(() => expect(screen.getByPlaceholderText("Session name...")).toBeInTheDocument());
+
+    const input = screen.getByPlaceholderText("Session name...");
+    fireEvent.change(input, { target: { value: "fail-name" } });
+    fireEvent.click(screen.getByText("Rename"));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Failed: Server error/)).toBeInTheDocument();
+    });
+  });
+
+  it("shows error status when restart session fails", async () => {
+    mockRestartSession.mockRejectedValue(new Error("Connection refused"));
+
+    const onReconnect = vi.fn();
+    render(<ActionBar activeTab="terminal" onReconnect={onReconnect} />);
+    fireEvent.click(screen.getByLabelText("Open reconnect menu"));
+    await waitFor(() => expect(screen.getByText("Restart Claude Session")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByText("Restart Claude Session"));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Restart failed: Connection refused/)).toBeInTheDocument();
+    });
+  });
+
+  // ─── Accessibility ─────────────────────────────────────────────
+
+  it("has aria-label on git menu dropdown button", () => {
+    render(<ActionBar activeTab="terminal" />);
+    const gitMenuBtn = screen.getByLabelText("Open git menu");
+    expect(gitMenuBtn).toBeInTheDocument();
+  });
+
+  it("has aria-label on reconnect menu dropdown button", () => {
+    render(<ActionBar activeTab="terminal" onReconnect={() => {}} />);
+    const reconnectMenuBtn = screen.getByLabelText("Open reconnect menu");
+    expect(reconnectMenuBtn).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/__tests__/ActionBar.test.tsx
+++ b/apps/web/src/components/__tests__/ActionBar.test.tsx
@@ -524,7 +524,7 @@ describe("ActionBar", () => {
 
   // ─── Status message lifecycle ──────────────────────────────────
 
-  it("clears status message after the 2-second handleSendToChat timeout", async () => {
+  it("clears status message after the 4-second useEffect status timer", async () => {
     render(<ActionBar activeTab="files" viewingFile={{ path: "/tmp/test.txt", name: "test.txt" }} />);
     fireEvent.click(screen.getByText("Send to Chat"));
 
@@ -532,11 +532,11 @@ describe("ActionBar", () => {
       expect(screen.getByText("Sent to chat")).toBeInTheDocument();
     });
 
-    // At 1900ms the 2s timeout has NOT yet fired — message must still be present
-    act(() => { vi.advanceTimersByTime(1900); });
+    // At 3900ms the 4s useEffect timer has NOT yet fired — message must still be present
+    act(() => { vi.advanceTimersByTime(3900); });
     expect(screen.getByText("Sent to chat")).toBeInTheDocument();
 
-    // Advance past 2000ms — the 2s timeout fires and clears the message
+    // Advance past 4000ms — the useEffect timer fires and clears the message
     act(() => { vi.advanceTimersByTime(200); });
 
     await waitFor(() => {

--- a/apps/web/src/components/__tests__/ActionBar.test.tsx
+++ b/apps/web/src/components/__tests__/ActionBar.test.tsx
@@ -5,6 +5,7 @@ import { render, screen, fireEvent, waitFor, act } from "@testing-library/react"
 
 vi.mock("../../lib/telegram", () => ({
   getAuthHeaders: () => ({ Authorization: "tma test" }),
+  getTelegramWebApp: () => null,
 }));
 
 // Stub BottomSheet to render children directly

--- a/apps/web/src/components/action-bar/ActionBar.tsx
+++ b/apps/web/src/components/action-bar/ActionBar.tsx
@@ -15,8 +15,16 @@ import { AudioGenModal } from "./AudioGenModal";
 import { StatusLine } from "./StatusLine";
 import { btnStyle, type ActionBarProps, type AudioStatus, type GitBranch, type Modal, type SearchResult, type SessionName } from "./types";
 import { checkAudio, deleteSessionName, fetchGitBranch, fetchGitStatus, fetchSessionNames, fetchTodo, generateAudio, postAction, renameSession, restartSession, runGitCommand, searchFiles, sendAudioTelegram, sendCompactCommand, sendFileToChat, sendToTmux } from "./api";
+import { usePreferences } from "../../hooks/usePreferences";
 
-const SEARCH_SCOPE_KEY = "cpc:search:currentFolderOnly";
+// Preference key for the "current folder only" search toggle. Stored under
+// the unified cpc_dashboard_prefs aggregate via CloudStorage (Bot API 8.0+)
+// with a localStorage fallback — see apps/web/src/lib/cloud-storage.ts.
+// Renamed from the old localStorage-direct key "cpc:search:currentFolderOnly"
+// when we migrated to the aggregate store; the old key is left behind on
+// upgraded clients (one-time loss of this single toggle), which is acceptable
+// for a boolean with a sensible default of ON.
+const SEARCH_SCOPE_PREF = "searchCurrentFolderOnly";
 
 export function ActionBar({ onReconnect, connected, activeTab, fileShowHidden, setFileShowHidden, fileSortMode, setFileSortMode, viewingFile, currentFolder }: ActionBarProps) {
   const [status, setStatus] = useState<string | null>(null);
@@ -32,21 +40,11 @@ export function ActionBar({ onReconnect, connected, activeTab, fileShowHidden, s
   const [searchQuery, setSearchQuery] = useState("");
   const [searchResults, setSearchResults] = useState<SearchResult[]>([]);
   // "Current folder only" search toggle — default ON, persisted per-user via
-  // localStorage. When ON we pass the folder the user is browsing as a
-  // `scope` query param; when OFF the server falls back to the old global
-  // search across all allowed roots. (Search UX C3.)
-  const [searchCurrentFolderOnly, setSearchCurrentFolderOnly] = useState<boolean>(() => {
-    try {
-      // Default to true unless explicitly set to "false" — so a fresh user
-      // gets the scoped behavior we actually want as the default.
-      return localStorage.getItem(SEARCH_SCOPE_KEY) !== "false";
-    } catch {
-      return true;
-    }
-  });
-  useEffect(() => {
-    try { localStorage.setItem(SEARCH_SCOPE_KEY, String(searchCurrentFolderOnly)); } catch { /* ignore */ }
-  }, [searchCurrentFolderOnly]);
+  // Telegram CloudStorage (syncs across devices) with a localStorage fallback.
+  // When ON we pass the folder the user is browsing as a `scope` query param;
+  // when OFF the server falls back to the old global search across all allowed
+  // roots. (Search UX C3; migrated to unified prefs in feat/cloud-storage-prefs.)
+  const [searchCurrentFolderOnly, setSearchCurrentFolderOnly] = usePreferences<boolean>(SEARCH_SCOPE_PREF, true);
   // Keep the latest scope value in a ref so the debounced search callback
   // (which is a useCallback with a stable identity) can read the freshest
   // toggle + folder without needing to rebuild on every change.

--- a/apps/web/src/components/action-bar/ActionBar.tsx
+++ b/apps/web/src/components/action-bar/ActionBar.tsx
@@ -14,7 +14,13 @@ import { TldrModal } from "./TldrModal";
 import { AudioGenModal } from "./AudioGenModal";
 import { StatusLine } from "./StatusLine";
 import { btnStyle, type ActionBarProps, type AudioStatus, type GitBranch, type Modal, type SearchResult, type SessionName } from "./types";
-import { checkAudio, deleteSessionName, fetchGitBranch, fetchGitStatus, fetchSessionNames, fetchTodo, generateAudio, postAction, renameSession, restartSession, runGitCommand, searchFiles, sendAudioTelegram, sendCompactCommand, sendFileToChat, sendToTmux } from "./api";
+import {
+  checkAudio, deleteSessionName, fetchGitBranch, fetchGitStatus,
+  fetchSessionNames, fetchTodo, generateAudio, postAction,
+  renameSession, restartSession, runGitCommand, searchFiles,
+  sendAudioTelegram, sendCompactCommand, sendFileToChat, sendToTmux,
+} from "./api";
+import { haptic } from "../../lib/haptic";
 import { usePreferences } from "../../hooks/usePreferences";
 
 // Preference key for the "current folder only" search toggle. Stored under
@@ -103,14 +109,52 @@ export function ActionBar({ onReconnect, connected, activeTab, fileShowHidden, s
     setStatus(`Running ${label}...`);
     try {
       const data = await postAction(endpoint);
-      setStatus(!data.ok ? `Failed: ${data.error || "unknown error"}` : data.output || `${label}: OK`);
-    } catch (err) { setStatus(`Error: ${err instanceof Error ? err.message : String(err)}`); }
+      if (!data.ok) {
+        haptic.error();
+        setStatus(`Failed: ${data.error || "unknown error"}`);
+      } else {
+        haptic.success();
+        setStatus(data.output || `${label}: OK`);
+      }
+    } catch (err) {
+      haptic.error();
+      setStatus(`Error: ${err instanceof Error ? err.message : String(err)}`);
+    }
   };
-  const loadGitStatus = async () => { try { setGitOutput(await fetchGitStatus()); } catch { setGitOutput("Failed to fetch"); } };
-  const loadTodo = async () => { try { setTodoContent(await fetchTodo()); } catch { setTodoContent("Failed to fetch"); } };
-  const loadSessionNames = async () => { try { setSessionNames(await fetchSessionNames()); } catch { setSessionNames([]); } };
-  const removeSessionName = async (ts: number) => { try { await deleteSessionName(ts); setSessionNames((prev) => prev.filter((s) => s.ts !== ts)); } catch {} setDeleteTarget(null); setModal("resume"); };
-  const handleCompact = async (message: string, label = "Compact") => { setModal(null); setStatus(`${label}...`); try { const data = await sendCompactCommand(message); setStatus(data.ok ? `${label} sent` : `Failed: ${data.error}`); } catch (err) { setStatus(`Error: ${err instanceof Error ? err.message : String(err)}`); } };
+  const loadGitStatus = async () => {
+    try { setGitOutput(await fetchGitStatus()); } catch { setGitOutput("Failed to fetch"); }
+  };
+  const loadTodo = async () => {
+    try { setTodoContent(await fetchTodo()); } catch { setTodoContent("Failed to fetch"); }
+  };
+  const loadSessionNames = async () => {
+    try { setSessionNames(await fetchSessionNames()); } catch { setSessionNames([]); }
+  };
+  const removeSessionName = async (ts: number) => {
+    try {
+      await deleteSessionName(ts);
+      setSessionNames((prev) => prev.filter((s) => s.ts !== ts));
+    } catch {}
+    setDeleteTarget(null);
+    setModal("resume");
+  };
+  const handleCompact = async (message: string, label = "Compact") => {
+    setModal(null);
+    setStatus(`${label}...`);
+    try {
+      const data = await sendCompactCommand(message);
+      if (data.ok) {
+        haptic.success();
+        setStatus(`${label} sent`);
+      } else {
+        haptic.error();
+        setStatus(`Failed: ${data.error}`);
+      }
+    } catch (err) {
+      haptic.error();
+      setStatus(`Error: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  };
   const handleRename = async () => {
     if (!renameName.trim()) return;
     setModal(null);
@@ -118,7 +162,13 @@ export function ActionBar({ onReconnect, connected, activeTab, fileShowHidden, s
     void sendToTmux(`/rename ${renameName.trim()}`);
     try {
       const data = await renameSession(renameName.trim());
-      setStatus(data.ok ? `Renamed to "${renameName.trim()}"` : `Failed: ${data.error}`);
+      if (data.ok) {
+        haptic.success();
+        setStatus(`Renamed to "${renameName.trim()}"`);
+      } else {
+        haptic.error();
+        setStatus(`Failed: ${data.error}`);
+      }
     } catch (err) {
       // Previously this catch swallowed the error and optimistically reported
       // success because the in-tmux /rename side-effect had already happened.
@@ -126,12 +176,23 @@ export function ActionBar({ onReconnect, connected, activeTab, fileShowHidden, s
       // server-side rejections (400/409) land here too, and a false success
       // would hide real failures. Report the error instead. (Codex round-4
       // review re-pass.)
+      haptic.error();
       setStatus(`Failed: ${err instanceof Error ? err.message : String(err)}`);
     }
     setTimeout(() => setStatus(null), 2000);
   };
-  const handleFork = () => { const name = forkName.trim(); setModal(null); void sendToTmux(name ? `/fork\n/rename ${name}` : "/fork"); setStatus(name ? `Forked as "${name}"` : "Forked"); setTimeout(() => setStatus(null), 2000); };
-  const handleGitAction = async (action: { label: string; command: string }) => { setGitOutput(`Running ${action.label}...`); setModal("git-status"); try { setGitOutput(await runGitCommand(action.command)); } catch { setGitOutput("Failed to run command"); } };
+  const handleFork = () => {
+    const name = forkName.trim();
+    setModal(null);
+    void sendToTmux(name ? `/fork\n/rename ${name}` : "/fork");
+    setStatus(name ? `Forked as "${name}"` : "Forked");
+    setTimeout(() => setStatus(null), 2000);
+  };
+  const handleGitAction = async (action: { label: string; command: string }) => {
+    setGitOutput(`Running ${action.label}...`);
+    setModal("git-status");
+    try { setGitOutput(await runGitCommand(action.command)); } catch { setGitOutput("Failed to run command"); }
+  };
   const resetFileSearch = useCallback(() => {
     // Cancel any pending debounce and abort any in-flight request, then
     // clear query+results. Needed when re-opening the search sheet so a
@@ -231,15 +292,26 @@ export function ActionBar({ onReconnect, connected, activeTab, fileShowHidden, s
       const timeout = setTimeout(() => controller.abort(), 60000);
       try {
         const data = await generateAudio(filePath, controller.signal);
-        if (data.ok) { setAudioStatus({ exists: true, path: data.path }); setStatus("Audio generated"); }
-        else setStatus(`Failed: ${data.error}`);
+        if (data.ok) {
+          haptic.success();
+          setAudioStatus({ exists: true, path: data.path });
+          setStatus("Audio generated");
+        } else {
+          haptic.error();
+          setStatus(`Failed: ${data.error}`);
+        }
       } finally {
         // clearTimeout in finally so a thrown fetch doesn't leave the
         // 60s timeout dangling and accumulating. (Copilot round-3 review.)
         clearTimeout(timeout);
       }
     } catch (err) {
-      setStatus(err instanceof DOMException && err.name === "AbortError" ? "Timed out" : `Error: ${err instanceof Error ? err.message : String(err)}`);
+      haptic.error();
+      setStatus(
+        err instanceof DOMException && err.name === "AbortError"
+          ? "Timed out"
+          : `Error: ${err instanceof Error ? err.message : String(err)}`
+      );
     } finally {
       audioInFlightRef.current = false;
       setAudioOp("idle");
@@ -257,14 +329,25 @@ export function ActionBar({ onReconnect, connected, activeTab, fileShowHidden, s
       const timeout = setTimeout(() => controller.abort(), 30000);
       try {
         const data = await sendAudioTelegram(audioPath, controller.signal);
-        setStatus(data.ok ? "Sent to Telegram" : `Failed: ${data.error}`);
+        if (data.ok) {
+          haptic.success();
+          setStatus("Sent to Telegram");
+        } else {
+          haptic.error();
+          setStatus(`Failed: ${data.error}`);
+        }
       } finally {
         // clearTimeout in finally so a thrown fetch doesn't leave the
         // 30s timeout dangling and accumulating. (Copilot round-3 review.)
         clearTimeout(timeout);
       }
     } catch (err) {
-      setStatus(err instanceof DOMException && err.name === "AbortError" ? "Timed out" : `Error: ${err instanceof Error ? err.message : String(err)}`);
+      haptic.error();
+      setStatus(
+        err instanceof DOMException && err.name === "AbortError"
+          ? "Timed out"
+          : `Error: ${err instanceof Error ? err.message : String(err)}`
+      );
     } finally {
       audioInFlightRef.current = false;
       setAudioOp("idle");
@@ -276,53 +359,295 @@ export function ActionBar({ onReconnect, connected, activeTab, fileShowHidden, s
     setStatus("Restarting session...");
     try {
       const data = await restartSession();
-      setStatus(data.ok ? "Session restarted" : `Failed: ${data.error}`);
+      if (data.ok) {
+        haptic.success();
+        setStatus("Session restarted");
+      } else {
+        haptic.error();
+        setStatus(`Failed: ${data.error}`);
+      }
     } catch (err) {
       // Surface the server error text (now extracted by jsonFetch from a
       // { error } body on non-2xx responses) instead of a generic message.
       // (Codex round-4 review re-pass.)
+      haptic.error();
       setStatus(`Restart failed: ${err instanceof Error ? err.message : String(err)}`);
     }
     setTimeout(() => setStatus(null), 3000);
   };
-  const handleSendToChat = async () => { if (!viewingFile) return; setStatus("Sharing..."); try { const data = await sendFileToChat(viewingFile.path); setStatus(data.ok ? "Sent to chat" : "Failed"); } catch { setStatus("Failed"); } setTimeout(() => setStatus(null), 2000); };
+  const handleSendToChat = async () => {
+    if (!viewingFile) return;
+    setStatus("Sharing...");
+    try {
+      const data = await sendFileToChat(viewingFile.path);
+      if (data.ok) {
+        haptic.success();
+        setStatus("Sent to chat");
+      } else {
+        haptic.error();
+        setStatus("Failed");
+      }
+    } catch {
+      haptic.error();
+      setStatus("Failed");
+    }
+    setTimeout(() => setStatus(null), 2000);
+  };
 
   let modalNode: ReactNode = null;
   switch (modal) {
-    case "commands": modalNode = <CommandsSheet onClose={() => setModal(null)} onEsc={() => { void sendToTmux("Escape", true); setModal(null); setStatus("Sent: Esc"); setTimeout(() => setStatus(null), 1500); }} onDigit={(digit) => { void sendToTmux(String(digit)); setModal(null); setStatus(`Sent: ${digit}`); setTimeout(() => setStatus(null), 1500); }} onShiftTab={() => { void sendToTmux("BTab", true); setModal(null); setStatus("Sent: \u21e7Tab"); setTimeout(() => setStatus(null), 1500); }} onControlB={() => { void sendToTmux("C-b", true); setModal(null); setStatus("Sent: ^B"); setTimeout(() => setStatus(null), 1500); }} onNew={() => setModal("new-confirm")} onResume={() => { void loadSessionNames(); setModal("resume"); }} onFork={() => { setForkName(""); setModal("fork-name"); }} onRename={() => { setRenameName(""); setModal("rename"); }} onCompact={() => setModal("compact-confirm")} onReloadPlugins={() => { setModal(null); void handleAction("/api/terminal/reload-plugins", "Reload plugins"); }} />; break;
-    case "rename": modalNode = <RenameModal value={renameName} onChange={setRenameName} onBack={() => setModal("commands")} onSubmit={() => void handleRename()} />; break;
-    case "fork-name": modalNode = <ForkNameModal value={forkName} onChange={setForkName} onBack={() => setModal("commands")} onSubmit={handleFork} />; break;
-    case "resume": modalNode = <ResumeSheet sessionNames={sessionNames} onClose={() => setModal("commands")} onResume={(session) => { setModal(null); void handleCompact(`/resume ${session.name}`, "Resume"); }} onDelete={(session) => { setDeleteTarget(session); setModal("confirm-delete"); }} />; break;
-    case "confirm-delete": modalNode = deleteTarget ? <ConfirmDeleteSheet deleteTarget={deleteTarget} onCancel={() => { setDeleteTarget(null); setModal("resume"); }} onConfirm={() => void removeSessionName(deleteTarget.ts)} /> : null; break;
-    case "reconnect-menu": modalNode = onReconnect ? <ReconnectMenu onClose={() => setModal(null)} onReconnect={() => { onReconnect(); setModal(null); }} onRestart={() => void handleRestartSession()} /> : null; break;
-    case "new-confirm": modalNode = <NewConfirmModal onCancel={() => setModal("commands")} onConfirm={() => void handleCompact("/new", "New session")} />; break;
-    case "git-status": modalNode = <GitStatusSheet gitOutput={gitOutput} onClose={() => setModal(null)} />; break;
-    case "git-menu": modalNode = <GitMenuSheet onClose={() => setModal(null)} onViewStatus={() => { void loadGitStatus(); setModal("git-status"); }} onAction={(action) => void handleGitAction(action)} />; break;
-    case "todo": modalNode = <TodoSheet todoContent={todoContent} onClose={() => setModal(null)} />; break;
-    case "compact-confirm": modalNode = <CompactConfirmModal onCompactNow={() => { setCompactFocus(""); setModal("compact-focus"); }} onContinuity={() => { setContinuityNotes(""); setModal("continuity-notes"); }} onCancel={() => setModal(null)} />; break;
-    case "compact-focus": modalNode = <CompactFocusModal value={compactFocus} onChange={setCompactFocus} onBack={() => setModal("compact-confirm")} onSubmit={() => void handleCompact(compactFocus.trim() ? `/compact ${compactFocus.trim()}` : "/compact")} />; break;
-    case "continuity-notes": modalNode = <ContinuityNotesModal value={continuityNotes} onChange={setContinuityNotes} onBack={() => setModal("compact-confirm")} onSubmit={() => void handleCompact(`Before compacting, please ensure: 1) README.md is up to date with recent changes. 2) Anything important from this session is saved to the knowledge base or memory. 3) Open work and next steps are captured in NEXT-SESSION.md and TODO.md.${continuityNotes.trim() ? ` Additional context from user: "${continuityNotes.trim()}".` : ""}`)} />; break;
-    case "file-options": modalNode = <FileOptionsSheet fileShowHidden={fileShowHidden} fileSortMode={fileSortMode} setFileShowHidden={setFileShowHidden} setFileSortMode={setFileSortMode} onClose={() => setModal(null)} />; break;
-    case "file-search": modalNode = <FileSearchSheet searchQuery={searchQuery} searchResults={searchResults} currentFolder={currentFolder ?? null} currentFolderOnly={searchCurrentFolderOnly} onToggleCurrentFolderOnly={setSearchCurrentFolderOnly} onClose={() => setModal(null)} onChange={handleSearchInput} onSelect={(result) => { setModal(null); window.location.hash = `files&file=${encodeURIComponent(result.path)}`; window.location.reload(); }} />; break;
-    case "tldr": modalNode = viewingFile ? <TldrModal viewingFile={viewingFile} onClose={() => setModal(null)} /> : null; break;
-    case "audio-gen": modalNode = viewingFile ? <AudioGenModal viewingFile={viewingFile} audioLoading={audioLoading} audioOp={audioOp} audioStatus={audioStatus} onClose={() => setModal(null)} onGenerate={() => void handleGenerateAudio(viewingFile.path)} onSend={() => { if (audioStatus?.path) void handleSendAudio(audioStatus.path); }} /> : null; break;
+    case "commands":
+      modalNode = (
+        <CommandsSheet
+          onClose={() => setModal(null)}
+          onEsc={() => { void sendToTmux("Escape", true); setModal(null); setStatus("Sent: Esc"); setTimeout(() => setStatus(null), 1500); }}
+          onDigit={(digit) => { void sendToTmux(String(digit)); setModal(null); setStatus(`Sent: ${digit}`); setTimeout(() => setStatus(null), 1500); }}
+          onShiftTab={() => { void sendToTmux("BTab", true); setModal(null); setStatus("Sent: \u21e7Tab"); setTimeout(() => setStatus(null), 1500); }}
+          onControlB={() => { void sendToTmux("C-b", true); setModal(null); setStatus("Sent: ^B"); setTimeout(() => setStatus(null), 1500); }}
+          onNew={() => setModal("new-confirm")}
+          onResume={() => { void loadSessionNames(); setModal("resume"); }}
+          onFork={() => { setForkName(""); setModal("fork-name"); }}
+          onRename={() => { setRenameName(""); setModal("rename"); }}
+          onCompact={() => setModal("compact-confirm")}
+          onReloadPlugins={() => { setModal(null); void handleAction("/api/terminal/reload-plugins", "Reload plugins"); }}
+        />
+      );
+      break;
+    case "rename":
+      modalNode = (
+        <RenameModal value={renameName} onChange={setRenameName} onBack={() => setModal("commands")} onSubmit={() => void handleRename()} />
+      );
+      break;
+    case "fork-name":
+      modalNode = (
+        <ForkNameModal value={forkName} onChange={setForkName} onBack={() => setModal("commands")} onSubmit={handleFork} />
+      );
+      break;
+    case "resume":
+      modalNode = (
+        <ResumeSheet
+          sessionNames={sessionNames}
+          onClose={() => setModal("commands")}
+          onResume={(session) => { setModal(null); void handleCompact(`/resume ${session.name}`, "Resume"); }}
+          onDelete={(session) => { setDeleteTarget(session); setModal("confirm-delete"); }}
+        />
+      );
+      break;
+    case "confirm-delete":
+      modalNode = deleteTarget ? (
+        <ConfirmDeleteSheet
+          deleteTarget={deleteTarget}
+          onCancel={() => { setDeleteTarget(null); setModal("resume"); }}
+          onConfirm={() => void removeSessionName(deleteTarget.ts)}
+        />
+      ) : null;
+      break;
+    case "reconnect-menu":
+      modalNode = onReconnect ? (
+        <ReconnectMenu
+          onClose={() => setModal(null)}
+          onReconnect={() => { onReconnect(); setModal(null); }}
+          onRestart={() => void handleRestartSession()}
+        />
+      ) : null;
+      break;
+    case "new-confirm":
+      modalNode = (
+        <NewConfirmModal onCancel={() => setModal("commands")} onConfirm={() => void handleCompact("/new", "New session")} />
+      );
+      break;
+    case "git-status":
+      modalNode = <GitStatusSheet gitOutput={gitOutput} onClose={() => setModal(null)} />;
+      break;
+    case "git-menu":
+      modalNode = (
+        <GitMenuSheet
+          onClose={() => setModal(null)}
+          onViewStatus={() => { void loadGitStatus(); setModal("git-status"); }}
+          onAction={(action) => void handleGitAction(action)}
+        />
+      );
+      break;
+    case "todo":
+      modalNode = <TodoSheet todoContent={todoContent} onClose={() => setModal(null)} />;
+      break;
+    case "compact-confirm":
+      modalNode = (
+        <CompactConfirmModal
+          onCompactNow={() => { setCompactFocus(""); setModal("compact-focus"); }}
+          onContinuity={() => { setContinuityNotes(""); setModal("continuity-notes"); }}
+          onCancel={() => setModal(null)}
+        />
+      );
+      break;
+    case "compact-focus":
+      modalNode = (
+        <CompactFocusModal
+          value={compactFocus}
+          onChange={setCompactFocus}
+          onBack={() => setModal("compact-confirm")}
+          onSubmit={() => void handleCompact(compactFocus.trim() ? `/compact ${compactFocus.trim()}` : "/compact")}
+        />
+      );
+      break;
+    case "continuity-notes": {
+      const continuityMsg = [
+        "Before compacting, please ensure:",
+        "1) README.md is up to date with recent changes.",
+        "2) Anything important from this session is saved to the knowledge base or memory.",
+        "3) Open work and next steps are captured in NEXT-SESSION.md and TODO.md.",
+        continuityNotes.trim() ? `Additional context from user: "${continuityNotes.trim()}".` : "",
+      ].filter(Boolean).join(" ");
+      modalNode = (
+        <ContinuityNotesModal
+          value={continuityNotes}
+          onChange={setContinuityNotes}
+          onBack={() => setModal("compact-confirm")}
+          onSubmit={() => void handleCompact(continuityMsg)}
+        />
+      );
+      break;
+    }
+    case "file-options":
+      modalNode = (
+        <FileOptionsSheet
+          fileShowHidden={fileShowHidden}
+          fileSortMode={fileSortMode}
+          setFileShowHidden={setFileShowHidden}
+          setFileSortMode={setFileSortMode}
+          onClose={() => setModal(null)}
+        />
+      );
+      break;
+    case "file-search":
+      modalNode = (
+        <FileSearchSheet
+          searchQuery={searchQuery}
+          searchResults={searchResults}
+          currentFolder={currentFolder ?? null}
+          currentFolderOnly={searchCurrentFolderOnly}
+          onToggleCurrentFolderOnly={setSearchCurrentFolderOnly}
+          onClose={() => setModal(null)}
+          onChange={handleSearchInput}
+          onSelect={(result) => {
+            setModal(null);
+            window.location.hash = `files&file=${encodeURIComponent(result.path)}`;
+            window.location.reload();
+          }}
+        />
+      );
+      break;
+    case "tldr":
+      modalNode = viewingFile ? <TldrModal viewingFile={viewingFile} onClose={() => setModal(null)} /> : null;
+      break;
+    case "audio-gen":
+      modalNode = viewingFile ? (
+        <AudioGenModal
+          viewingFile={viewingFile}
+          audioLoading={audioLoading}
+          audioOp={audioOp}
+          audioStatus={audioStatus}
+          onClose={() => setModal(null)}
+          onGenerate={() => void handleGenerateAudio(viewingFile.path)}
+          onSend={() => { if (audioStatus?.path) void handleSendAudio(audioStatus.path); }}
+        />
+      ) : null;
+      break;
   }
+
+  const isViewingMd = viewingFile?.name.toLowerCase().endsWith(".md");
 
   return (
     <>
       {modalNode}
       <div style={{ padding: "10px 12px 8px", borderTop: "1px solid var(--color-border)", flexShrink: 0 }}>
         <div style={{ display: "flex", gap: "8px", overflowX: "auto" }}>
-          <button onClick={() => { setModal("todo"); void loadTodo(); }} style={{ ...btnStyle, background: "#3a3520", color: "var(--color-accent-yellow)", border: "1px solid #5a4a30" }}>TODO</button>
+          <button
+            onClick={() => { haptic.impact("light"); setModal("todo"); void loadTodo(); }}
+            style={{ ...btnStyle, background: "#3a3520", color: "var(--color-accent-yellow)", border: "1px solid #5a4a30" }}
+          >
+            TODO
+          </button>
+
           {activeTab === "terminal" && <>
-            {onReconnect && <div style={{ display: "flex", flexShrink: 0 }}><button onClick={onReconnect} style={{ ...btnStyle, background: "#1a3a2a", color: "var(--color-accent-green)", border: "1px solid #2d5a3d", borderRadius: "6px 0 0 6px", borderRight: "none" }}>Reconnect</button><button onClick={() => setModal("reconnect-menu")} aria-label="Open reconnect menu" title="Open reconnect menu" style={{ ...btnStyle, background: "#1a3a2a", color: "var(--color-accent-green)", border: "1px solid #2d5a3d", borderRadius: "0 6px 6px 0", padding: "6px 8px", fontSize: 14 }}>&#9652;</button></div>}
-            <div style={{ display: "flex", flexShrink: 0 }}><button onClick={() => { setModal("git-status"); void loadGitStatus(); }} style={{ ...btnStyle, borderRadius: "6px 0 0 6px", borderRight: "none" }}>Git</button><button onClick={() => setModal("git-menu")} aria-label="Open git menu" title="Open git menu" style={{ ...btnStyle, borderRadius: "0 6px 6px 0", padding: "6px 8px", fontSize: 14 }}>&#9652;</button></div>
-            <button onClick={() => setModal("commands")} style={{ ...btnStyle, background: "#2d2a3a", color: "var(--color-accent-purple)", border: "1px solid #4a3d6a" }}>/commands</button>
+            {onReconnect && (
+              <div style={{ display: "flex", flexShrink: 0 }}>
+                <button
+                  onClick={() => { haptic.impact("light"); onReconnect(); }}
+                  style={{ ...btnStyle, background: "#1a3a2a", color: "var(--color-accent-green)", border: "1px solid #2d5a3d", borderRadius: "6px 0 0 6px", borderRight: "none" }}
+                >
+                  Reconnect
+                </button>
+                <button
+                  onClick={() => { haptic.impact("light"); setModal("reconnect-menu"); }}
+                  aria-label="Open reconnect menu"
+                  title="Open reconnect menu"
+                  style={{ ...btnStyle, background: "#1a3a2a", color: "var(--color-accent-green)", border: "1px solid #2d5a3d", borderRadius: "0 6px 6px 0", padding: "6px 8px", fontSize: 14 }}
+                >
+                  &#9652;
+                </button>
+              </div>
+            )}
+            <div style={{ display: "flex", flexShrink: 0 }}>
+              <button
+                onClick={() => { haptic.impact("light"); setModal("git-status"); void loadGitStatus(); }}
+                style={{ ...btnStyle, borderRadius: "6px 0 0 6px", borderRight: "none" }}
+              >
+                Git
+              </button>
+              <button
+                onClick={() => { haptic.impact("light"); setModal("git-menu"); }}
+                aria-label="Open git menu"
+                title="Open git menu"
+                style={{ ...btnStyle, borderRadius: "0 6px 6px 0", padding: "6px 8px", fontSize: 14 }}
+              >
+                &#9652;
+              </button>
+            </div>
+            <button
+              onClick={() => { haptic.impact("light"); setModal("commands"); }}
+              style={{ ...btnStyle, background: "#2d2a3a", color: "var(--color-accent-purple)", border: "1px solid #4a3d6a" }}
+            >
+              /commands
+            </button>
           </>}
-          {activeTab === "files" && !viewingFile && <><button onClick={() => { resetFileSearch(); setModal("file-search"); }} style={{ ...btnStyle, background: "#2d3a5a", color: "var(--color-accent-blue)", border: "1px solid #3d4a6a" }}>Search</button><button onClick={() => setModal("file-options")} style={btnStyle}>Options</button></>}
-          {activeTab === "files" && viewingFile && <button onClick={() => void handleSendToChat()} style={{ ...btnStyle, background: "#1a2a3a", color: "var(--color-accent-cyan)", border: "1px solid #2d4a5a" }}>Send to Chat</button>}
-          {activeTab === "files" && viewingFile?.name.toLowerCase().endsWith(".md") && <button onClick={() => setModal("tldr")} style={{ ...btnStyle, background: "#1a3a3a", color: "var(--color-accent-cyan)", border: "1px solid #2d5a5a" }}>TL;DR</button>}
-          {activeTab === "files" && viewingFile?.name.toLowerCase().endsWith(".md") && <button onClick={() => { void handleCheckAudio(viewingFile.path); setModal("audio-gen"); }} style={{ ...btnStyle, background: "#2d2a3a", color: "var(--color-accent-purple)", border: "1px solid #4a3d6a" }}>Audio</button>}
+
+          {activeTab === "files" && !viewingFile && <>
+            <button
+              onClick={() => { resetFileSearch(); setModal("file-search"); }}
+              style={{ ...btnStyle, background: "#2d3a5a", color: "var(--color-accent-blue)", border: "1px solid #3d4a6a" }}
+            >
+              Search
+            </button>
+            <button onClick={() => setModal("file-options")} style={btnStyle}>Options</button>
+          </>}
+
+          {activeTab === "files" && viewingFile && (
+            <button
+              onClick={() => { haptic.impact("light"); void handleSendToChat(); }}
+              style={{ ...btnStyle, background: "#1a2a3a", color: "var(--color-accent-cyan)", border: "1px solid #2d4a5a" }}
+            >
+              Send to Chat
+            </button>
+          )}
+
+          {activeTab === "files" && isViewingMd && (
+            <button
+              onClick={() => setModal("tldr")}
+              style={{ ...btnStyle, background: "#1a3a3a", color: "var(--color-accent-cyan)", border: "1px solid #2d5a5a" }}
+            >
+              TL;DR
+            </button>
+          )}
+
+          {activeTab === "files" && isViewingMd && viewingFile && (
+            <button
+              onClick={() => { void handleCheckAudio(viewingFile.path); setModal("audio-gen"); }}
+              style={{ ...btnStyle, background: "#2d2a3a", color: "var(--color-accent-purple)", border: "1px solid #4a3d6a" }}
+            >
+              Audio
+            </button>
+          )}
         </div>
         <StatusLine connected={connected} status={status} gitBranch={gitBranch} />
       </div>

--- a/apps/web/src/components/action-bar/ActionBar.tsx
+++ b/apps/web/src/components/action-bar/ActionBar.tsx
@@ -179,14 +179,12 @@ export function ActionBar({ onReconnect, connected, activeTab, fileShowHidden, s
       haptic.error();
       setStatus(`Failed: ${err instanceof Error ? err.message : String(err)}`);
     }
-    setTimeout(() => setStatus(null), 2000);
   };
   const handleFork = () => {
     const name = forkName.trim();
     setModal(null);
     void sendToTmux(name ? `/fork\n/rename ${name}` : "/fork");
     setStatus(name ? `Forked as "${name}"` : "Forked");
-    setTimeout(() => setStatus(null), 2000);
   };
   const handleGitAction = async (action: { label: string; command: string }) => {
     setGitOutput(`Running ${action.label}...`);
@@ -373,7 +371,6 @@ export function ActionBar({ onReconnect, connected, activeTab, fileShowHidden, s
       haptic.error();
       setStatus(`Restart failed: ${err instanceof Error ? err.message : String(err)}`);
     }
-    setTimeout(() => setStatus(null), 3000);
   };
   const handleSendToChat = async () => {
     if (!viewingFile) return;
@@ -391,7 +388,6 @@ export function ActionBar({ onReconnect, connected, activeTab, fileShowHidden, s
       haptic.error();
       setStatus("Failed");
     }
-    setTimeout(() => setStatus(null), 2000);
   };
 
   let modalNode: ReactNode = null;
@@ -400,10 +396,10 @@ export function ActionBar({ onReconnect, connected, activeTab, fileShowHidden, s
       modalNode = (
         <CommandsSheet
           onClose={() => setModal(null)}
-          onEsc={() => { void sendToTmux("Escape", true); setModal(null); setStatus("Sent: Esc"); setTimeout(() => setStatus(null), 1500); }}
-          onDigit={(digit) => { void sendToTmux(String(digit)); setModal(null); setStatus(`Sent: ${digit}`); setTimeout(() => setStatus(null), 1500); }}
-          onShiftTab={() => { void sendToTmux("BTab", true); setModal(null); setStatus("Sent: \u21e7Tab"); setTimeout(() => setStatus(null), 1500); }}
-          onControlB={() => { void sendToTmux("C-b", true); setModal(null); setStatus("Sent: ^B"); setTimeout(() => setStatus(null), 1500); }}
+          onEsc={() => { void sendToTmux("Escape", true); setModal(null); setStatus("Sent: Esc"); }}
+          onDigit={(digit) => { void sendToTmux(String(digit)); setModal(null); setStatus(`Sent: ${digit}`); }}
+          onShiftTab={() => { void sendToTmux("BTab", true); setModal(null); setStatus("Sent: \u21e7Tab"); }}
+          onControlB={() => { void sendToTmux("C-b", true); setModal(null); setStatus("Sent: ^B"); }}
           onNew={() => setModal("new-confirm")}
           onResume={() => { void loadSessionNames(); setModal("resume"); }}
           onFork={() => { setForkName(""); setModal("fork-name"); }}

--- a/apps/web/src/hooks/__tests__/usePreferences.test.tsx
+++ b/apps/web/src/hooks/__tests__/usePreferences.test.tsx
@@ -1,0 +1,155 @@
+import { beforeEach, afterEach, describe, it, expect } from "vitest";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { usePreferences } from "../usePreferences";
+import { __resetForTests } from "../../lib/cloud-storage";
+
+/**
+ * Integration tests for the usePreferences hook. We exercise the hook
+ * against the localStorage fallback (no Telegram global installed) since
+ * that path is deterministic under jsdom and covers the React-specific
+ * behaviours we care about here: default-on-first-render, async load,
+ * optimistic write, and key-change re-sync.
+ *
+ * The cloud-storage tests already cover the Telegram-backend async
+ * callbacks — this file focuses on the hook contract.
+ */
+
+beforeEach(() => {
+  __resetForTests();
+  localStorage.clear();
+});
+
+afterEach(() => {
+  localStorage.clear();
+});
+
+describe("usePreferences", () => {
+  it("returns the default value on first render", () => {
+    const { result } = renderHook(() =>
+      usePreferences<boolean>("toggle", true),
+    );
+    expect(result.current[0]).toBe(true);
+  });
+
+  it("isLoading is true on first render and false after the initial load resolves", async () => {
+    localStorage.setItem(
+      "cpc_dashboard_prefs",
+      JSON.stringify({ loading_test: "stored" }),
+    );
+    const { result } = renderHook(() =>
+      usePreferences<string>("loading_test", "default"),
+    );
+    // Third element is isLoading.
+    expect(result.current[2]).toBe(true);
+    // After the async load resolves, isLoading must be false and the value
+    // must be the stored value, not the default placeholder.
+    await waitFor(() => {
+      expect(result.current[2]).toBe(false);
+      expect(result.current[0]).toBe("stored");
+    });
+  });
+
+  it("hydrates from storage after mount", async () => {
+    // Seed localStorage with an existing blob.
+    localStorage.setItem(
+      "cpc_dashboard_prefs",
+      JSON.stringify({ toggle: false }),
+    );
+    const { result } = renderHook(() =>
+      usePreferences<boolean>("toggle", true),
+    );
+    // Initial render: default.
+    expect(result.current[0]).toBe(true);
+    // After the async load resolves, the stored value takes over.
+    await waitFor(() => expect(result.current[0]).toBe(false));
+  });
+
+  it("updates state synchronously when setValue is called (optimistic)", async () => {
+    const { result } = renderHook(() =>
+      usePreferences<number>("count", 0),
+    );
+    await waitFor(() => expect(result.current[0]).toBe(0));
+    act(() => {
+      result.current[1](7);
+    });
+    expect(result.current[0]).toBe(7);
+  });
+
+  it("persists the written value so a fresh mount sees it", async () => {
+    const first = renderHook(() =>
+      usePreferences<string>("name", "anon"),
+    );
+    await waitFor(() => expect(first.result.current[0]).toBe("anon"));
+    act(() => {
+      first.result.current[1]("liam");
+    });
+    // Wait for the write to drain to the backend.
+    await waitFor(() => {
+      const raw = localStorage.getItem("cpc_dashboard_prefs");
+      expect(raw && JSON.parse(raw).name).toBe("liam");
+    });
+
+    first.unmount();
+    __resetForTests();
+
+    const second = renderHook(() =>
+      usePreferences<string>("name", "anon"),
+    );
+    await waitFor(() => expect(second.result.current[0]).toBe("liam"));
+  });
+
+  it("does not re-fire the storage load on default-value identity changes", async () => {
+    // Re-rendering with a fresh default object literal must NOT overwrite
+    // the loaded value — the default is captured on first render.
+    localStorage.setItem(
+      "cpc_dashboard_prefs",
+      JSON.stringify({ list: ["a", "b"] }),
+    );
+    const { result, rerender } = renderHook(
+      ({ def }: { def: string[] }) =>
+        usePreferences<string[]>("list", def),
+      { initialProps: { def: [] as string[] } },
+    );
+    await waitFor(() =>
+      expect(result.current[0]).toEqual(["a", "b"]),
+    );
+    rerender({ def: ["fresh", "default"] });
+    // Stored value must still win after the rerender.
+    expect(result.current[0]).toEqual(["a", "b"]);
+  });
+
+  it("re-loads when the key prop changes", async () => {
+    localStorage.setItem(
+      "cpc_dashboard_prefs",
+      JSON.stringify({ alpha: 1, beta: 2 }),
+    );
+    const { result, rerender } = renderHook(
+      ({ k }: { k: string }) => usePreferences<number>(k, 0),
+      { initialProps: { k: "alpha" } },
+    );
+    await waitFor(() => expect(result.current[0]).toBe(1));
+    rerender({ k: "beta" });
+    await waitFor(() => expect(result.current[0]).toBe(2));
+  });
+
+  it("concurrent writes from two hooks against different keys both persist", async () => {
+    const h1 = renderHook(() =>
+      usePreferences<boolean>("a", false),
+    );
+    const h2 = renderHook(() =>
+      usePreferences<boolean>("b", false),
+    );
+    await waitFor(() => expect(h1.result.current[0]).toBe(false));
+    await waitFor(() => expect(h2.result.current[0]).toBe(false));
+    act(() => {
+      h1.result.current[1](true);
+      h2.result.current[1](true);
+    });
+    await waitFor(() => {
+      const raw = localStorage.getItem("cpc_dashboard_prefs");
+      expect(raw).toBeTruthy();
+      const parsed = JSON.parse(raw!);
+      expect(parsed).toEqual({ a: true, b: true });
+    });
+  });
+});

--- a/apps/web/src/hooks/usePreferences.ts
+++ b/apps/web/src/hooks/usePreferences.ts
@@ -1,0 +1,89 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { getPref, setPref } from "../lib/cloud-storage";
+
+/**
+ * React hook binding a single preference key to the unified cloud-storage
+ * wrapper. Returns a three-element tuple [value, setValue, isLoading].
+ * `isLoading` is true until the initial storage load resolves; callers can
+ * use it to distinguish the default placeholder from the actual stored value.
+ * The API is otherwise modeled on useState — so existing components using
+ * useState + useEffect(localStorage) can swap in with a minimal diff.
+ *
+ * Semantics:
+ *
+ * - The first render returns `defaultValue` synchronously. The actual
+ *   stored value loads asynchronously and triggers a re-render once
+ *   resolved. Callers should treat the initial value as a placeholder,
+ *   NOT as authoritative. For most UI prefs (toggle states, sort orders)
+ *   the one-frame flash to the stored value is imperceptible and preferable
+ *   to blocking the whole tree on storage.
+ *
+ * - `setValue` writes optimistically: local state updates immediately and
+ *   the storage write happens in the background. If the write fails we log
+ *   but do NOT roll back state — preferences are best-effort, and showing
+ *   the user's last click survive a refresh (via in-memory state) while a
+ *   network-less client silently fails to persist is the expected degraded
+ *   behaviour.
+ *
+ * - `defaultValue` is captured ONCE on first render via a ref. Passing a
+ *   fresh object/array literal on every render therefore does not cause
+ *   the storage load to re-fire. Callers who want to reset to a new default
+ *   should unmount and remount, or call setValue(newDefault) explicitly.
+ *
+ * - The hook does NOT listen for cross-tab storage events. CPC runs as a
+ *   Telegram mini app in a single webview per session; multi-tab sync has
+ *   no product value here and adds surface area for race bugs.
+ */
+export function usePreferences<T>(
+  key: string,
+  defaultValue: T,
+): [T, (value: T) => void, boolean] {
+  // Capture the default on first render — see JSDoc note above. Using a ref
+  // rather than a useState so we don't burn an extra slot.
+  const defaultRef = useRef<T>(defaultValue);
+  const [value, setValueState] = useState<T>(defaultValue);
+  // isLoading is true until the initial storage load resolves. Callers can
+  // use this to distinguish "default placeholder" from "actual stored value",
+  // e.g. to defer rendering a controlled input until the true value is known.
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+
+  // Track mount state so async resolution after unmount doesn't warn /
+  // mutate. React 18+ tolerates setState-after-unmount but still logs, and
+  // the transient Telegram CloudStorage latency (a few hundred ms) makes
+  // unmount-during-load genuinely possible on fast tab switches.
+  const mountedRef = useRef(true);
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  // Load once per (key) change. We depend on `key` so a component that
+  // dynamically switches keys (rare but not impossible) stays in sync.
+  useEffect(() => {
+    let cancelled = false;
+    setIsLoading(true);
+    void getPref<T>(key, defaultRef.current).then((stored) => {
+      if (cancelled || !mountedRef.current) return;
+      setValueState(stored);
+      setIsLoading(false);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [key]);
+
+  const setValue = useCallback(
+    (next: T) => {
+      setValueState(next);
+      void setPref<T>(key, next).catch((err) => {
+        // eslint-disable-next-line no-console
+        console.warn(`usePreferences: failed to persist ${key}`, err);
+      });
+    },
+    [key],
+  );
+
+  return [value, setValue, isLoading];
+}

--- a/apps/web/src/lib/__tests__/cloud-storage.test.ts
+++ b/apps/web/src/lib/__tests__/cloud-storage.test.ts
@@ -1,0 +1,299 @@
+import { beforeEach, afterEach, describe, it, expect, vi } from "vitest";
+import {
+  getPref,
+  setPref,
+  isAvailable,
+  __resetForTests,
+} from "../cloud-storage";
+
+/**
+ * Tests for the unified preferences wrapper. We exercise both backends:
+ *
+ *   1. The Telegram CloudStorage path, via a fake that mimics the async
+ *      err-first-callback contract and holds values in a plain Map.
+ *
+ *   2. The localStorage fallback, using jsdom's built-in implementation.
+ *
+ * Notable behaviours under test:
+ *
+ * - Serialization of concurrent writes (two setPref against the same key
+ *   must not lose the second write, and two setPref against DIFFERENT keys
+ *   must both land in the final blob).
+ * - Round-trip through the aggregate blob (stored under a single key).
+ * - Graceful degradation when CloudStorage is absent / throws / reports
+ *   isSupported() === false.
+ * - Safe parsing of corrupt/non-object stored values.
+ */
+
+type Cb<T = void> = (err: Error | null | string, value?: T) => void;
+
+interface FakeCloudStorageOptions {
+  isSupported?: boolean;
+  throwOnIsSupported?: boolean;
+  failNextSet?: boolean;
+  initial?: Record<string, string>;
+}
+
+function makeFakeCloudStorage(opts: FakeCloudStorageOptions = {}) {
+  const store = new Map<string, string>(
+    Object.entries(opts.initial ?? {}),
+  );
+  let failNextSet = opts.failNextSet ?? false;
+  const cs = {
+    isSupported: vi.fn(() => {
+      if (opts.throwOnIsSupported) throw new Error("no");
+      return opts.isSupported ?? true;
+    }),
+    getItem: vi.fn((key: string, cb: Cb<string>) => {
+      // Async callback to match the real Telegram API, which uses
+      // postMessage under the hood and never resolves synchronously.
+      queueMicrotask(() => cb(null, store.get(key) ?? ""));
+    }),
+    setItem: vi.fn(
+      (key: string, value: string, cb?: Cb<boolean>) => {
+        queueMicrotask(() => {
+          if (failNextSet) {
+            failNextSet = false;
+            cb?.(new Error("injected failure"));
+            return;
+          }
+          store.set(key, value);
+          cb?.(null, true);
+        });
+      },
+    ),
+    removeItem: vi.fn((key: string, cb?: (err: Error | null) => void) => {
+      queueMicrotask(() => {
+        store.delete(key);
+        cb?.(null);
+      });
+    }),
+    getKeys: vi.fn((cb: Cb<string[]>) => {
+      queueMicrotask(() => cb(null, Array.from(store.keys())));
+    }),
+    __store: store,
+  };
+  return cs;
+}
+
+function installTelegram(cs: ReturnType<typeof makeFakeCloudStorage> | null) {
+  // @ts-expect-error — test harness monkey-patch
+  window.Telegram = cs ? { WebApp: { CloudStorage: cs } } : undefined;
+}
+
+beforeEach(() => {
+  __resetForTests();
+  localStorage.clear();
+  installTelegram(null);
+});
+
+afterEach(() => {
+  installTelegram(null);
+  localStorage.clear();
+});
+
+describe("isAvailable()", () => {
+  it("returns false when no Telegram global exists", () => {
+    expect(isAvailable()).toBe(false);
+  });
+
+  it("returns true when CloudStorage.isSupported() returns true", () => {
+    installTelegram(makeFakeCloudStorage({ isSupported: true }));
+    expect(isAvailable()).toBe(true);
+  });
+
+  it("returns false when CloudStorage.isSupported() returns false", () => {
+    installTelegram(makeFakeCloudStorage({ isSupported: false }));
+    expect(isAvailable()).toBe(false);
+  });
+
+  it("returns false when CloudStorage.isSupported() throws", () => {
+    installTelegram(makeFakeCloudStorage({ throwOnIsSupported: true }));
+    expect(isAvailable()).toBe(false);
+  });
+
+  it("returns false when CloudStorage object is missing from WebApp", () => {
+    // @ts-expect-error — test harness
+    window.Telegram = { WebApp: {} };
+    expect(isAvailable()).toBe(false);
+  });
+
+  it("returns false when CloudStorage has no isSupported function (absent = not supported)", () => {
+    // An old polyfill might expose the CloudStorage object but omit isSupported.
+    // We must treat absence as "not supported", NOT "assume yes".
+    // @ts-expect-error — test harness: intentionally omitting isSupported
+    window.Telegram = { WebApp: { CloudStorage: { getItem: () => {}, setItem: () => {} } } };
+    expect(isAvailable()).toBe(false);
+  });
+});
+
+describe("localStorage fallback", () => {
+  it("returns the default when nothing is stored", async () => {
+    expect(await getPref("foo", "default")).toBe("default");
+  });
+
+  it("round-trips a string value through localStorage", async () => {
+    await setPref("greeting", "hello");
+    __resetForTests();
+    expect(await getPref("greeting", "fallback")).toBe("hello");
+  });
+
+  it("round-trips boolean, number, and object values", async () => {
+    await setPref("flag", true);
+    await setPref("count", 42);
+    await setPref("obj", { a: 1, b: [2, 3] });
+    __resetForTests();
+    expect(await getPref("flag", false)).toBe(true);
+    expect(await getPref("count", 0)).toBe(42);
+    expect(await getPref("obj", {})).toEqual({ a: 1, b: [2, 3] });
+  });
+
+  it("stores all keys under a single aggregate localStorage key", async () => {
+    await setPref("a", 1);
+    await setPref("b", 2);
+    await setPref("c", 3);
+    // Exactly one CPC prefs key should exist — not one per setting.
+    const cpcKeys = Object.keys(localStorage).filter((k) =>
+      k.startsWith("cpc_dashboard_prefs"),
+    );
+    expect(cpcKeys).toEqual(["cpc_dashboard_prefs"]);
+    const raw = localStorage.getItem("cpc_dashboard_prefs")!;
+    expect(JSON.parse(raw)).toEqual({ a: 1, b: 2, c: 3 });
+  });
+
+  it("recovers from corrupt JSON in localStorage by returning defaults", async () => {
+    localStorage.setItem("cpc_dashboard_prefs", "{not valid json");
+    expect(await getPref("anything", "dflt")).toBe("dflt");
+  });
+
+  it("ignores non-object stored values (arrays, primitives)", async () => {
+    localStorage.setItem("cpc_dashboard_prefs", JSON.stringify([1, 2, 3]));
+    expect(await getPref("x", "dflt")).toBe("dflt");
+  });
+});
+
+describe("CloudStorage backend", () => {
+  it("reads from Telegram CloudStorage when available", async () => {
+    const cs = makeFakeCloudStorage({
+      initial: {
+        cpc_dashboard_prefs: JSON.stringify({ theme: "dark" }),
+      },
+    });
+    installTelegram(cs);
+    expect(await getPref("theme", "light")).toBe("dark");
+    expect(cs.getItem).toHaveBeenCalledWith(
+      "cpc_dashboard_prefs",
+      expect.any(Function),
+    );
+  });
+
+  it("writes go to CloudStorage, not localStorage", async () => {
+    const cs = makeFakeCloudStorage();
+    installTelegram(cs);
+    await setPref("hidden", true);
+    expect(cs.setItem).toHaveBeenCalledTimes(1);
+    expect(localStorage.getItem("cpc_dashboard_prefs")).toBeNull();
+    expect(cs.__store.get("cpc_dashboard_prefs")).toBe(
+      JSON.stringify({ hidden: true }),
+    );
+  });
+
+  it("de-duplicates concurrent first-load getItem calls", async () => {
+    const cs = makeFakeCloudStorage({
+      initial: { cpc_dashboard_prefs: JSON.stringify({ a: 1 }) },
+    });
+    installTelegram(cs);
+    // Fire three reads in parallel before any resolve.
+    const [a, b, c] = await Promise.all([
+      getPref("a", 0),
+      getPref("a", 0),
+      getPref("a", 0),
+    ]);
+    expect([a, b, c]).toEqual([1, 1, 1]);
+    // Exactly one underlying getItem call — subsequent reads hit the cache
+    // or the in-flight loadPromise.
+    expect(cs.getItem).toHaveBeenCalledTimes(1);
+  });
+
+  it("serializes concurrent writes against the same key without losing updates", async () => {
+    const cs = makeFakeCloudStorage();
+    installTelegram(cs);
+    // Prime the snapshot so both writes see the same base.
+    await getPref("counter", 0);
+    await Promise.all([setPref("counter", 1), setPref("counter", 2)]);
+    // Both writes must have been applied — final value is whichever ran
+    // last (we guarantee ordering, not which one "wins" beyond that).
+    expect(await getPref("counter", 0)).toBe(2);
+    expect(cs.setItem).toHaveBeenCalledTimes(2);
+  });
+
+  it("serialized writes to different keys all land in the final blob", async () => {
+    const cs = makeFakeCloudStorage();
+    installTelegram(cs);
+    await Promise.all([
+      setPref("a", 1),
+      setPref("b", 2),
+      setPref("c", 3),
+    ]);
+    __resetForTests();
+    // Rehydrate from cloud: all three keys must have survived.
+    expect(await getPref("a", 0)).toBe(1);
+    expect(await getPref("b", 0)).toBe(2);
+    expect(await getPref("c", 0)).toBe(3);
+  });
+
+  it("propagates a setItem failure as a rejected setPref promise", async () => {
+    const cs = makeFakeCloudStorage({ failNextSet: true });
+    installTelegram(cs);
+    await expect(setPref("x", "y")).rejects.toThrow("injected failure");
+  });
+
+  it("keeps the write queue alive after a failed write", async () => {
+    const cs = makeFakeCloudStorage({ failNextSet: true });
+    installTelegram(cs);
+    // First write fails; second must still succeed.
+    await expect(setPref("x", 1)).rejects.toThrow();
+    await expect(setPref("x", 2)).resolves.toBeUndefined();
+    expect(await getPref("x", 0)).toBe(2);
+  });
+
+  it("rejects writes whose serialized blob would exceed 4096 chars", async () => {
+    const cs = makeFakeCloudStorage();
+    installTelegram(cs);
+    const huge = "x".repeat(5000);
+    await expect(setPref("big", huge)).rejects.toThrow(/4096/);
+  });
+
+  it("returns defaults when cloud getItem reports an error", async () => {
+    const cs = makeFakeCloudStorage();
+    // Override getItem to error.
+    cs.getItem.mockImplementation((_key, cb: Cb<string>) =>
+      queueMicrotask(() => cb("not supported")),
+    );
+    installTelegram(cs);
+    expect(await getPref("anything", "dflt")).toBe("dflt");
+  });
+});
+
+describe("cache semantics", () => {
+  it("does not re-read cloud storage on subsequent getPref calls", async () => {
+    const cs = makeFakeCloudStorage({
+      initial: { cpc_dashboard_prefs: JSON.stringify({ a: 1, b: 2 }) },
+    });
+    installTelegram(cs);
+    await getPref("a", 0);
+    await getPref("b", 0);
+    await getPref("c", 99);
+    expect(cs.getItem).toHaveBeenCalledTimes(1);
+  });
+
+  it("setPref updates the in-memory snapshot without requiring a re-read", async () => {
+    const cs = makeFakeCloudStorage();
+    installTelegram(cs);
+    await setPref("a", 1);
+    // getItem is called once inside the write path to prime the snapshot.
+    const priorGetCalls = cs.getItem.mock.calls.length;
+    expect(await getPref("a", 0)).toBe(1);
+    expect(cs.getItem.mock.calls.length).toBe(priorGetCalls);
+  });
+});

--- a/apps/web/src/lib/cloud-storage.ts
+++ b/apps/web/src/lib/cloud-storage.ts
@@ -1,0 +1,251 @@
+/**
+ * Unified preferences storage backed by Telegram Bot API 8.0+ CloudStorage
+ * with a localStorage fallback for older clients / non-Telegram contexts
+ * (e.g. the browser dev view at cpc.claude.do/dev/).
+ *
+ * Design decisions (see also ~/code/claude-pocket-console ADR TBD):
+ *
+ * 1. ONE aggregate key holds a JSON blob for all dashboard prefs.
+ *    Telegram's CloudStorage enforces a 1024-key-per-user-per-bot quota, and
+ *    one feature request churn can easily burn through dozens of keys if we
+ *    naïvely shard by preference name. Instead we keep everything under a
+ *    single `cpc_dashboard_prefs` key and JSON-stringify a flat record.
+ *
+ * 2. Same shape for both backends. When CloudStorage is unavailable we store
+ *    the identical JSON blob under the same key in localStorage, which means
+ *    a user who starts in a legacy client and later upgrades sees their
+ *    settings migrate organically the first time setPref() runs on the new
+ *    client (the write path reads-modifies-writes and upgrades the backing
+ *    store as a side effect).
+ *
+ * 3. All writes go through a single in-flight promise (`writeQueue`). The
+ *    Telegram CloudStorage API is async and two concurrent setPref() calls
+ *    against the same aggregate key would race: both read the old blob,
+ *    each writes its own mutation, the second write clobbers the first.
+ *    Serializing writes is correct-by-construction and much simpler than
+ *    CRDTs for a key-value preferences store.
+ *
+ * 4. In-memory snapshot cache. After the first load we keep the parsed blob
+ *    in memory so subsequent getPref() calls are synchronous-ish (still
+ *    returned via a resolved Promise to keep the API uniform). The snapshot
+ *    is invalidated on every successful write.
+ *
+ * 5. Missing keys in CloudStorage return `''` (empty string), NOT null or
+ *    undefined. We treat empty-string-or-missing identically: if JSON.parse
+ *    throws or yields a non-object, we start from {}.
+ */
+
+const AGGREGATE_KEY = "cpc_dashboard_prefs";
+
+interface TelegramCloudStorage {
+  isSupported?: () => boolean;
+  getItem: (
+    key: string,
+    callback: (err: Error | null | string, value?: string) => void,
+  ) => void;
+  setItem: (
+    key: string,
+    value: string,
+    callback?: (err: Error | null | string, success?: boolean) => void,
+  ) => void;
+  // Not used today but declared for completeness.
+  removeItem?: (key: string, callback?: (err: Error | null) => void) => void;
+  getKeys?: (
+    callback: (err: Error | null | string, keys?: string[]) => void,
+  ) => void;
+}
+
+interface TelegramWebAppWithCloudStorage {
+  CloudStorage?: TelegramCloudStorage;
+}
+
+type PrefBlob = Record<string, unknown>;
+
+// Module-level state. Both caches hold the SAME shape: the parsed aggregate
+// blob. `snapshot` is authoritative once loaded; `loadPromise` de-duplicates
+// concurrent first-load calls; `writeQueue` serializes writes.
+let snapshot: PrefBlob | null = null;
+let loadPromise: Promise<PrefBlob> | null = null;
+let writeQueue: Promise<void> = Promise.resolve();
+
+/**
+ * Returns the CloudStorage handle if the current Telegram client advertises
+ * Bot API 8.0+ support, otherwise null. Safe to call on any platform — the
+ * chain of optional accesses returns undefined when there's no Telegram
+ * global at all (plain browser dev view).
+ */
+function getCloudStorage(): TelegramCloudStorage | null {
+  const webapp = (window.Telegram?.WebApp ?? null) as
+    | TelegramWebAppWithCloudStorage
+    | null;
+  const cs = webapp?.CloudStorage;
+  if (!cs) return null;
+  // isSupported is a Telegram-level capability probe; when absent we assume
+  // "not supported" rather than "assume yes" so old polyfills don't false-
+  // positive. We require the function to be present AND return true — if it's
+  // missing the client hasn't declared Bot API 8.0 support so we reject.
+  try {
+    if (typeof cs.isSupported !== "function" || !cs.isSupported()) return null;
+  } catch {
+    return null;
+  }
+  return cs;
+}
+
+export function isAvailable(): boolean {
+  return getCloudStorage() !== null;
+}
+
+function safeParse(raw: string | undefined | null): PrefBlob {
+  if (!raw) return {};
+  try {
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return parsed as PrefBlob;
+    }
+  } catch {
+    /* fall through to empty */
+  }
+  return {};
+}
+
+function readFromLocalStorage(): PrefBlob {
+  try {
+    return safeParse(localStorage.getItem(AGGREGATE_KEY));
+  } catch {
+    return {};
+  }
+}
+
+function writeToLocalStorage(blob: PrefBlob): void {
+  try {
+    localStorage.setItem(AGGREGATE_KEY, JSON.stringify(blob));
+  } catch {
+    /* quota exceeded / private-mode Safari — best-effort */
+  }
+}
+
+function readFromCloud(cs: TelegramCloudStorage): Promise<PrefBlob> {
+  return new Promise((resolve) => {
+    cs.getItem(AGGREGATE_KEY, (err, value) => {
+      // Telegram's callback contract uses err-as-string for "not supported"
+      // shaped failures and Error for other clients. Either way we degrade
+      // to an empty blob rather than reject — callers have no good recovery
+      // path for a storage-read failure other than "use defaults".
+      if (err) {
+        resolve({});
+        return;
+      }
+      resolve(safeParse(value));
+    });
+  });
+}
+
+function writeToCloud(cs: TelegramCloudStorage, blob: PrefBlob): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const payload = JSON.stringify(blob);
+    // Telegram enforces a 4096-char limit per value. If we blow past that the
+    // API would fail silently — surface it as a rejection so getPref callers
+    // aren't stuck returning stale snapshots. Extremely unlikely to hit in
+    // practice since our prefs are flat booleans/short strings/small arrays.
+    if (payload.length > 4096) {
+      reject(
+        new Error(
+          `cloud-storage: aggregate prefs blob exceeds 4096 chars (got ${payload.length})`,
+        ),
+      );
+      return;
+    }
+    cs.setItem(AGGREGATE_KEY, payload, (err) => {
+      if (err) {
+        reject(err instanceof Error ? err : new Error(String(err)));
+        return;
+      }
+      resolve();
+    });
+  });
+}
+
+/**
+ * Load the aggregate blob, populating the module-level snapshot. Concurrent
+ * callers share a single in-flight promise so a dashboard that mounts ten
+ * components at once fires exactly one getItem() call.
+ */
+function loadSnapshot(): Promise<PrefBlob> {
+  if (snapshot !== null) return Promise.resolve(snapshot);
+  if (loadPromise) return loadPromise;
+  const cs = getCloudStorage();
+  loadPromise = (async () => {
+    const blob = cs ? await readFromCloud(cs) : readFromLocalStorage();
+    snapshot = blob;
+    return blob;
+  })();
+  // Clear the in-flight ref once settled so a subsequent resetForTests() or
+  // explicit invalidation can re-fetch.
+  void loadPromise.finally(() => {
+    loadPromise = null;
+  });
+  return loadPromise;
+}
+
+/**
+ * Read a preference by key. Returns the stored value or the supplied default
+ * if the key is missing or the stored value is of the wrong shape.
+ *
+ * Type parameter T is a hint for the caller — we do NOT runtime-validate the
+ * stored value against T because that would require a schema library. For
+ * booleans/strings/numbers the caller should pass a default of the right
+ * type and optionally narrow with a typeof check downstream.
+ */
+export async function getPref<T>(key: string, defaultValue: T): Promise<T> {
+  const blob = await loadSnapshot();
+  const val = blob[key];
+  if (val === undefined) return defaultValue;
+  return val as T;
+}
+
+/**
+ * Write a preference by key. Serializes against other writes so the read-
+ * modify-write sequence can't be interleaved by a concurrent caller.
+ *
+ * On write failure (e.g., quota exceeded, network error), the rejection
+ * propagates to the caller but the in-memory snapshot remains at the
+ * pre-failure state — the failed key's new value is NOT reflected. A
+ * subsequent successful write will NOT include the failed key's value unless
+ * the caller retries. Callers must retry failed writes explicitly if
+ * persistence is critical.
+ */
+export function setPref<T>(key: string, value: T): Promise<void> {
+  const next = writeQueue.then(async () => {
+    // Ensure we have the current blob before mutating. We deliberately call
+    // loadSnapshot() inside the queue so even the FIRST write after page
+    // load sees a consistent base.
+    const blob = await loadSnapshot();
+    const updated: PrefBlob = { ...blob, [key]: value };
+    const cs = getCloudStorage();
+    if (cs) {
+      await writeToCloud(cs, updated);
+    } else {
+      writeToLocalStorage(updated);
+    }
+    snapshot = updated;
+  });
+  // Chain the next write regardless of this one's success — a single failed
+  // write shouldn't permanently deadlock the queue. We swallow the error on
+  // the queue's internal chain but re-expose it on the returned promise.
+  writeQueue = next.catch(() => {
+    /* keep the queue alive */
+  });
+  return next;
+}
+
+/**
+ * Test-only hook. Exported so unit tests can reset module state between
+ * cases without needing vi.resetModules() (which is expensive). NOT intended
+ * for production callers.
+ */
+export function __resetForTests(): void {
+  snapshot = null;
+  loadPromise = null;
+  writeQueue = Promise.resolve();
+}

--- a/apps/web/src/lib/haptic.ts
+++ b/apps/web/src/lib/haptic.ts
@@ -1,0 +1,23 @@
+import { getTelegramWebApp } from "./telegram";
+
+function hf() {
+  return getTelegramWebApp()?.HapticFeedback;
+}
+
+export const haptic = {
+  impact(style: "light" | "medium" | "heavy" | "rigid" | "soft" = "light") {
+    hf()?.impactOccurred(style);
+  },
+  success() {
+    hf()?.notificationOccurred("success");
+  },
+  error() {
+    hf()?.notificationOccurred("error");
+  },
+  warning() {
+    hf()?.notificationOccurred("warning");
+  },
+  selection() {
+    hf()?.selectionChanged();
+  },
+};

--- a/apps/web/src/lib/telegram.ts
+++ b/apps/web/src/lib/telegram.ts
@@ -34,6 +34,8 @@ interface TelegramWebApp {
   themeParams: Record<string, string>;
   colorScheme: "light" | "dark";
   isExpanded: boolean;
+  checkHomeScreenStatus?(callback: (status: "added" | "missed" | "unknown") => void): void;
+  addToHomeScreen?(): void;
 }
 
 export function getTelegramWebApp(): TelegramWebApp | null {

--- a/apps/web/src/lib/telegram.ts
+++ b/apps/web/src/lib/telegram.ts
@@ -36,6 +36,11 @@ interface TelegramWebApp {
   isExpanded: boolean;
   checkHomeScreenStatus?(callback: (status: "added" | "missed" | "unknown") => void): void;
   addToHomeScreen?(): void;
+  HapticFeedback?: {
+    impactOccurred(style: "light" | "medium" | "heavy" | "rigid" | "soft"): void;
+    notificationOccurred(type: "error" | "success" | "warning"): void;
+    selectionChanged(): void;
+  };
 }
 
 export function getTelegramWebApp(): TelegramWebApp | null {

--- a/changelogs/unreleased/220-server-route-tests.md
+++ b/changelogs/unreleased/220-server-route-tests.md
@@ -1,0 +1,5 @@
+---
+type: infrastructure
+pr: 220
+---
+Add test coverage for /api/prs, /api/telegram, and routes/utils (47 new tests).

--- a/changelogs/unreleased/228-actionbar-tests.md
+++ b/changelogs/unreleased/228-actionbar-tests.md
@@ -1,0 +1,5 @@
+---
+type: infrastructure
+pr: 228
+---
+Add 47 tests for ActionBar.tsx component covering modals, state transitions, git, rename, and audio flows.

--- a/changelogs/unreleased/229-auth-hardening.md
+++ b/changelogs/unreleased/229-auth-hardening.md
@@ -1,0 +1,5 @@
+---
+type: fix
+pr: 229
+---
+Harden auth middleware — ticket length+format validation (blocks newline bypass) + initData auth_date expiry with NaN guard + ambiguous ticket+path request rejection.

--- a/changelogs/unreleased/230-send-to-chat-hardening.md
+++ b/changelogs/unreleased/230-send-to-chat-hardening.md
@@ -1,0 +1,5 @@
+---
+type: fix
+pr: 230
+---
+Validate filePath with isPathAllowed + replace shell curl with native fetch (eliminates shell injection) + check Telegram API response (return 502 on failure).

--- a/changelogs/unreleased/232-add-to-home-screen.md
+++ b/changelogs/unreleased/232-add-to-home-screen.md
@@ -1,0 +1,7 @@
+---
+type: feature
+pr: 232
+issue: 222
+---
+
+Add-to-home-screen prompt on first CPC launch. Uses Telegram Bot API 8.0+ `addToHomeScreen()` to offer a native shortcut after a 3-second delay. Prompt is shown at most once (suppressed via `localStorage`). Silently skipped on older Telegram clients that lack the API.

--- a/changelogs/unreleased/233-haptic-feedback.md
+++ b/changelogs/unreleased/233-haptic-feedback.md
@@ -1,0 +1,7 @@
+---
+type: feature
+pr: 233
+issue: 224
+---
+
+Haptic feedback on key events via Telegram Bot API 6.1+ `HapticFeedback`. Selection pulse on tab switches, success/error notifications on async outcomes, light impact on primary button taps and PR row taps. Gracefully skipped on older clients where the API is absent.

--- a/changelogs/unreleased/234-markdownviewer-tests.md
+++ b/changelogs/unreleased/234-markdownviewer-tests.md
@@ -1,0 +1,6 @@
+---
+type: infrastructure
+pr: 234
+---
+
+Add MarkdownViewer component test suite (29 tests). Covers rendering basics, collapsible section fold/unfold, external link handling (Telegram openLink + window.open fallback), code block rendering, GFM tables, and pre-block touch propagation. Fixes two synthetic-event test bugs found in swarm review.

--- a/changelogs/unreleased/235-terminal-tests.md
+++ b/changelogs/unreleased/235-terminal-tests.md
@@ -1,0 +1,6 @@
+---
+type: infrastructure
+pr: 235
+---
+
+Add Terminal component test suite (22 tests). Covers WebSocket URL construction, auth fallback chain (Telegram initData → URL param → localStorage), connection state callbacks, xterm initialization, message handling (dimensions/pane/raw), and cleanup on unmount. Establishes the WebSocket mock pattern for the codebase.

--- a/changelogs/unreleased/238-brighter-fileviewer-scrollbar.md
+++ b/changelogs/unreleased/238-brighter-fileviewer-scrollbar.md
@@ -1,0 +1,5 @@
+---
+type: feature
+pr: 238
+---
+Brighten FileViewer scrollbars (cyan `#7dcfff` thumb, blue hover) so long directory listings and file contents are obviously scrollable against the dark theme. Scoped to the FileViewer only — the rest of the app keeps its native scrollbars.

--- a/changelogs/unreleased/244-prs-tab-visibility.md
+++ b/changelogs/unreleased/244-prs-tab-visibility.md
@@ -1,0 +1,5 @@
+---
+type: fixes
+issue: 244
+---
+PRs tab now always visible — dropped stale `VITE_FEATURE_PR_TICKER` feature flag so the multi-repo PR dashboard (shipped in v1.11.0–v1.11.2) is reachable in prod without env wiring.

--- a/changelogs/unreleased/247-terminal-auto-reconnect.md
+++ b/changelogs/unreleased/247-terminal-auto-reconnect.md
@@ -1,0 +1,5 @@
+---
+type: features
+issue: 247
+---
+Terminal WebSocket auto-reconnects on initial open and when switching back to the Terminal tab, eliminating the need to manually tap Reconnect.


### PR DESCRIPTION
## Summary

18 commits from dev → main covering security hardening, comprehensive test suites, and new mini-app features.

### Security fixes
- **#229** — Ticket format validation + initData expiry + ambiguous request guard (closes #225, #227)
- **#230** — Validate filePath + replace curl with fetch in send-to-chat (closes #226)

### Tests (98 new tests)
- **#220** — Server route tests for prs, telegram, and utils
- **#228** — ActionBar component tests (47 tests)
- **#234** — MarkdownViewer component tests (29 tests)
- **#235** — Terminal component tests (22 tests)

### Features
- **#231** — Unified CloudStorage-backed preferences system
- **#236** — Offline PR cache with stale-while-revalidate (closes #223)
- **#232** — Add-to-home-screen prompt on first launch (closes #222)
- **#233** — Haptic feedback on key events (closes #224)
- **#238** — Brighter scrollbar against dark theme (#237)
- **#248** — Terminal auto-reconnect on tab switch and initial open (closes #247)
- **#245** — PRs tab in navigation array

## Test plan
- [ ] Verify mini app loads in Telegram
- [ ] Test terminal auto-reconnect on tab switch
- [ ] Test haptic feedback on buttons
- [ ] Verify security: ambiguous ticket+path requests return 400
- [ ] Verify CloudStorage preferences persist across sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)