### PR TITLE
feat(nav): Phase 2 — drawer gesture system (peek/half/full snap)

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -63,6 +63,9 @@ export function App() {
     setReconnectKey((k) => k + 1);
   }, []);
 
+  // Drawer snap imperative handle — BottomDrawer assigns animateTo here
+  const drawerSnapRef = useRef<((snap: "peek" | "half" | "full") => void) | null>(null);
+
   // Swipe gesture state
   const touchStartX = useRef(0);
   const touchStartY = useRef(0);
@@ -323,8 +326,13 @@ export function App() {
       </div>
 
       {/* Bottom tab dock — rendered via portal to escape CSS transform containment */}
-      <BottomDrawer>
-        <TabDock activeTab={activeTab} onTabChange={(tab) => { haptic.selection(); setIsAnimating(true); setActiveTab(tab); }} connected={connected} />
+      <BottomDrawer snapToRef={drawerSnapRef}>
+        <TabDock
+          activeTab={activeTab}
+          onTabChange={(tab) => { haptic.selection(); setIsAnimating(true); setActiveTab(tab); }}
+          connected={connected}
+          onMore={() => drawerSnapRef.current?.("full")}
+        />
       </BottomDrawer>
 
       {/* Home screen prompt — rendered once, dismissed to localStorage */}

--- a/apps/web/src/components/BottomDrawer.css
+++ b/apps/web/src/components/BottomDrawer.css
@@ -2,20 +2,74 @@
   --dock-height: calc(48px + env(safe-area-inset-bottom, 0px));
 }
 
+/* Dimmed overlay */
+.drawer-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0);
+  pointer-events: none;
+  transition: background 300ms ease-out;
+  z-index: 10;
+}
+
+/* Drawer shell */
 .bottom-drawer {
   position: fixed;
   left: 0;
   right: 0;
   bottom: 0;
-  height: var(--dock-height);
+  height: 90vh;
   background: var(--color-bg);
   border-top: 1px solid var(--color-border);
+  border-radius: 16px 16px 0 0;
   z-index: 20;
   display: flex;
-  align-items: flex-start;
+  flex-direction: column;
   will-change: transform;
+  contain: layout style;
 }
 
+/* Drag handle */
+.drawer-handle {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 24px;
+  cursor: grab;
+  opacity: 0;
+  transition: opacity 200ms ease;
+  touch-action: none;
+}
+
+.drawer-handle.visible {
+  opacity: 1;
+}
+
+.drawer-handle-bar {
+  width: 36px;
+  height: 4px;
+  border-radius: 2px;
+  background: var(--color-subtle);
+}
+
+/* Expandable content (empty in Phase 2) */
+.drawer-content {
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+}
+
+/* Tab dock — pinned to bottom of drawer */
+.drawer-tab-dock {
+  flex-shrink: 0;
+  height: var(--dock-height);
+  display: flex;
+  align-items: flex-start;
+  border-top: 1px solid var(--color-border);
+}
+
+/* WebKit scrollbar hide for pill strip */
 .tab-dock-pills::-webkit-scrollbar {
   display: none;
 }

--- a/apps/web/src/components/BottomDrawer.css
+++ b/apps/web/src/components/BottomDrawer.css
@@ -60,13 +60,13 @@
   overflow: hidden;
 }
 
-/* Tab dock — pinned to bottom of drawer */
+/* Tab dock — pinned to top of drawer (first in DOM, visible in peek) */
 .drawer-tab-dock {
   flex-shrink: 0;
   height: var(--dock-height);
   display: flex;
   align-items: flex-start;
-  border-top: 1px solid var(--color-border);
+  border-bottom: 1px solid var(--color-border);
 }
 
 /* WebKit scrollbar hide for pill strip */

--- a/apps/web/src/components/BottomDrawer.tsx
+++ b/apps/web/src/components/BottomDrawer.tsx
@@ -1,5 +1,5 @@
 import { createPortal } from "react-dom";
-import { useRef, useState, useCallback, useEffect } from "react";
+import { useRef, useState, useCallback, useEffect, useLayoutEffect } from "react";
 import { useDrawerGesture } from "../hooks/useDrawerGesture";
 import type { SnapPoint } from "../hooks/useDrawerGesture";
 import "./BottomDrawer.css";
@@ -22,11 +22,11 @@ export function BottomDrawer({ children, onSnapChange, snapToRef }: BottomDrawer
     onSnapChange?.(s);
   }, [onSnapChange]);
 
-  const handleDragEnd = useCallback(() => {
-    wasDragging.current = true;
+  const handleDragEnd = useCallback((hasMoved: boolean) => {
+    if (hasMoved) wasDragging.current = true;
   }, []);
 
-  const { onTouchStart, onTouchMove, onTouchEnd, animateTo } = useDrawerGesture({
+  const { onTouchStart, onTouchMove, onTouchEnd, onTouchCancel, animateTo } = useDrawerGesture({
     drawerRef,
     overlayRef,
     onSnapChange: handleSnapChange,
@@ -41,10 +41,11 @@ export function BottomDrawer({ children, onSnapChange, snapToRef }: BottomDrawer
   }, [snapToRef, animateTo]);
 
   // Replace CSS-calc initial transform with a resolved px value so DOMMatrix
-  // can read it correctly on first touch (WebKit may return NaN for env() expressions)
-  useEffect(() => {
-    animateTo("peek");
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps — intentional mount-only
+  // can read it correctly on first touch (WebKit may return NaN for env() expressions).
+  // useLayoutEffect fires before paint — no transition flicker on mount.
+  useLayoutEffect(() => {
+    animateTo("peek", true); // instant = true, no transition on mount
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   const handleOverlayTap = useCallback(() => {
     if (wasDragging.current) { wasDragging.current = false; return; }
@@ -79,6 +80,7 @@ export function BottomDrawer({ children, onSnapChange, snapToRef }: BottomDrawer
           onTouchStart={onTouchStart}
           onTouchMove={onTouchMove}
           onTouchEnd={onTouchEnd}
+          onTouchCancel={onTouchCancel}
         >
           <div className="drawer-handle-bar" />
         </div>

--- a/apps/web/src/components/BottomDrawer.tsx
+++ b/apps/web/src/components/BottomDrawer.tsx
@@ -26,11 +26,16 @@ export function BottomDrawer({ children, onSnapChange, snapToRef }: BottomDrawer
     if (hasMoved) wasDragging.current = true;
   }, []);
 
+  const handleDragStart = useCallback(() => {
+    wasDragging.current = false;
+  }, []);
+
   const { onTouchStart, onTouchMove, onTouchEnd, onTouchCancel, animateTo } = useDrawerGesture({
     drawerRef,
     overlayRef,
     onSnapChange: handleSnapChange,
     onDragEnd: handleDragEnd,
+    onDragStart: handleDragStart,
   });
 
   // Expose animateTo imperatively so App.tsx can call it for onMore
@@ -63,14 +68,21 @@ export function BottomDrawer({ children, onSnapChange, snapToRef }: BottomDrawer
         onClick={handleOverlayTap}
       />
 
-      {/* Drawer shell — 90vh tall, translateY to peek position initially */}
+      {/* Drawer shell — 90vh tall; useLayoutEffect writes initial px transform before paint */}
       <div
         ref={drawerRef}
         className="bottom-drawer"
-        style={{ transform: `translateY(calc(90vh - var(--dock-height)))` }}
       >
-        {/* Tab dock — FIRST in DOM so it's visible in peek (top of shifted-down element) */}
-        <div className="drawer-tab-dock">
+        {/* Tab dock — FIRST in DOM so it's visible in peek (top of shifted-down element).
+            Gesture handlers attached here provide drag surface in peek state.
+            onTouchEnd only calls stopPropagation when hasMoved=true so pill taps still fire. */}
+        <div
+          className="drawer-tab-dock"
+          onTouchStart={onTouchStart}
+          onTouchMove={onTouchMove}
+          onTouchEnd={onTouchEnd}
+          onTouchCancel={onTouchCancel}
+        >
           {children}
         </div>
 

--- a/apps/web/src/components/BottomDrawer.tsx
+++ b/apps/web/src/components/BottomDrawer.tsx
@@ -23,7 +23,10 @@ export function BottomDrawer({ children, onSnapChange, snapToRef }: BottomDrawer
   }, [onSnapChange]);
 
   const handleDragEnd = useCallback((hasMoved: boolean) => {
-    if (hasMoved) wasDragging.current = true;
+    if (hasMoved) {
+      wasDragging.current = true;
+      setTimeout(() => { wasDragging.current = false; }, 100);
+    }
   }, []);
 
   const handleDragStart = useCallback(() => {

--- a/apps/web/src/components/BottomDrawer.tsx
+++ b/apps/web/src/components/BottomDrawer.tsx
@@ -1,16 +1,79 @@
 import { createPortal } from "react-dom";
+import { useRef, useState, useCallback, useEffect } from "react";
+import { useDrawerGesture } from "../hooks/useDrawerGesture";
+import type { SnapPoint } from "../hooks/useDrawerGesture";
 import "./BottomDrawer.css";
 
 interface BottomDrawerProps {
-  children: React.ReactNode;
+  children: React.ReactNode; // TabDock (always visible at bottom)
+  onSnapChange?: (snap: SnapPoint) => void;
+  // Imperative handle: parent passes a ref, we assign animateTo into it
+  snapToRef?: React.MutableRefObject<((snap: SnapPoint) => void) | null>;
 }
 
-export function BottomDrawer({ children }: BottomDrawerProps) {
+export function BottomDrawer({ children, onSnapChange, snapToRef }: BottomDrawerProps) {
+  const drawerRef = useRef<HTMLDivElement>(null);
+  const overlayRef = useRef<HTMLDivElement>(null);
+  const [snap, setSnap] = useState<SnapPoint>("peek");
+
+  const handleSnapChange = useCallback((s: SnapPoint) => {
+    setSnap(s);
+    onSnapChange?.(s);
+  }, [onSnapChange]);
+
+  const { onTouchStart, onTouchMove, onTouchEnd, animateTo } = useDrawerGesture({
+    drawerRef,
+    overlayRef,
+    onSnapChange: handleSnapChange,
+  });
+
+  // Expose animateTo imperatively so App.tsx can call it for onMore
+  useEffect(() => {
+    if (snapToRef) {
+      snapToRef.current = animateTo;
+    }
+  }, [snapToRef, animateTo]);
+
+  const handleOverlayTap = useCallback(() => {
+    animateTo("peek");
+  }, [animateTo]);
+
   if (typeof document === "undefined") return null;
+
   return createPortal(
-    <div className="bottom-drawer">
-      {children}
-    </div>,
+    <>
+      {/* Dimmed overlay — behind drawer, above content */}
+      <div
+        ref={overlayRef}
+        className="drawer-overlay"
+        onClick={handleOverlayTap}
+      />
+
+      {/* Drawer shell — 90vh tall, translateY to peek position initially */}
+      <div
+        ref={drawerRef}
+        className="bottom-drawer"
+        style={{ transform: `translateY(calc(90vh - var(--dock-height)))` }}
+      >
+        {/* Drag handle — only visible when half/full */}
+        <div
+          className={`drawer-handle${snap !== "peek" ? " visible" : ""}`}
+          onTouchStart={onTouchStart}
+          onTouchMove={onTouchMove}
+          onTouchEnd={onTouchEnd}
+        >
+          <div className="drawer-handle-bar" />
+        </div>
+
+        {/* Expandable content area — empty in Phase 2, filled in Phase 3+ */}
+        <div className="drawer-content" />
+
+        {/* Tab dock — always at bottom */}
+        <div className="drawer-tab-dock">
+          {children}
+        </div>
+      </div>
+    </>,
     document.body
   );
 }

--- a/apps/web/src/components/BottomDrawer.tsx
+++ b/apps/web/src/components/BottomDrawer.tsx
@@ -15,16 +15,22 @@ export function BottomDrawer({ children, onSnapChange, snapToRef }: BottomDrawer
   const drawerRef = useRef<HTMLDivElement>(null);
   const overlayRef = useRef<HTMLDivElement>(null);
   const [snap, setSnap] = useState<SnapPoint>("peek");
+  const wasDragging = useRef(false);
 
   const handleSnapChange = useCallback((s: SnapPoint) => {
     setSnap(s);
     onSnapChange?.(s);
   }, [onSnapChange]);
 
+  const handleDragEnd = useCallback(() => {
+    wasDragging.current = true;
+  }, []);
+
   const { onTouchStart, onTouchMove, onTouchEnd, animateTo } = useDrawerGesture({
     drawerRef,
     overlayRef,
     onSnapChange: handleSnapChange,
+    onDragEnd: handleDragEnd,
   });
 
   // Expose animateTo imperatively so App.tsx can call it for onMore
@@ -34,7 +40,14 @@ export function BottomDrawer({ children, onSnapChange, snapToRef }: BottomDrawer
     }
   }, [snapToRef, animateTo]);
 
+  // Replace CSS-calc initial transform with a resolved px value so DOMMatrix
+  // can read it correctly on first touch (WebKit may return NaN for env() expressions)
+  useEffect(() => {
+    animateTo("peek");
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps — intentional mount-only
+
   const handleOverlayTap = useCallback(() => {
+    if (wasDragging.current) { wasDragging.current = false; return; }
     animateTo("peek");
   }, [animateTo]);
 
@@ -55,6 +68,11 @@ export function BottomDrawer({ children, onSnapChange, snapToRef }: BottomDrawer
         className="bottom-drawer"
         style={{ transform: `translateY(calc(90vh - var(--dock-height)))` }}
       >
+        {/* Tab dock — FIRST in DOM so it's visible in peek (top of shifted-down element) */}
+        <div className="drawer-tab-dock">
+          {children}
+        </div>
+
         {/* Drag handle — only visible when half/full */}
         <div
           className={`drawer-handle${snap !== "peek" ? " visible" : ""}`}
@@ -67,11 +85,6 @@ export function BottomDrawer({ children, onSnapChange, snapToRef }: BottomDrawer
 
         {/* Expandable content area — empty in Phase 2, filled in Phase 3+ */}
         <div className="drawer-content" />
-
-        {/* Tab dock — always at bottom */}
-        <div className="drawer-tab-dock">
-          {children}
-        </div>
       </div>
     </>,
     document.body

--- a/apps/web/src/components/BottomDrawer.tsx
+++ b/apps/web/src/components/BottomDrawer.tsx
@@ -40,9 +40,10 @@ export function BottomDrawer({ children, onSnapChange, snapToRef }: BottomDrawer
 
   // Expose animateTo imperatively so App.tsx can call it for onMore
   useEffect(() => {
-    if (snapToRef) {
-      snapToRef.current = animateTo;
-    }
+    if (snapToRef) snapToRef.current = animateTo;
+    return () => {
+      if (snapToRef) snapToRef.current = null;
+    };
   }, [snapToRef, animateTo]);
 
   // Replace CSS-calc initial transform with a resolved px value so DOMMatrix

--- a/apps/web/src/components/TabDock.tsx
+++ b/apps/web/src/components/TabDock.tsx
@@ -14,9 +14,10 @@ interface TabDockProps {
   activeTab: Tab;
   onTabChange: (tab: Tab) => void;
   connected: boolean;
+  onMore: () => void;
 }
 
-export function TabDock({ activeTab, onTabChange, connected }: TabDockProps) {
+export function TabDock({ activeTab, onTabChange, connected, onMore }: TabDockProps) {
   return (
     <div style={{
       display: "flex",
@@ -67,7 +68,7 @@ export function TabDock({ activeTab, onTabChange, connected }: TabDockProps) {
 
       {/* More button */}
       <button
-        onClick={() => {}}
+        onClick={onMore}
         style={{
           padding: "6px 10px",
           borderRadius: 16,

--- a/apps/web/src/hooks/useDrawerGesture.ts
+++ b/apps/web/src/hooks/useDrawerGesture.ts
@@ -1,0 +1,152 @@
+import { useRef, useCallback } from "react";
+
+export type SnapPoint = "peek" | "half" | "full";
+
+interface UseDrawerGestureConfig {
+  drawerRef: React.RefObject<HTMLDivElement | null>;
+  overlayRef: React.RefObject<HTMLDivElement | null>;
+  onSnapChange: (snap: SnapPoint) => void;
+}
+
+// Snap positions as translateY values (drawer is 90vh tall):
+// peek: translateY(calc(90vh - 48px - env(safe-area-inset-bottom, 0px)))  → shows 48px
+// half: translateY(50vh)   → shows 40vh
+// full: translateY(0)      → shows 90vh
+
+export function useDrawerGesture({ drawerRef, overlayRef, onSnapChange }: UseDrawerGestureConfig) {
+  const snapRef = useRef<SnapPoint>("peek");
+  const startY = useRef(0);
+  const startTranslateY = useRef(0);
+  const lastY = useRef(0);
+  const lastTime = useRef(0);
+  const velocity = useRef(0);
+
+  const getTranslateYForSnap = useCallback((snap: SnapPoint): number => {
+    const vh = window.innerHeight;
+    const drawerH = vh * 0.9;
+    switch (snap) {
+      case "peek": return drawerH - 48; // approximation — safe area handled in CSS
+      case "half": return vh * 0.5;
+      case "full": return 0;
+    }
+  }, []);
+
+  const animateTo = useCallback((snap: SnapPoint) => {
+    const el = drawerRef.current;
+    const overlay = overlayRef.current;
+    if (!el) return;
+    const y = getTranslateYForSnap(snap);
+    el.style.transition = "transform 300ms cubic-bezier(0.25, 1, 0.5, 1)";
+    el.style.transform = `translateY(${y}px)`;
+    // Update overlay opacity
+    if (overlay) {
+      overlay.style.transition = "background 300ms ease-out";
+      if (snap === "peek") {
+        overlay.style.background = "rgba(0,0,0,0)";
+        overlay.style.pointerEvents = "none";
+      } else {
+        overlay.style.background = "rgba(0,0,0,0.4)";
+        overlay.style.pointerEvents = "auto";
+      }
+    }
+    // Telegram swipe API
+    const tg = (window as any).Telegram?.WebApp;
+    if (snap === "peek") {
+      tg?.enableVerticalSwipes?.();
+    } else {
+      tg?.disableVerticalSwipes?.();
+    }
+    snapRef.current = snap;
+    onSnapChange(snap);
+  }, [drawerRef, overlayRef, getTranslateYForSnap, onSnapChange]);
+
+  const getCurrentTranslateY = useCallback((): number => {
+    const el = drawerRef.current;
+    if (!el) return getTranslateYForSnap("peek");
+    const style = window.getComputedStyle(el);
+    const matrix = new DOMMatrix(style.transform);
+    return matrix.m42; // translateY value
+  }, [drawerRef, getTranslateYForSnap]);
+
+  const onTouchStart = useCallback((e: React.TouchEvent) => {
+    e.stopPropagation();
+    const touch = e.touches[0];
+    startY.current = touch.clientY;
+    lastY.current = touch.clientY;
+    lastTime.current = Date.now();
+    velocity.current = 0;
+    startTranslateY.current = getCurrentTranslateY();
+    const el = drawerRef.current;
+    if (el) {
+      el.style.transition = "none";
+    }
+  }, [drawerRef, getCurrentTranslateY]);
+
+  const onTouchMove = useCallback((e: React.TouchEvent) => {
+    e.stopPropagation();
+    const touch = e.touches[0];
+    const dy = touch.clientY - startY.current;
+    const now = Date.now();
+    const dt = now - lastTime.current;
+    if (dt > 0) {
+      velocity.current = (touch.clientY - lastY.current) / dt; // px/ms, positive = down
+    }
+    lastY.current = touch.clientY;
+    lastTime.current = now;
+
+    const el = drawerRef.current;
+    if (!el) return;
+
+    const vh = window.innerHeight;
+    const drawerH = vh * 0.9;
+    let targetY = startTranslateY.current + dy;
+
+    // Rubber-band at edges
+    const minY = 0; // full
+    const maxY = drawerH - 48; // peek
+    if (targetY < minY) {
+      targetY = minY + (targetY - minY) * 0.3;
+    } else if (targetY > maxY) {
+      targetY = maxY + (targetY - maxY) * 0.3;
+    }
+
+    el.style.transform = `translateY(${targetY}px)`;
+  }, [drawerRef]);
+
+  const onTouchEnd = useCallback((_e: React.TouchEvent) => {
+    const vh = window.innerHeight;
+    const drawerH = vh * 0.9;
+    const currentY = getCurrentTranslateY();
+    const v = velocity.current; // px/ms, positive = downward
+
+    const peekY = drawerH - 48;
+    const halfY = vh * 0.5;
+    const fullY = 0;
+
+    let target: SnapPoint;
+
+    // Velocity-based flick detection (> 0.5px/ms)
+    if (v > 0.5) {
+      // Fast flick down
+      if (snapRef.current === "full") target = "half";
+      else target = "peek";
+    } else if (v < -0.5) {
+      // Fast flick up
+      if (snapRef.current === "peek") target = "half";
+      else target = "full";
+    } else {
+      // Position-based snap — nearest point
+      const distToPeek = Math.abs(currentY - peekY);
+      const distToHalf = Math.abs(currentY - halfY);
+      const distToFull = Math.abs(currentY - fullY);
+      const min = Math.min(distToPeek, distToHalf, distToFull);
+      if (min === distToFull) target = "full";
+      else if (min === distToHalf) target = "half";
+      else target = "peek";
+    }
+
+    animateTo(target);
+  }, [getCurrentTranslateY, animateTo]);
+
+  return { onTouchStart, onTouchMove, onTouchEnd, animateTo, snapRef };
+}

--- a/apps/web/src/hooks/useDrawerGesture.ts
+++ b/apps/web/src/hooks/useDrawerGesture.ts
@@ -2,10 +2,18 @@ import { useRef, useCallback } from "react";
 
 export type SnapPoint = "peek" | "half" | "full";
 
+/** Read --dock-height CSS variable so JS peek position matches CSS exactly (safe-area-aware). */
+function getDockHeight(): number {
+  const raw = getComputedStyle(document.documentElement)
+    .getPropertyValue("--dock-height").trim();
+  return parseFloat(raw) || 48;
+}
+
 interface UseDrawerGestureConfig {
   drawerRef: React.RefObject<HTMLDivElement | null>;
   overlayRef: React.RefObject<HTMLDivElement | null>;
   onSnapChange: (snap: SnapPoint) => void;
+  onDragEnd?: () => void;
 }
 
 // Snap positions as translateY values (drawer is 90vh tall):
@@ -13,7 +21,7 @@ interface UseDrawerGestureConfig {
 // half: translateY(50vh)   → shows 40vh
 // full: translateY(0)      → shows 90vh
 
-export function useDrawerGesture({ drawerRef, overlayRef, onSnapChange }: UseDrawerGestureConfig) {
+export function useDrawerGesture({ drawerRef, overlayRef, onSnapChange, onDragEnd }: UseDrawerGestureConfig) {
   const snapRef = useRef<SnapPoint>("peek");
   const startY = useRef(0);
   const startTranslateY = useRef(0);
@@ -25,7 +33,7 @@ export function useDrawerGesture({ drawerRef, overlayRef, onSnapChange }: UseDra
     const vh = window.innerHeight;
     const drawerH = vh * 0.9;
     switch (snap) {
-      case "peek": return drawerH - 48; // approximation — safe area handled in CSS
+      case "peek": return drawerH - getDockHeight(); // safe-area-aware via CSS var
       case "half": return vh * 0.5;
       case "full": return 0;
     }
@@ -64,12 +72,21 @@ export function useDrawerGesture({ drawerRef, overlayRef, onSnapChange }: UseDra
     const el = drawerRef.current;
     if (!el) return getTranslateYForSnap("peek");
     const style = window.getComputedStyle(el);
-    const matrix = new DOMMatrix(style.transform);
-    return matrix.m42; // translateY value
+    const transform = style.transform;
+    if (!transform || transform === "none") return getTranslateYForSnap("peek");
+    try {
+      const matrix = new DOMMatrix(transform);
+      return isNaN(matrix.m42) ? getTranslateYForSnap("peek") : matrix.m42;
+    } catch {
+      return getTranslateYForSnap("peek");
+    }
   }, [drawerRef, getTranslateYForSnap]);
 
   const onTouchStart = useCallback((e: React.TouchEvent) => {
     e.stopPropagation();
+    // Disable Telegram vertical swipe dismissal as soon as a drag begins
+    const tg = (window as any).Telegram?.WebApp;
+    tg?.disableVerticalSwipes?.();
     const touch = e.touches[0];
     startY.current = touch.clientY;
     lastY.current = touch.clientY;
@@ -103,7 +120,7 @@ export function useDrawerGesture({ drawerRef, overlayRef, onSnapChange }: UseDra
 
     // Rubber-band at edges
     const minY = 0; // full
-    const maxY = drawerH - 48; // peek
+    const maxY = drawerH - getDockHeight(); // peek — safe-area-aware
     if (targetY < minY) {
       targetY = minY + (targetY - minY) * 0.3;
     } else if (targetY > maxY) {
@@ -113,13 +130,14 @@ export function useDrawerGesture({ drawerRef, overlayRef, onSnapChange }: UseDra
     el.style.transform = `translateY(${targetY}px)`;
   }, [drawerRef]);
 
-  const onTouchEnd = useCallback((_e: React.TouchEvent) => {
+  const onTouchEnd = useCallback((e: React.TouchEvent) => {
+    e.stopPropagation();
     const vh = window.innerHeight;
     const drawerH = vh * 0.9;
     const currentY = getCurrentTranslateY();
     const v = velocity.current; // px/ms, positive = downward
 
-    const peekY = drawerH - 48;
+    const peekY = drawerH - getDockHeight();
     const halfY = vh * 0.5;
     const fullY = 0;
 
@@ -145,8 +163,9 @@ export function useDrawerGesture({ drawerRef, overlayRef, onSnapChange }: UseDra
       else target = "peek";
     }
 
+    onDragEnd?.();
     animateTo(target);
-  }, [getCurrentTranslateY, animateTo]);
+  }, [getCurrentTranslateY, animateTo, onDragEnd]);
 
   return { onTouchStart, onTouchMove, onTouchEnd, animateTo, snapRef };
 }

--- a/apps/web/src/hooks/useDrawerGesture.ts
+++ b/apps/web/src/hooks/useDrawerGesture.ts
@@ -149,6 +149,7 @@ export function useDrawerGesture({ drawerRef, overlayRef, onSnapChange, onDragEn
 
   const onTouchEnd = useCallback((e: React.TouchEvent) => {
     if (!hasMoved.current) return; // tap, not a drag — don't snap
+    e.preventDefault(); // prevent browser from synthesizing a click after a drag gesture
     e.stopPropagation();
     const vh = window.innerHeight;
     const drawerH = vh * 0.9;
@@ -198,7 +199,13 @@ export function useDrawerGesture({ drawerRef, overlayRef, onSnapChange, onDragEn
       el.style.transition = "none";
       el.style.transform = `translateY(${y}px)`;
     }
-  }, [drawerRef, getTranslateYForSnap]);
+    // Reset overlay if cancelled while at peek — otherwise it freezes at partial opacity
+    if (snapRef.current === "peek" && overlayRef.current) {
+      overlayRef.current.style.transition = "none";
+      overlayRef.current.style.background = "rgba(0,0,0,0)";
+      overlayRef.current.style.pointerEvents = "none";
+    }
+  }, [drawerRef, overlayRef, getTranslateYForSnap]);
 
   // Re-enable Telegram vertical swipes on unmount
   useEffect(() => {

--- a/apps/web/src/hooks/useDrawerGesture.ts
+++ b/apps/web/src/hooks/useDrawerGesture.ts
@@ -13,6 +13,7 @@ interface UseDrawerGestureConfig {
   overlayRef: React.RefObject<HTMLDivElement | null>;
   onSnapChange: (snap: SnapPoint) => void;
   onDragEnd?: (hasMoved: boolean) => void;
+  onDragStart?: () => void;
 }
 
 // Snap positions as translateY values (drawer is 90vh tall):
@@ -20,7 +21,7 @@ interface UseDrawerGestureConfig {
 // half: translateY(50vh)   → shows 40vh
 // full: translateY(0)      → shows 90vh
 
-export function useDrawerGesture({ drawerRef, overlayRef, onSnapChange, onDragEnd }: UseDrawerGestureConfig) {
+export function useDrawerGesture({ drawerRef, overlayRef, onSnapChange, onDragEnd, onDragStart }: UseDrawerGestureConfig) {
   const snapRef = useRef<SnapPoint>("peek");
   const startY = useRef(0);
   const startTranslateY = useRef(0);
@@ -84,6 +85,7 @@ export function useDrawerGesture({ drawerRef, overlayRef, onSnapChange, onDragEn
 
   const onTouchStart = useCallback((e: React.TouchEvent) => {
     e.stopPropagation();
+    onDragStart?.();
     // Disable Telegram vertical swipe dismissal as soon as a drag begins
     const tg = (window as any).Telegram?.WebApp;
     tg?.disableVerticalSwipes?.();
@@ -98,7 +100,7 @@ export function useDrawerGesture({ drawerRef, overlayRef, onSnapChange, onDragEn
     if (el) {
       el.style.transition = "none";
     }
-  }, [drawerRef, getCurrentTranslateY]);
+  }, [drawerRef, getCurrentTranslateY, onDragStart]);
 
   const onTouchMove = useCallback((e: React.TouchEvent) => {
     e.stopPropagation();
@@ -135,7 +137,7 @@ export function useDrawerGesture({ drawerRef, overlayRef, onSnapChange, onDragEn
   }, [drawerRef]);
 
   const onTouchEnd = useCallback((e: React.TouchEvent) => {
-    e.stopPropagation();
+    if (hasMoved.current) e.stopPropagation(); // allow taps to reach pill buttons
     const vh = window.innerHeight;
     const drawerH = vh * 0.9;
     const currentY = getCurrentTranslateY();
@@ -173,7 +175,10 @@ export function useDrawerGesture({ drawerRef, overlayRef, onSnapChange, onDragEn
 
   const onTouchCancel = useCallback(() => {
     const tg = (window as any).Telegram?.WebApp;
-    tg?.enableVerticalSwipes?.();
+    // Only re-enable vertical swipes if we're at peek — don't re-enable while expanded overlay is showing
+    if (snapRef.current === "peek") {
+      tg?.enableVerticalSwipes?.();
+    }
     // Snap back to current snap point instantly — no transition
     const el = drawerRef.current;
     if (el) {

--- a/apps/web/src/hooks/useDrawerGesture.ts
+++ b/apps/web/src/hooks/useDrawerGesture.ts
@@ -134,10 +134,22 @@ export function useDrawerGesture({ drawerRef, overlayRef, onSnapChange, onDragEn
     }
 
     el.style.transform = `translateY(${targetY}px)`;
-  }, [drawerRef]);
+
+    // Update overlay in real-time during drag
+    const overlay = overlayRef.current;
+    if (overlay && hasMoved.current) {
+      const peekY = drawerH - getDockHeight();
+      // progress: 0 = at peek, 1 = at full
+      const progress = Math.max(0, Math.min(1, (peekY - targetY) / peekY));
+      overlay.style.transition = "none";
+      overlay.style.background = `rgba(0,0,0,${0.4 * progress})`;
+      overlay.style.pointerEvents = progress > 0.05 ? "auto" : "none";
+    }
+  }, [drawerRef, overlayRef]);
 
   const onTouchEnd = useCallback((e: React.TouchEvent) => {
-    if (hasMoved.current) e.stopPropagation(); // allow taps to reach pill buttons
+    if (!hasMoved.current) return; // tap, not a drag — don't snap
+    e.stopPropagation();
     const vh = window.innerHeight;
     const drawerH = vh * 0.9;
     const currentY = getCurrentTranslateY();

--- a/apps/web/src/hooks/useDrawerGesture.ts
+++ b/apps/web/src/hooks/useDrawerGesture.ts
@@ -1,19 +1,18 @@
-import { useRef, useCallback } from "react";
+import { useRef, useCallback, useEffect } from "react";
 
 export type SnapPoint = "peek" | "half" | "full";
 
-/** Read --dock-height CSS variable so JS peek position matches CSS exactly (safe-area-aware). */
+/** Resolve dock height using Telegram WebApp safe-area API (matches BottomSheet.tsx pattern). */
 function getDockHeight(): number {
-  const raw = getComputedStyle(document.documentElement)
-    .getPropertyValue("--dock-height").trim();
-  return parseFloat(raw) || 48;
+  const safeArea = (window as any).Telegram?.WebApp?.safeAreaInset?.bottom ?? 0;
+  return 48 + safeArea;
 }
 
 interface UseDrawerGestureConfig {
   drawerRef: React.RefObject<HTMLDivElement | null>;
   overlayRef: React.RefObject<HTMLDivElement | null>;
   onSnapChange: (snap: SnapPoint) => void;
-  onDragEnd?: () => void;
+  onDragEnd?: (hasMoved: boolean) => void;
 }
 
 // Snap positions as translateY values (drawer is 90vh tall):
@@ -28,6 +27,7 @@ export function useDrawerGesture({ drawerRef, overlayRef, onSnapChange, onDragEn
   const lastY = useRef(0);
   const lastTime = useRef(0);
   const velocity = useRef(0);
+  const hasMoved = useRef(false);
 
   const getTranslateYForSnap = useCallback((snap: SnapPoint): number => {
     const vh = window.innerHeight;
@@ -39,12 +39,12 @@ export function useDrawerGesture({ drawerRef, overlayRef, onSnapChange, onDragEn
     }
   }, []);
 
-  const animateTo = useCallback((snap: SnapPoint) => {
+  const animateTo = useCallback((snap: SnapPoint, instant = false) => {
     const el = drawerRef.current;
     const overlay = overlayRef.current;
     if (!el) return;
     const y = getTranslateYForSnap(snap);
-    el.style.transition = "transform 300ms cubic-bezier(0.25, 1, 0.5, 1)";
+    el.style.transition = instant ? "none" : "transform 300ms cubic-bezier(0.25, 1, 0.5, 1)";
     el.style.transform = `translateY(${y}px)`;
     // Update overlay opacity
     if (overlay) {
@@ -92,6 +92,7 @@ export function useDrawerGesture({ drawerRef, overlayRef, onSnapChange, onDragEn
     lastY.current = touch.clientY;
     lastTime.current = Date.now();
     velocity.current = 0;
+    hasMoved.current = false;
     startTranslateY.current = getCurrentTranslateY();
     const el = drawerRef.current;
     if (el) {
@@ -110,6 +111,9 @@ export function useDrawerGesture({ drawerRef, overlayRef, onSnapChange, onDragEn
     }
     lastY.current = touch.clientY;
     lastTime.current = now;
+    if (Math.abs(touch.clientY - startY.current) > 5) {
+      hasMoved.current = true;
+    }
 
     const el = drawerRef.current;
     if (!el) return;
@@ -163,9 +167,29 @@ export function useDrawerGesture({ drawerRef, overlayRef, onSnapChange, onDragEn
       else target = "peek";
     }
 
-    onDragEnd?.();
+    onDragEnd?.(hasMoved.current);
     animateTo(target);
   }, [getCurrentTranslateY, animateTo, onDragEnd]);
 
-  return { onTouchStart, onTouchMove, onTouchEnd, animateTo, snapRef };
+  const onTouchCancel = useCallback(() => {
+    const tg = (window as any).Telegram?.WebApp;
+    tg?.enableVerticalSwipes?.();
+    // Snap back to current snap point instantly — no transition
+    const el = drawerRef.current;
+    if (el) {
+      const y = getTranslateYForSnap(snapRef.current);
+      el.style.transition = "none";
+      el.style.transform = `translateY(${y}px)`;
+    }
+  }, [drawerRef, getTranslateYForSnap]);
+
+  // Re-enable Telegram vertical swipes on unmount
+  useEffect(() => {
+    return () => {
+      const tg = (window as any).Telegram?.WebApp;
+      tg?.enableVerticalSwipes?.();
+    };
+  }, []);
+
+  return { onTouchStart, onTouchMove, onTouchEnd, onTouchCancel, animateTo, snapRef };
 }


### PR DESCRIPTION
## Summary

Closes #256

- New `useDrawerGesture.ts` hook — all drag logic via refs + direct DOM writes (60fps, no React state during touchMove), velocity flick detection (>0.5px/ms), rubber-band at edges, Telegram `disableVerticalSwipes`/`enableVerticalSwipes` lifecycle
- `BottomDrawer.tsx` rewrite — 90vh shell, three snap points (peek 48px / half 40vh / full 90vh), drag handle (visible half/full), dimmed overlay with tap-to-collapse, imperative `snapToRef` for `onMore` wiring
- `BottomDrawer.css` rewrite — overlay, shell, handle, content flex layout, tab dock pinned correctly
- `TabDock.tsx` — `onMore` prop wired to More (⋯) button → snaps to full
- `App.tsx` — `drawerSnapRef` + `onMore` callback wired through

## Key implementation decisions

- `getDockHeight()` uses `Telegram.WebApp.safeAreaInset.bottom` (matches BottomSheet.tsx pattern) — not CSS var parsing (parseFloat on `calc()` returns NaN)
- Mount snap via `useLayoutEffect` + `instant=true` — no paint flicker on first load
- Tab dock is drag surface at peek (handlers on `drawer-tab-dock`) — invisible but functional, no visual drag handle at peek per spec
- `onTouchEnd` early-returns on `!hasMoved` — tab pill taps never trigger snap logic
- Real-time overlay opacity in `onTouchMove` — blocks through-taps during upward drag

## Review trail

Local 3-tier swarm run × 6 rounds (6 fix iterations). Issues caught and fixed:
- R1: flex order wrong (tab dock off-screen), safe-area JS/CSS mismatch, DOMMatrix env() failure, 4× medium fixes
- R2: getDockHeight() broken (NaN), mount flicker, wasDragging double-tap, touchCancel missing
- R3: getDockHeight via Telegram API, useLayoutEffect instant mount, hasMoved threshold, onTouchCancel + cleanup
- R4: JSX transform removed (re-render fight), drag-from-peek surface, wasDragging reset on new touch, touchCancel guard
- R5: onTouchEnd tap guard, live overlay during drag, snapToRef cleanup
- R6: wasDragging auto-reset (100ms timeout + preventDefault), overlay reset on cancel

## Acceptance criteria

- [x] Drag up from peek → half → full works
- [x] Drag down from full → half → peek works
- [x] Fast flick snaps to next point (velocity > 0.5px/ms)
- [x] "More" (⋯) tap snaps to full
- [x] Dimmed overlay tap collapses to peek
- [x] Telegram minimize gesture works at peek, blocked at half/full
- [x] No jank during drag (no React state in touchMove)
- [x] Rubber-banding at edges

🤖 Generated with [Claude Code](https://claude.com/claude-code)