### PR TITLE
feat(auth): multi-bot token support (closes #252)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,9 @@
 # Telegram bot token (same one used for the channel plugin)
 TELEGRAM_BOT_TOKEN=
 
+# For multi-bot support, use comma-separated list (takes priority over TELEGRAM_BOT_TOKEN)
+TELEGRAM_BOT_TOKENS=
+
 # Comma-separated Telegram user IDs allowed to access the app
 ALLOWED_TELEGRAM_USERS=<YOUR_TELEGRAM_USER_ID>
 

--- a/apps/server/src/auth.ts
+++ b/apps/server/src/auth.ts
@@ -173,12 +173,32 @@ export function validateSession(token: string): { valid: boolean; user?: Telegra
   return { valid: true, user: session.user };
 }
 
+/** Return the list of bot tokens to validate against.
+ * Prefers TELEGRAM_BOT_TOKENS (comma-separated) over TELEGRAM_BOT_TOKEN. */
+export function getBotTokens(): string[] {
+  const multi = process.env.TELEGRAM_BOT_TOKENS;
+  if (multi) {
+    const tokens = multi.split(",").map((t) => t.trim()).filter(Boolean);
+    if (tokens.length > 0) return tokens;
+  }
+  const single = process.env.TELEGRAM_BOT_TOKEN;
+  return single ? [single] : [];
+}
+
 /** Full auth check: validate initData + check allowlist. Returns user if authorized. */
 export function checkAuth(initData: string): { ok: boolean; user?: TelegramUser; error?: string } {
-  const botToken = process.env.TELEGRAM_BOT_TOKEN;
-  if (!botToken) return { ok: false, error: "Server not configured" };
+  const tokens = getBotTokens();
+  if (tokens.length === 0) return { ok: false, error: "Server not configured" };
 
-  const { valid, user } = validateTelegramInitData(initData, botToken);
+  let lastResult: { valid: boolean; user?: TelegramUser } = { valid: false };
+  for (const token of tokens) {
+    const result = validateTelegramInitData(initData, token);
+    if (result.valid) {
+      lastResult = result;
+      break;
+    }
+  }
+  const { valid, user } = lastResult;
   if (!valid) return { ok: false, error: "Invalid auth" };
 
   const allowed = getAllowedUsers();

--- a/apps/server/src/auth.ts
+++ b/apps/server/src/auth.ts
@@ -173,6 +173,34 @@ export function validateSession(token: string): { valid: boolean; user?: Telegra
   return { valid: true, user: session.user };
 }
 
+/**
+ * Try initData against each token in order; return first success or { valid: false }.
+ */
+export function validateTelegramInitDataWithTokens(
+  initData: string,
+  tokens: string[],
+): { valid: boolean; user?: TelegramUser } {
+  for (const token of tokens) {
+    const result = validateTelegramInitData(initData, token);
+    if (result.valid) return result;
+  }
+  return { valid: false };
+}
+
+/**
+ * Try a JWT token against each bot token in order; return first success or { valid: false }.
+ */
+export function validateJwtTokenWithTokens(
+  jwtToken: string,
+  tokens: string[],
+): { valid: boolean; user?: TelegramUser } {
+  for (const token of tokens) {
+    const result = validateJwtToken(jwtToken, token);
+    if (result.valid) return result;
+  }
+  return { valid: false };
+}
+
 /** Return the list of bot tokens to validate against.
  * Prefers TELEGRAM_BOT_TOKENS (comma-separated) over TELEGRAM_BOT_TOKEN. */
 export function getBotTokens(): string[] {
@@ -190,15 +218,7 @@ export function checkAuth(initData: string): { ok: boolean; user?: TelegramUser;
   const tokens = getBotTokens();
   if (tokens.length === 0) return { ok: false, error: "Server not configured" };
 
-  let lastResult: { valid: boolean; user?: TelegramUser } = { valid: false };
-  for (const token of tokens) {
-    const result = validateTelegramInitData(initData, token);
-    if (result.valid) {
-      lastResult = result;
-      break;
-    }
-  }
-  const { valid, user } = lastResult;
+  const { valid, user } = validateTelegramInitDataWithTokens(initData, tokens);
   if (!valid) return { ok: false, error: "Invalid auth" };
 
   const allowed = getAllowedUsers();

--- a/apps/server/src/middleware.ts
+++ b/apps/server/src/middleware.ts
@@ -1,5 +1,10 @@
 import type { Context, Next } from "hono";
-import { validateTelegramInitData, validateSession, validateJwtToken, getBotTokens } from "./auth.js";
+import {
+  validateSession,
+  getBotTokens,
+  validateTelegramInitDataWithTokens,
+  validateJwtTokenWithTokens,
+} from "./auth.js";
 import { isAllowedUser } from "./lib/allowed-users.js";
 
 /**
@@ -46,17 +51,7 @@ export async function telegramAuth(c: Context, next: Next) {
   // Primary: Telegram Mini App initData
   if (authHeader?.startsWith("tma ")) {
     const initData = authHeader.slice(4);
-    // Try each token; accept on first match
-    let valid = false;
-    let user: ReturnType<typeof validateTelegramInitData>["user"];
-    for (const token of botTokens) {
-      const result = validateTelegramInitData(initData, token);
-      if (result.valid) {
-        valid = true;
-        user = result.user;
-        break;
-      }
-    }
+    const { valid, user } = validateTelegramInitDataWithTokens(initData, botTokens);
 
     if (!valid) {
       return c.json({ error: "Invalid Telegram auth" }, 401);
@@ -94,11 +89,7 @@ export async function telegramAuth(c: Context, next: Next) {
     }
 
     // Try JWT token validation (keyboard button auth) — try each configured bot token
-    let jwtResult: ReturnType<typeof validateJwtToken> = { valid: false };
-    for (const bt of botTokens) {
-      const r = validateJwtToken(token, bt);
-      if (r.valid) { jwtResult = r; break; }
-    }
+    const jwtResult = validateJwtTokenWithTokens(token, botTokens);
     if (jwtResult.valid) {
       if (!isAllowedUser(jwtResult.user?.id)) {
         return c.json({ error: "User not authorized" }, 403);
@@ -118,12 +109,7 @@ export async function telegramAuth(c: Context, next: Next) {
   // Fallback: JWT token in query param (keyboard button auth)
   const urlToken = c.req.query("token");
   if (urlToken) {
-    let jwtQResult: ReturnType<typeof validateJwtToken> = { valid: false };
-    for (const bt of botTokens) {
-      const r = validateJwtToken(urlToken, bt);
-      if (r.valid) { jwtQResult = r; break; }
-    }
-    const { valid, user } = jwtQResult;
+    const { valid, user } = validateJwtTokenWithTokens(urlToken, botTokens);
     if (valid) {
       if (!isAllowedUser(user?.id)) {
         return c.json({ error: "User not authorized" }, 403);

--- a/apps/server/src/middleware.ts
+++ b/apps/server/src/middleware.ts
@@ -1,5 +1,5 @@
 import type { Context, Next } from "hono";
-import { validateTelegramInitData, validateSession, validateJwtToken } from "./auth.js";
+import { validateTelegramInitData, validateSession, validateJwtToken, getBotTokens } from "./auth.js";
 import { isAllowedUser } from "./lib/allowed-users.js";
 
 /**
@@ -36,8 +36,8 @@ export async function telegramAuth(c: Context, next: Next) {
     return;
   }
 
-  const botToken = process.env.TELEGRAM_BOT_TOKEN;
-  if (!botToken) {
+  const botTokens = getBotTokens();
+  if (botTokens.length === 0) {
     return c.json({ error: "Server not configured: missing bot token" }, 500);
   }
 
@@ -46,7 +46,17 @@ export async function telegramAuth(c: Context, next: Next) {
   // Primary: Telegram Mini App initData
   if (authHeader?.startsWith("tma ")) {
     const initData = authHeader.slice(4);
-    const { valid, user } = validateTelegramInitData(initData, botToken);
+    // Try each token; accept on first match
+    let valid = false;
+    let user: ReturnType<typeof validateTelegramInitData>["user"];
+    for (const token of botTokens) {
+      const result = validateTelegramInitData(initData, token);
+      if (result.valid) {
+        valid = true;
+        user = result.user;
+        break;
+      }
+    }
 
     if (!valid) {
       return c.json({ error: "Invalid Telegram auth" }, 401);
@@ -83,8 +93,12 @@ export async function telegramAuth(c: Context, next: Next) {
       return;
     }
 
-    // Try JWT token validation (keyboard button auth)
-    const jwtResult = validateJwtToken(token, botToken);
+    // Try JWT token validation (keyboard button auth) — try each configured bot token
+    let jwtResult: ReturnType<typeof validateJwtToken> = { valid: false };
+    for (const bt of botTokens) {
+      const r = validateJwtToken(token, bt);
+      if (r.valid) { jwtResult = r; break; }
+    }
     if (jwtResult.valid) {
       if (!isAllowedUser(jwtResult.user?.id)) {
         return c.json({ error: "User not authorized" }, 403);
@@ -104,7 +118,12 @@ export async function telegramAuth(c: Context, next: Next) {
   // Fallback: JWT token in query param (keyboard button auth)
   const urlToken = c.req.query("token");
   if (urlToken) {
-    const { valid, user } = validateJwtToken(urlToken, botToken);
+    let jwtQResult: ReturnType<typeof validateJwtToken> = { valid: false };
+    for (const bt of botTokens) {
+      const r = validateJwtToken(urlToken, bt);
+      if (r.valid) { jwtQResult = r; break; }
+    }
+    const { valid, user } = jwtQResult;
     if (valid) {
       if (!isAllowedUser(user?.id)) {
         return c.json({ error: "User not authorized" }, 403);

--- a/apps/server/src/routes/__tests__/auth.test.ts
+++ b/apps/server/src/routes/__tests__/auth.test.ts
@@ -246,6 +246,69 @@ describe("telegramAuth middleware", () => {
     });
   });
 
+  describe("multi-bot token support (TELEGRAM_BOT_TOKENS)", () => {
+    const SECOND_BOT_TOKEN = "654321:XYZ-TOKEN2ndBot-abcdef";
+
+    it("accepts initData signed by the second token in TELEGRAM_BOT_TOKENS list", async () => {
+      const originalSingle = process.env.TELEGRAM_BOT_TOKEN;
+      const hadMulti = "TELEGRAM_BOT_TOKENS" in process.env;
+      const originalMulti = process.env.TELEGRAM_BOT_TOKENS;
+      process.env.TELEGRAM_BOT_TOKENS = `${TEST_BOT_TOKEN},${SECOND_BOT_TOKEN}`;
+      delete process.env.TELEGRAM_BOT_TOKEN;
+      try {
+        const initData = makeInitData(TEST_USER, { botToken: SECOND_BOT_TOKEN });
+        const res = await app.request("/api/test", {
+          headers: { Authorization: `tma ${initData}` },
+        });
+        expect(res.status).toBe(200);
+      } finally {
+        if (originalSingle !== undefined) {
+          process.env.TELEGRAM_BOT_TOKEN = originalSingle;
+        }
+        if (hadMulti) {
+          process.env.TELEGRAM_BOT_TOKENS = originalMulti;
+        } else {
+          delete process.env.TELEGRAM_BOT_TOKENS;
+        }
+      }
+    });
+
+    it("rejects initData when no token in TELEGRAM_BOT_TOKENS matches", async () => {
+      const originalSingle = process.env.TELEGRAM_BOT_TOKEN;
+      const hadMulti = "TELEGRAM_BOT_TOKENS" in process.env;
+      const originalMulti = process.env.TELEGRAM_BOT_TOKENS;
+      process.env.TELEGRAM_BOT_TOKENS = `${TEST_BOT_TOKEN},${SECOND_BOT_TOKEN}`;
+      delete process.env.TELEGRAM_BOT_TOKEN;
+      try {
+        const initData = makeInitData(TEST_USER, { botToken: "999999:UNREGISTERED-TOKEN" });
+        const res = await app.request("/api/test", {
+          headers: { Authorization: `tma ${initData}` },
+        });
+        expect(res.status).toBe(401);
+        const body = (await res.json()) as { error: string };
+        expect(body.error).toBe("Invalid Telegram auth");
+      } finally {
+        if (originalSingle !== undefined) {
+          process.env.TELEGRAM_BOT_TOKEN = originalSingle;
+        }
+        if (hadMulti) {
+          process.env.TELEGRAM_BOT_TOKENS = originalMulti;
+        } else {
+          delete process.env.TELEGRAM_BOT_TOKENS;
+        }
+      }
+    });
+
+    it("falls back to TELEGRAM_BOT_TOKEN when TELEGRAM_BOT_TOKENS is not set", async () => {
+      // Default test env already has TELEGRAM_BOT_TOKEN set — just verify existing behavior
+      const initData = makeInitData(TEST_USER);
+      const res = await app.request("/api/test", {
+        headers: { Authorization: `tma ${initData}` },
+      });
+      expect(res.status).toBe(200);
+    });
+  });
+
   describe("ticket format bypass (issue #225)", () => {
     it("bypasses auth for a valid hex-32 ticket on /api/files/download", async () => {
       const res = await app.request(

--- a/apps/server/src/routes/terminal-ws.ts
+++ b/apps/server/src/routes/terminal-ws.ts
@@ -1,6 +1,6 @@
 import { spawn, execSync } from "node:child_process";
 import type { WSContext } from "hono/ws";
-import { checkAuth, validateSession, validateJwtToken } from "../auth.js";
+import { checkAuth, validateSession, validateJwtToken, getBotTokens } from "../auth.js";
 import { isAllowedUser } from "../lib/allowed-users.js";
 // Import the validated TMUX_SESSION from routes/utils so we inherit the
 // `/^[A-Za-z0-9_.-]+$/` character-set check that runs once at module load.
@@ -61,15 +61,17 @@ export function terminalWsRoute(c: any) {
       }
 
       // Fallback: JWT token validation (keyboard button auth)
+      // Iterates all configured bot tokens (TELEGRAM_BOT_TOKENS or TELEGRAM_BOT_TOKEN)
+      // so multi-bot deployments work over WebSocket the same as over HTTP.
       if (!authResult.ok) {
-        const botToken = process.env.TELEGRAM_BOT_TOKEN;
-        if (botToken) {
-          const { valid: jwtValid, user: jwtUser } = validateJwtToken(token, botToken);
-          if (jwtValid && jwtUser) {
-            if (isAllowedUser(jwtUser.id)) {
-              authResult = { ok: true, user: jwtUser };
-            }
-          }
+        const botTokens = getBotTokens();
+        let jwtUser = null;
+        for (const t of botTokens) {
+          const { valid: jwtValid, user: u } = validateJwtToken(token, t);
+          if (jwtValid && u) { jwtUser = u; break; }
+        }
+        if (jwtUser && isAllowedUser(jwtUser.id)) {
+          authResult = { ok: true, user: jwtUser };
         }
       }
     }

--- a/apps/server/src/routes/terminal-ws.ts
+++ b/apps/server/src/routes/terminal-ws.ts
@@ -1,6 +1,6 @@
 import { spawn, execSync } from "node:child_process";
 import type { WSContext } from "hono/ws";
-import { checkAuth, validateSession, validateJwtToken, getBotTokens } from "../auth.js";
+import { checkAuth, validateSession, validateJwtTokenWithTokens, getBotTokens } from "../auth.js";
 import { isAllowedUser } from "../lib/allowed-users.js";
 // Import the validated TMUX_SESSION from routes/utils so we inherit the
 // `/^[A-Za-z0-9_.-]+$/` character-set check that runs once at module load.
@@ -64,13 +64,8 @@ export function terminalWsRoute(c: any) {
       // Iterates all configured bot tokens (TELEGRAM_BOT_TOKENS or TELEGRAM_BOT_TOKEN)
       // so multi-bot deployments work over WebSocket the same as over HTTP.
       if (!authResult.ok) {
-        const botTokens = getBotTokens();
-        let jwtUser = null;
-        for (const t of botTokens) {
-          const { valid: jwtValid, user: u } = validateJwtToken(token, t);
-          if (jwtValid && u) { jwtUser = u; break; }
-        }
-        if (jwtUser && isAllowedUser(jwtUser.id)) {
+        const { valid: jwtValid, user: jwtUser } = validateJwtTokenWithTokens(token, getBotTokens());
+        if (jwtValid && jwtUser && isAllowedUser(jwtUser.id)) {
           authResult = { ok: true, user: jwtUser };
         }
       }


### PR DESCRIPTION
## Summary

- Adds `TELEGRAM_BOT_TOKENS` env var (comma-separated list) for multi-bot mini app access
- `checkAuth()` and `telegramAuth` middleware try each token in order; accept on first match
- Full backwards compat: `TELEGRAM_BOT_TOKEN` (single) still works unchanged
- JWT Bearer + query-param token paths also updated to try all configured tokens

## Changes

- `apps/server/src/auth.ts`: new `getBotTokens()` helper + updated `checkAuth()`
- `apps/server/src/middleware.ts`: tma / Bearer JWT / query-param JWT all multi-token aware
- `apps/server/src/routes/__tests__/auth.test.ts`: 3 new test cases

## Test plan

- [x] 268 tests pass (3 new: second-token match, all-tokens-fail → 401, single-token fallback)
- [x] Build clean (tsc + vite)
- [x] Backwards compatible: existing single-token behavior verified by existing test suite

Closes #252

🤖 Generated with [Claude Code](https://claude.com/claude-code)