### PR TITLE
feat(nav): Phase 3 — ActionChips + useActionBarModals extraction

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -5,6 +5,7 @@ import { FileViewer } from "./components/FileViewer";
 import type { SortMode } from "./components/FileViewer";
 import { Links } from "./components/Links";
 import { ActionBar } from "./components/action-bar";
+import { ActionChips } from "./components/ActionChips";
 import { BottomDrawer } from "./components/BottomDrawer";
 import { TabDock } from "./components/TabDock";
 import { VoiceRecorder } from "./components/VoiceRecorder";
@@ -310,23 +311,23 @@ export function App() {
         </div>
       </div>
 
-      {/* Action bar — stop propagation so swipe doesn't fire from action buttons */}
-      <div onTouchStart={(e) => e.stopPropagation()}>
-        <ActionBar
-          onReconnect={onReconnect}
-          connected={connected}
-          activeTab={activeTab}
-          fileShowHidden={fileShowHidden}
-          setFileShowHidden={setFileShowHidden}
-          fileSortMode={fileSortMode}
-          setFileSortMode={setFileSortMode}
-          viewingFile={viewingFile}
-          currentFolder={currentFolder}
-        />
-      </div>
-
       {/* Bottom tab dock — rendered via portal to escape CSS transform containment */}
-      <BottomDrawer snapToRef={drawerSnapRef}>
+      <BottomDrawer
+        snapToRef={drawerSnapRef}
+        drawerContent={
+          <ActionChips
+            onReconnect={onReconnect}
+            connected={connected}
+            activeTab={activeTab}
+            fileShowHidden={fileShowHidden}
+            setFileShowHidden={setFileShowHidden}
+            fileSortMode={fileSortMode}
+            setFileSortMode={setFileSortMode}
+            viewingFile={viewingFile}
+            currentFolder={currentFolder}
+          />
+        }
+      >
         <TabDock
           activeTab={activeTab}
           onTabChange={(tab) => { haptic.selection(); setIsAnimating(true); setActiveTab(tab); }}

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -4,7 +4,6 @@ import { Terminal } from "./components/Terminal";
 import { FileViewer } from "./components/FileViewer";
 import type { SortMode } from "./components/FileViewer";
 import { Links } from "./components/Links";
-import { ActionBar } from "./components/action-bar";
 import { ActionChips } from "./components/ActionChips";
 import { BottomDrawer } from "./components/BottomDrawer";
 import { TabDock } from "./components/TabDock";

--- a/apps/web/src/components/ActionChips.tsx
+++ b/apps/web/src/components/ActionChips.tsx
@@ -1,0 +1,118 @@
+import { useActionBarModals } from "../hooks/useActionBarModals";
+import { btnStyle, type ActionBarProps } from "./action-bar/types";
+import { haptic } from "../lib/haptic";
+
+const chipStyle = { ...btnStyle, fontSize: 12, padding: "5px 12px", borderRadius: 14 };
+
+export function ActionChips(props: ActionBarProps) {
+  const {
+    modalNode,
+    openTodo,
+    openCommands,
+    openGitStatus,
+    openGitMenu,
+    openReconnectMenu,
+    openFileSearch,
+    openFileOptions,
+    openTldr,
+    openAudioGen,
+    handleSendToChat,
+    handleReconnect,
+    isViewingMd,
+  } = useActionBarModals(props);
+
+  const { activeTab, viewingFile, onReconnect } = props;
+
+  return (
+    <>
+      {modalNode}
+      <div style={{ padding: "8px 12px", display: "flex", gap: 8, flexWrap: "wrap", overflowX: "auto" }}>
+
+        {/* TODO — always visible */}
+        <button
+          onClick={() => { haptic.impact("light"); openTodo(); }}
+          style={{ ...chipStyle, background: "#3a3520", color: "var(--color-accent-yellow)", border: "1px solid #5a4a30" }}
+        >
+          TODO
+        </button>
+
+        {/* Terminal chips */}
+        {activeTab === "terminal" && <>
+          {onReconnect && (
+            <button
+              onClick={() => { haptic.impact("light"); handleReconnect(); }}
+              style={{ ...chipStyle, background: "#1a3a2a", color: "var(--color-accent-green)", border: "1px solid #2d5a3d" }}
+            >
+              Reconnect
+            </button>
+          )}
+          {onReconnect && (
+            <button
+              onClick={() => { haptic.impact("light"); openReconnectMenu(); }}
+              style={{ ...chipStyle, background: "#1a3a2a", color: "var(--color-accent-green)", border: "1px solid #2d5a3d" }}
+            >
+              Reconnect Menu
+            </button>
+          )}
+          <button
+            onClick={() => { haptic.impact("light"); openGitStatus(); }}
+            style={chipStyle}
+          >
+            Git
+          </button>
+          <button
+            onClick={() => { haptic.impact("light"); openGitMenu(); }}
+            style={chipStyle}
+          >
+            Git Menu
+          </button>
+          <button
+            onClick={() => { haptic.impact("light"); openCommands(); }}
+            style={{ ...chipStyle, background: "#2d2a3a", color: "var(--color-accent-purple)", border: "1px solid #4a3d6a" }}
+          >
+            /commands
+          </button>
+        </>}
+
+        {/* Files chips — browsing */}
+        {activeTab === "files" && !viewingFile && <>
+          <button
+            onClick={() => { openFileSearch(); }}
+            style={{ ...chipStyle, background: "#2d3a5a", color: "var(--color-accent-blue)", border: "1px solid #3d4a6a" }}
+          >
+            Search
+          </button>
+          <button onClick={() => openFileOptions()} style={chipStyle}>
+            Options
+          </button>
+        </>}
+
+        {/* Files chips — viewing */}
+        {activeTab === "files" && viewingFile && <>
+          <button
+            onClick={() => { haptic.impact("light"); void handleSendToChat(); }}
+            style={{ ...chipStyle, background: "#1a2a3a", color: "var(--color-accent-cyan)", border: "1px solid #2d4a5a" }}
+          >
+            Send to Chat
+          </button>
+          {isViewingMd && (
+            <button
+              onClick={() => openTldr()}
+              style={{ ...chipStyle, background: "#1a3a3a", color: "var(--color-accent-cyan)", border: "1px solid #2d5a5a" }}
+            >
+              TL;DR
+            </button>
+          )}
+          {isViewingMd && (
+            <button
+              onClick={() => openAudioGen()}
+              style={{ ...chipStyle, background: "#2d2a3a", color: "var(--color-accent-purple)", border: "1px solid #4a3d6a" }}
+            >
+              Audio
+            </button>
+          )}
+        </>}
+      </div>
+    </>
+  );
+}

--- a/apps/web/src/components/ActionChips.tsx
+++ b/apps/web/src/components/ActionChips.tsx
@@ -1,5 +1,6 @@
 import { useActionBarModals } from "../hooks/useActionBarModals";
 import { btnStyle, type ActionBarProps } from "./action-bar/types";
+import { StatusLine } from "./action-bar/StatusLine";
 import { haptic } from "../lib/haptic";
 
 const chipStyle = { ...btnStyle, fontSize: 12, padding: "5px 12px", borderRadius: 14 };
@@ -7,6 +8,8 @@ const chipStyle = { ...btnStyle, fontSize: 12, padding: "5px 12px", borderRadius
 export function ActionChips(props: ActionBarProps) {
   const {
     modalNode,
+    status,
+    gitBranch,
     openTodo,
     openCommands,
     openGitStatus,
@@ -21,12 +24,15 @@ export function ActionChips(props: ActionBarProps) {
     isViewingMd,
   } = useActionBarModals(props);
 
-  const { activeTab, viewingFile, onReconnect } = props;
+  const { activeTab, viewingFile, onReconnect, connected } = props;
 
   return (
     <>
       {modalNode}
-      <div style={{ padding: "8px 12px", display: "flex", gap: 8, flexWrap: "wrap", overflowX: "auto" }}>
+      <div
+        onTouchStart={(e) => e.stopPropagation()}
+        style={{ padding: "8px 12px", display: "flex", gap: 8, flexWrap: "wrap", overflowX: "auto" }}
+      >
 
         {/* TODO — always visible */}
         <button
@@ -113,6 +119,7 @@ export function ActionChips(props: ActionBarProps) {
           )}
         </>}
       </div>
+      <StatusLine connected={connected} status={status} gitBranch={gitBranch} />
     </>
   );
 }

--- a/apps/web/src/components/BottomDrawer.tsx
+++ b/apps/web/src/components/BottomDrawer.tsx
@@ -102,9 +102,9 @@ export function BottomDrawer({ children, drawerContent, onSnapChange, snapToRef 
           <div className="drawer-handle-bar" />
         </div>
 
-        {/* Expandable content area — ActionChips render here in half/full */}
-        <div className="drawer-content">
-          {snap !== "peek" && drawerContent}
+        {/* Expandable content area — ActionChips always mounted, hidden at peek via CSS to preserve state */}
+        <div className="drawer-content" style={snap === "peek" ? { display: "none" } : undefined}>
+          {drawerContent}
         </div>
       </div>
     </>,

--- a/apps/web/src/components/BottomDrawer.tsx
+++ b/apps/web/src/components/BottomDrawer.tsx
@@ -6,12 +6,13 @@ import "./BottomDrawer.css";
 
 interface BottomDrawerProps {
   children: React.ReactNode; // TabDock (always visible at bottom)
+  drawerContent?: React.ReactNode; // ActionChips (only shows in half/full)
   onSnapChange?: (snap: SnapPoint) => void;
   // Imperative handle: parent passes a ref, we assign animateTo into it
   snapToRef?: React.MutableRefObject<((snap: SnapPoint) => void) | null>;
 }
 
-export function BottomDrawer({ children, onSnapChange, snapToRef }: BottomDrawerProps) {
+export function BottomDrawer({ children, drawerContent, onSnapChange, snapToRef }: BottomDrawerProps) {
   const drawerRef = useRef<HTMLDivElement>(null);
   const overlayRef = useRef<HTMLDivElement>(null);
   const [snap, setSnap] = useState<SnapPoint>("peek");
@@ -101,8 +102,10 @@ export function BottomDrawer({ children, onSnapChange, snapToRef }: BottomDrawer
           <div className="drawer-handle-bar" />
         </div>
 
-        {/* Expandable content area — empty in Phase 2, filled in Phase 3+ */}
-        <div className="drawer-content" />
+        {/* Expandable content area — ActionChips render here in half/full */}
+        <div className="drawer-content">
+          {snap !== "peek" && drawerContent}
+        </div>
       </div>
     </>,
     document.body

--- a/apps/web/src/components/action-bar/ActionBar.tsx
+++ b/apps/web/src/components/action-bar/ActionBar.tsx
@@ -1,557 +1,28 @@
-import { useCallback, useEffect, useRef, useState, type ReactNode } from "react";
-import { CommandsSheet } from "./CommandsSheet";
-import { RenameModal } from "./RenameModal";
-import { ForkNameModal } from "./ForkNameModal";
-import { ResumeSheet, ConfirmDeleteSheet } from "./ResumeSheet";
-import { NewConfirmModal } from "./NewConfirmModal";
-import { CompactConfirmModal, CompactFocusModal, ContinuityNotesModal } from "./CompactModals";
-import { GitStatusSheet, GitMenuSheet } from "./GitSheets";
-import { TodoSheet } from "./TodoSheet";
-import { ReconnectMenu } from "./ReconnectMenu";
-import { FileOptionsSheet } from "./FileOptionsSheet";
-import { FileSearchSheet } from "./FileSearchSheet";
-import { TldrModal } from "./TldrModal";
-import { AudioGenModal } from "./AudioGenModal";
+import { useActionBarModals } from "../../hooks/useActionBarModals";
 import { StatusLine } from "./StatusLine";
-import { btnStyle, type ActionBarProps, type AudioStatus, type GitBranch, type Modal, type SearchResult, type SessionName } from "./types";
-import {
-  checkAudio, deleteSessionName, fetchGitBranch, fetchGitStatus,
-  fetchSessionNames, fetchTodo, generateAudio, postAction,
-  renameSession, restartSession, runGitCommand, searchFiles,
-  sendAudioTelegram, sendCompactCommand, sendFileToChat, sendToTmux,
-} from "./api";
+import { btnStyle, type ActionBarProps } from "./types";
 import { haptic } from "../../lib/haptic";
-import { usePreferences } from "../../hooks/usePreferences";
 
-// Preference key for the "current folder only" search toggle. Stored under
-// the unified cpc_dashboard_prefs aggregate via CloudStorage (Bot API 8.0+)
-// with a localStorage fallback — see apps/web/src/lib/cloud-storage.ts.
-// Renamed from the old localStorage-direct key "cpc:search:currentFolderOnly"
-// when we migrated to the aggregate store; the old key is left behind on
-// upgraded clients (one-time loss of this single toggle), which is acceptable
-// for a boolean with a sensible default of ON.
-const SEARCH_SCOPE_PREF = "searchCurrentFolderOnly";
+export function ActionBar(props: ActionBarProps) {
+  const {
+    modalNode,
+    status,
+    gitBranch,
+    openTodo,
+    openCommands,
+    openGitStatus,
+    openGitMenu,
+    openReconnectMenu,
+    openFileSearch,
+    openFileOptions,
+    openTldr,
+    openAudioGen,
+    handleSendToChat,
+    handleReconnect,
+    isViewingMd,
+  } = useActionBarModals(props);
 
-export function ActionBar({ onReconnect, connected, activeTab, fileShowHidden, setFileShowHidden, fileSortMode, setFileSortMode, viewingFile, currentFolder }: ActionBarProps) {
-  const [status, setStatus] = useState<string | null>(null);
-  const [modal, setModal] = useState<Modal>(null);
-  const [compactFocus, setCompactFocus] = useState("");
-  const [continuityNotes, setContinuityNotes] = useState("");
-  const [renameName, setRenameName] = useState("");
-  const [forkName, setForkName] = useState("");
-  const [gitOutput, setGitOutput] = useState("");
-  const [todoContent, setTodoContent] = useState("");
-  const [sessionNames, setSessionNames] = useState<SessionName[]>([]);
-  const [deleteTarget, setDeleteTarget] = useState<SessionName | null>(null);
-  const [searchQuery, setSearchQuery] = useState("");
-  const [searchResults, setSearchResults] = useState<SearchResult[]>([]);
-  // "Current folder only" search toggle — default ON, persisted per-user via
-  // Telegram CloudStorage (syncs across devices) with a localStorage fallback.
-  // When ON we pass the folder the user is browsing as a `scope` query param;
-  // when OFF the server falls back to the old global search across all allowed
-  // roots. (Search UX C3; migrated to unified prefs in feat/cloud-storage-prefs.)
-  const [searchCurrentFolderOnly, setSearchCurrentFolderOnly] = usePreferences<boolean>(SEARCH_SCOPE_PREF, true);
-  // Keep the latest scope value in a ref so the debounced search callback
-  // (which is a useCallback with a stable identity) can read the freshest
-  // toggle + folder without needing to rebuild on every change.
-  const searchScopeRef = useRef<string | null>(null);
-  searchScopeRef.current = searchCurrentFolderOnly && currentFolder ? currentFolder : null;
-  const [audioStatus, setAudioStatus] = useState<AudioStatus | null>(null);
-  const [audioLoading, setAudioLoading] = useState(false);
-  const [audioOp, setAudioOp] = useState<"idle" | "checking" | "generating" | "sending">("idle");
-  // Synchronous in-flight guard for audio generation/send. Mirrors the
-  // TldrModal pattern (PR #121): React hasn't necessarily committed
-  // setAudioLoading(true) by the time a fast double-tap fires the second
-  // click handler, so a ref-based lock is the only way to prevent two
-  // concurrent backend audio jobs racing each other.
-  const audioInFlightRef = useRef(false);
-  const [gitBranch, setGitBranch] = useState<GitBranch | null>(null);
-  const searchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const searchAbortRef = useRef<AbortController | null>(null);
-
-  useEffect(() => {
-    const loadGitBranch = async () => {
-      try {
-        setGitBranch(await fetchGitBranch());
-      } catch (err) {
-        console.error("Failed to fetch git branch:", err);
-      }
-    };
-    void loadGitBranch();
-    const interval = setInterval(loadGitBranch, 30000);
-    return () => clearInterval(interval);
-  }, []);
-
-  // Clear the debounced file-search timer and abort any in-flight fetch on
-  // unmount so the callback can't fire and setState on an unmounted
-  // component, and a slow earlier response can't overwrite nothing either.
-  // (Copilot round-3 timer review + Gemini round-3 race review.)
-  useEffect(() => {
-    return () => {
-      if (searchTimerRef.current) {
-        clearTimeout(searchTimerRef.current);
-        searchTimerRef.current = null;
-      }
-      if (searchAbortRef.current) {
-        searchAbortRef.current.abort();
-        searchAbortRef.current = null;
-      }
-    };
-  }, []);
-
-  useEffect(() => {
-    if (!status) return;
-    const timer = setTimeout(() => setStatus(null), 4000);
-    return () => clearTimeout(timer);
-  }, [status]);
-
-  const handleAction = async (endpoint: string, label: string) => {
-    setStatus(`Running ${label}...`);
-    try {
-      const data = await postAction(endpoint);
-      if (!data.ok) {
-        haptic.error();
-        setStatus(`Failed: ${data.error || "unknown error"}`);
-      } else {
-        haptic.success();
-        setStatus(data.output || `${label}: OK`);
-      }
-    } catch (err) {
-      haptic.error();
-      setStatus(`Error: ${err instanceof Error ? err.message : String(err)}`);
-    }
-  };
-  const loadGitStatus = async () => {
-    try { setGitOutput(await fetchGitStatus()); } catch { setGitOutput("Failed to fetch"); }
-  };
-  const loadTodo = async () => {
-    try { setTodoContent(await fetchTodo()); } catch { setTodoContent("Failed to fetch"); }
-  };
-  const loadSessionNames = async () => {
-    try { setSessionNames(await fetchSessionNames()); } catch { setSessionNames([]); }
-  };
-  const removeSessionName = async (ts: number) => {
-    try {
-      await deleteSessionName(ts);
-      setSessionNames((prev) => prev.filter((s) => s.ts !== ts));
-    } catch {}
-    setDeleteTarget(null);
-    setModal("resume");
-  };
-  const handleCompact = async (message: string, label = "Compact") => {
-    setModal(null);
-    setStatus(`${label}...`);
-    try {
-      const data = await sendCompactCommand(message);
-      if (data.ok) {
-        haptic.success();
-        setStatus(`${label} sent`);
-      } else {
-        haptic.error();
-        setStatus(`Failed: ${data.error}`);
-      }
-    } catch (err) {
-      haptic.error();
-      setStatus(`Error: ${err instanceof Error ? err.message : String(err)}`);
-    }
-  };
-  const handleRename = async () => {
-    if (!renameName.trim()) return;
-    setModal(null);
-    setStatus("Renaming...");
-    void sendToTmux(`/rename ${renameName.trim()}`);
-    try {
-      const data = await renameSession(renameName.trim());
-      if (data.ok) {
-        haptic.success();
-        setStatus(`Renamed to "${renameName.trim()}"`);
-      } else {
-        haptic.error();
-        setStatus(`Failed: ${data.error}`);
-      }
-    } catch (err) {
-      // Previously this catch swallowed the error and optimistically reported
-      // success because the in-tmux /rename side-effect had already happened.
-      // But after jsonFetch started throwing on !res.ok (round-4 fix #1),
-      // server-side rejections (400/409) land here too, and a false success
-      // would hide real failures. Report the error instead. (Codex round-4
-      // review re-pass.)
-      haptic.error();
-      setStatus(`Failed: ${err instanceof Error ? err.message : String(err)}`);
-    }
-  };
-  const handleFork = () => {
-    const name = forkName.trim();
-    setModal(null);
-    void sendToTmux(name ? `/fork\n/rename ${name}` : "/fork");
-    setStatus(name ? `Forked as "${name}"` : "Forked");
-  };
-  const handleGitAction = async (action: { label: string; command: string }) => {
-    setGitOutput(`Running ${action.label}...`);
-    setModal("git-status");
-    try { setGitOutput(await runGitCommand(action.command)); } catch { setGitOutput("Failed to run command"); }
-  };
-  const resetFileSearch = useCallback(() => {
-    // Cancel any pending debounce and abort any in-flight request, then
-    // clear query+results. Needed when re-opening the search sheet so a
-    // stale fetch started before the previous close can't land and
-    // repopulate results under an empty query. (Codex round-4 review.)
-    if (searchTimerRef.current) {
-      clearTimeout(searchTimerRef.current);
-      searchTimerRef.current = null;
-    }
-    if (searchAbortRef.current) {
-      searchAbortRef.current.abort();
-      searchAbortRef.current = null;
-    }
-    setSearchQuery("");
-    setSearchResults([]);
-  }, []);
-
-  // Ref to the search input handler so an effect below can re-trigger the
-  // debounced search when the scope toggle changes without the effect
-  // having to depend on `handleSearchInput` itself (which would thrash
-  // whenever any of its deps changed).
-  const handleSearchInputRef = useRef<((query: string) => void) | null>(null);
-
-  const handleSearchInput = useCallback((query: string) => {
-    setSearchQuery(query);
-    if (searchTimerRef.current) clearTimeout(searchTimerRef.current);
-    // Abort any in-flight search before kicking off the debounce for a new
-    // one, so a slow earlier response can't land after a faster later one
-    // and overwrite the displayed results. (Gemini round-3 race review.)
-    if (searchAbortRef.current) {
-      searchAbortRef.current.abort();
-      searchAbortRef.current = null;
-    }
-    searchTimerRef.current = setTimeout(async () => {
-      if (query.length < 2) { setSearchResults([]); return; }
-      const controller = new AbortController();
-      searchAbortRef.current = controller;
-      try {
-        const results = await searchFiles(query, controller.signal, searchScopeRef.current);
-        // Only commit results if this fetch is still the latest one — a
-        // later call may have aborted us between await and here.
-        if (searchAbortRef.current === controller) {
-          setSearchResults(results);
-        }
-      } catch (err) {
-        if (err instanceof DOMException && err.name === "AbortError") return;
-        if (searchAbortRef.current === controller) setSearchResults([]);
-      } finally {
-        if (searchAbortRef.current === controller) searchAbortRef.current = null;
-      }
-    }, 300);
-  }, []);
-  handleSearchInputRef.current = handleSearchInput;
-
-  // When the user flips the "current folder only" toggle (or the current
-  // folder itself changes while the sheet is open), re-run the debounced
-  // search so the visible results reflect the new scope. We intentionally
-  // don't depend on `searchQuery` — typing it already schedules its own
-  // search via onChange, so including it here would double-fire.
-  useEffect(() => {
-    if (modal !== "file-search") return;
-    if (searchQuery.length < 2) return;
-    handleSearchInputRef.current?.(searchQuery);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [searchCurrentFolderOnly, currentFolder, modal]);
-
-  const handleCheckAudio = async (filePath: string) => {
-    // If a generate or send is already in-flight, don't clobber its
-    // loading/op state with a check — just show the in-progress panel.
-    if (audioInFlightRef.current) return;
-    setAudioStatus(null);
-    setAudioLoading(true);
-    setAudioOp("checking");
-    try {
-      const status = await checkAudio(filePath);
-      // Guard: if generate/send started while check was in-flight, don't
-      // overwrite their loading/op state with a stale check result.
-      if (!audioInFlightRef.current) setAudioStatus(status);
-    } catch {
-      if (!audioInFlightRef.current) setAudioStatus(null);
-    } finally {
-      // Only clear loading if no generate/send started while we were checking
-      if (!audioInFlightRef.current) {
-        setAudioOp("idle");
-        setAudioLoading(false);
-      }
-    }
-  };
-  const handleGenerateAudio = async (filePath: string) => {
-    if (audioInFlightRef.current) return;
-    audioInFlightRef.current = true;
-    setAudioLoading(true);
-    setAudioOp("generating");
-    setStatus("Generating audio...");
-    try {
-      const controller = new AbortController();
-      const timeout = setTimeout(() => controller.abort(), 60000);
-      try {
-        const data = await generateAudio(filePath, controller.signal);
-        if (data.ok) {
-          haptic.success();
-          setAudioStatus({ exists: true, path: data.path });
-          setStatus("Audio generated");
-        } else {
-          haptic.error();
-          setStatus(`Failed: ${data.error}`);
-        }
-      } finally {
-        // clearTimeout in finally so a thrown fetch doesn't leave the
-        // 60s timeout dangling and accumulating. (Copilot round-3 review.)
-        clearTimeout(timeout);
-      }
-    } catch (err) {
-      haptic.error();
-      setStatus(
-        err instanceof DOMException && err.name === "AbortError"
-          ? "Timed out"
-          : `Error: ${err instanceof Error ? err.message : String(err)}`
-      );
-    } finally {
-      audioInFlightRef.current = false;
-      setAudioOp("idle");
-      setAudioLoading(false);
-    }
-  };
-  const handleSendAudio = async (audioPath: string) => {
-    if (audioInFlightRef.current) return;
-    audioInFlightRef.current = true;
-    setAudioLoading(true);
-    setAudioOp("sending");
-    setStatus("Sending to Telegram...");
-    try {
-      const controller = new AbortController();
-      const timeout = setTimeout(() => controller.abort(), 30000);
-      try {
-        const data = await sendAudioTelegram(audioPath, controller.signal);
-        if (data.ok) {
-          haptic.success();
-          setStatus("Sent to Telegram");
-        } else {
-          haptic.error();
-          setStatus(`Failed: ${data.error}`);
-        }
-      } finally {
-        // clearTimeout in finally so a thrown fetch doesn't leave the
-        // 30s timeout dangling and accumulating. (Copilot round-3 review.)
-        clearTimeout(timeout);
-      }
-    } catch (err) {
-      haptic.error();
-      setStatus(
-        err instanceof DOMException && err.name === "AbortError"
-          ? "Timed out"
-          : `Error: ${err instanceof Error ? err.message : String(err)}`
-      );
-    } finally {
-      audioInFlightRef.current = false;
-      setAudioOp("idle");
-      setAudioLoading(false);
-    }
-  };
-  const handleRestartSession = async () => {
-    setModal(null);
-    setStatus("Restarting session...");
-    try {
-      const data = await restartSession();
-      if (data.ok) {
-        haptic.success();
-        setStatus("Session restarted");
-      } else {
-        haptic.error();
-        setStatus(`Failed: ${data.error}`);
-      }
-    } catch (err) {
-      // Surface the server error text (now extracted by jsonFetch from a
-      // { error } body on non-2xx responses) instead of a generic message.
-      // (Codex round-4 review re-pass.)
-      haptic.error();
-      setStatus(`Restart failed: ${err instanceof Error ? err.message : String(err)}`);
-    }
-  };
-  const handleSendToChat = async () => {
-    if (!viewingFile) return;
-    setStatus("Sharing...");
-    try {
-      const data = await sendFileToChat(viewingFile.path);
-      if (data.ok) {
-        haptic.success();
-        setStatus("Sent to chat");
-      } else {
-        haptic.error();
-        setStatus("Failed");
-      }
-    } catch {
-      haptic.error();
-      setStatus("Failed");
-    }
-  };
-
-  let modalNode: ReactNode = null;
-  switch (modal) {
-    case "commands":
-      modalNode = (
-        <CommandsSheet
-          onClose={() => setModal(null)}
-          onEsc={() => { void sendToTmux("Escape", true); setModal(null); setStatus("Sent: Esc"); }}
-          onDigit={(digit) => { void sendToTmux(String(digit)); setModal(null); setStatus(`Sent: ${digit}`); }}
-          onShiftTab={() => { void sendToTmux("BTab", true); setModal(null); setStatus("Sent: \u21e7Tab"); }}
-          onControlB={() => { void sendToTmux("C-b", true); setModal(null); setStatus("Sent: ^B"); }}
-          onNew={() => setModal("new-confirm")}
-          onResume={() => { void loadSessionNames(); setModal("resume"); }}
-          onFork={() => { setForkName(""); setModal("fork-name"); }}
-          onRename={() => { setRenameName(""); setModal("rename"); }}
-          onCompact={() => setModal("compact-confirm")}
-          onReloadPlugins={() => { setModal(null); void handleAction("/api/terminal/reload-plugins", "Reload plugins"); }}
-        />
-      );
-      break;
-    case "rename":
-      modalNode = (
-        <RenameModal value={renameName} onChange={setRenameName} onBack={() => setModal("commands")} onSubmit={() => void handleRename()} />
-      );
-      break;
-    case "fork-name":
-      modalNode = (
-        <ForkNameModal value={forkName} onChange={setForkName} onBack={() => setModal("commands")} onSubmit={handleFork} />
-      );
-      break;
-    case "resume":
-      modalNode = (
-        <ResumeSheet
-          sessionNames={sessionNames}
-          onClose={() => setModal("commands")}
-          onResume={(session) => { setModal(null); void handleCompact(`/resume ${session.name}`, "Resume"); }}
-          onDelete={(session) => { setDeleteTarget(session); setModal("confirm-delete"); }}
-        />
-      );
-      break;
-    case "confirm-delete":
-      modalNode = deleteTarget ? (
-        <ConfirmDeleteSheet
-          deleteTarget={deleteTarget}
-          onCancel={() => { setDeleteTarget(null); setModal("resume"); }}
-          onConfirm={() => void removeSessionName(deleteTarget.ts)}
-        />
-      ) : null;
-      break;
-    case "reconnect-menu":
-      modalNode = onReconnect ? (
-        <ReconnectMenu
-          onClose={() => setModal(null)}
-          onReconnect={() => { onReconnect(); setModal(null); }}
-          onRestart={() => void handleRestartSession()}
-        />
-      ) : null;
-      break;
-    case "new-confirm":
-      modalNode = (
-        <NewConfirmModal onCancel={() => setModal("commands")} onConfirm={() => void handleCompact("/new", "New session")} />
-      );
-      break;
-    case "git-status":
-      modalNode = <GitStatusSheet gitOutput={gitOutput} onClose={() => setModal(null)} />;
-      break;
-    case "git-menu":
-      modalNode = (
-        <GitMenuSheet
-          onClose={() => setModal(null)}
-          onViewStatus={() => { void loadGitStatus(); setModal("git-status"); }}
-          onAction={(action) => void handleGitAction(action)}
-        />
-      );
-      break;
-    case "todo":
-      modalNode = <TodoSheet todoContent={todoContent} onClose={() => setModal(null)} />;
-      break;
-    case "compact-confirm":
-      modalNode = (
-        <CompactConfirmModal
-          onCompactNow={() => { setCompactFocus(""); setModal("compact-focus"); }}
-          onContinuity={() => { setContinuityNotes(""); setModal("continuity-notes"); }}
-          onCancel={() => setModal(null)}
-        />
-      );
-      break;
-    case "compact-focus":
-      modalNode = (
-        <CompactFocusModal
-          value={compactFocus}
-          onChange={setCompactFocus}
-          onBack={() => setModal("compact-confirm")}
-          onSubmit={() => void handleCompact(compactFocus.trim() ? `/compact ${compactFocus.trim()}` : "/compact")}
-        />
-      );
-      break;
-    case "continuity-notes": {
-      const continuityMsg = [
-        "Before compacting, please ensure:",
-        "1) README.md is up to date with recent changes.",
-        "2) Anything important from this session is saved to the knowledge base or memory.",
-        "3) Open work and next steps are captured in NEXT-SESSION.md and TODO.md.",
-        continuityNotes.trim() ? `Additional context from user: "${continuityNotes.trim()}".` : "",
-      ].filter(Boolean).join(" ");
-      modalNode = (
-        <ContinuityNotesModal
-          value={continuityNotes}
-          onChange={setContinuityNotes}
-          onBack={() => setModal("compact-confirm")}
-          onSubmit={() => void handleCompact(continuityMsg)}
-        />
-      );
-      break;
-    }
-    case "file-options":
-      modalNode = (
-        <FileOptionsSheet
-          fileShowHidden={fileShowHidden}
-          fileSortMode={fileSortMode}
-          setFileShowHidden={setFileShowHidden}
-          setFileSortMode={setFileSortMode}
-          onClose={() => setModal(null)}
-        />
-      );
-      break;
-    case "file-search":
-      modalNode = (
-        <FileSearchSheet
-          searchQuery={searchQuery}
-          searchResults={searchResults}
-          currentFolder={currentFolder ?? null}
-          currentFolderOnly={searchCurrentFolderOnly}
-          onToggleCurrentFolderOnly={setSearchCurrentFolderOnly}
-          onClose={() => setModal(null)}
-          onChange={handleSearchInput}
-          onSelect={(result) => {
-            setModal(null);
-            window.location.hash = `files&file=${encodeURIComponent(result.path)}`;
-            window.location.reload();
-          }}
-        />
-      );
-      break;
-    case "tldr":
-      modalNode = viewingFile ? <TldrModal viewingFile={viewingFile} onClose={() => setModal(null)} /> : null;
-      break;
-    case "audio-gen":
-      modalNode = viewingFile ? (
-        <AudioGenModal
-          viewingFile={viewingFile}
-          audioLoading={audioLoading}
-          audioOp={audioOp}
-          audioStatus={audioStatus}
-          onClose={() => setModal(null)}
-          onGenerate={() => void handleGenerateAudio(viewingFile.path)}
-          onSend={() => { if (audioStatus?.path) void handleSendAudio(audioStatus.path); }}
-        />
-      ) : null;
-      break;
-  }
-
-  const isViewingMd = viewingFile?.name.toLowerCase().endsWith(".md");
+  const { onReconnect, connected, activeTab, viewingFile } = props;
 
   return (
     <>
@@ -559,7 +30,7 @@ export function ActionBar({ onReconnect, connected, activeTab, fileShowHidden, s
       <div style={{ padding: "10px 12px 8px", borderTop: "1px solid var(--color-border)", flexShrink: 0 }}>
         <div style={{ display: "flex", gap: "8px", overflowX: "auto" }}>
           <button
-            onClick={() => { haptic.impact("light"); setModal("todo"); void loadTodo(); }}
+            onClick={() => { haptic.impact("light"); openTodo(); }}
             style={{ ...btnStyle, background: "#3a3520", color: "var(--color-accent-yellow)", border: "1px solid #5a4a30" }}
           >
             TODO
@@ -569,13 +40,13 @@ export function ActionBar({ onReconnect, connected, activeTab, fileShowHidden, s
             {onReconnect && (
               <div style={{ display: "flex", flexShrink: 0 }}>
                 <button
-                  onClick={() => { haptic.impact("light"); onReconnect(); }}
+                  onClick={() => { haptic.impact("light"); handleReconnect(); }}
                   style={{ ...btnStyle, background: "#1a3a2a", color: "var(--color-accent-green)", border: "1px solid #2d5a3d", borderRadius: "6px 0 0 6px", borderRight: "none" }}
                 >
                   Reconnect
                 </button>
                 <button
-                  onClick={() => { haptic.impact("light"); setModal("reconnect-menu"); }}
+                  onClick={() => { haptic.impact("light"); openReconnectMenu(); }}
                   aria-label="Open reconnect menu"
                   title="Open reconnect menu"
                   style={{ ...btnStyle, background: "#1a3a2a", color: "var(--color-accent-green)", border: "1px solid #2d5a3d", borderRadius: "0 6px 6px 0", padding: "6px 8px", fontSize: 14 }}
@@ -586,13 +57,13 @@ export function ActionBar({ onReconnect, connected, activeTab, fileShowHidden, s
             )}
             <div style={{ display: "flex", flexShrink: 0 }}>
               <button
-                onClick={() => { haptic.impact("light"); setModal("git-status"); void loadGitStatus(); }}
+                onClick={() => { haptic.impact("light"); openGitStatus(); }}
                 style={{ ...btnStyle, borderRadius: "6px 0 0 6px", borderRight: "none" }}
               >
                 Git
               </button>
               <button
-                onClick={() => { haptic.impact("light"); setModal("git-menu"); }}
+                onClick={() => { haptic.impact("light"); openGitMenu(); }}
                 aria-label="Open git menu"
                 title="Open git menu"
                 style={{ ...btnStyle, borderRadius: "0 6px 6px 0", padding: "6px 8px", fontSize: 14 }}
@@ -601,7 +72,7 @@ export function ActionBar({ onReconnect, connected, activeTab, fileShowHidden, s
               </button>
             </div>
             <button
-              onClick={() => { haptic.impact("light"); setModal("commands"); }}
+              onClick={() => { haptic.impact("light"); openCommands(); }}
               style={{ ...btnStyle, background: "#2d2a3a", color: "var(--color-accent-purple)", border: "1px solid #4a3d6a" }}
             >
               /commands
@@ -610,12 +81,12 @@ export function ActionBar({ onReconnect, connected, activeTab, fileShowHidden, s
 
           {activeTab === "files" && !viewingFile && <>
             <button
-              onClick={() => { resetFileSearch(); setModal("file-search"); }}
+              onClick={() => { openFileSearch(); }}
               style={{ ...btnStyle, background: "#2d3a5a", color: "var(--color-accent-blue)", border: "1px solid #3d4a6a" }}
             >
               Search
             </button>
-            <button onClick={() => setModal("file-options")} style={btnStyle}>Options</button>
+            <button onClick={() => openFileOptions()} style={btnStyle}>Options</button>
           </>}
 
           {activeTab === "files" && viewingFile && (
@@ -629,7 +100,7 @@ export function ActionBar({ onReconnect, connected, activeTab, fileShowHidden, s
 
           {activeTab === "files" && isViewingMd && (
             <button
-              onClick={() => setModal("tldr")}
+              onClick={() => openTldr()}
               style={{ ...btnStyle, background: "#1a3a3a", color: "var(--color-accent-cyan)", border: "1px solid #2d5a5a" }}
             >
               TL;DR
@@ -638,7 +109,7 @@ export function ActionBar({ onReconnect, connected, activeTab, fileShowHidden, s
 
           {activeTab === "files" && isViewingMd && viewingFile && (
             <button
-              onClick={() => { void handleCheckAudio(viewingFile.path); setModal("audio-gen"); }}
+              onClick={() => { openAudioGen(); }}
               style={{ ...btnStyle, background: "#2d2a3a", color: "var(--color-accent-purple)", border: "1px solid #4a3d6a" }}
             >
               Audio

--- a/apps/web/src/hooks/useActionBarModals.tsx
+++ b/apps/web/src/hooks/useActionBarModals.tsx
@@ -622,7 +622,7 @@ export function useActionBarModals(props: ActionBarProps): UseActionBarModalsRet
       break;
   }
 
-  const isViewingMd = Boolean(viewingFile?.name.toLowerCase().endsWith(".md"));
+  const isViewingMd = viewingFile?.name?.toLowerCase()?.endsWith(".md") ?? false;
 
   return {
     modalNode,

--- a/apps/web/src/hooks/useActionBarModals.tsx
+++ b/apps/web/src/hooks/useActionBarModals.tsx
@@ -1,0 +1,644 @@
+import { useCallback, useEffect, useRef, useState, type ReactNode } from "react";
+import { CommandsSheet } from "../components/action-bar/CommandsSheet";
+import { RenameModal } from "../components/action-bar/RenameModal";
+import { ForkNameModal } from "../components/action-bar/ForkNameModal";
+import { ResumeSheet, ConfirmDeleteSheet } from "../components/action-bar/ResumeSheet";
+import { NewConfirmModal } from "../components/action-bar/NewConfirmModal";
+import { CompactConfirmModal, CompactFocusModal, ContinuityNotesModal } from "../components/action-bar/CompactModals";
+import { GitStatusSheet, GitMenuSheet } from "../components/action-bar/GitSheets";
+import { TodoSheet } from "../components/action-bar/TodoSheet";
+import { ReconnectMenu } from "../components/action-bar/ReconnectMenu";
+import { FileOptionsSheet } from "../components/action-bar/FileOptionsSheet";
+import { FileSearchSheet } from "../components/action-bar/FileSearchSheet";
+import { TldrModal } from "../components/action-bar/TldrModal";
+import { AudioGenModal } from "../components/action-bar/AudioGenModal";
+import { type ActionBarProps, type AudioStatus, type GitBranch, type Modal, type SearchResult, type SessionName } from "../components/action-bar/types";
+import {
+  checkAudio, deleteSessionName, fetchGitBranch, fetchGitStatus,
+  fetchSessionNames, fetchTodo, generateAudio, postAction,
+  renameSession, restartSession, runGitCommand, searchFiles,
+  sendAudioTelegram, sendCompactCommand, sendFileToChat, sendToTmux,
+} from "../components/action-bar/api";
+import { haptic } from "../lib/haptic";
+import { usePreferences } from "./usePreferences";
+
+// Preference key for the "current folder only" search toggle. Stored under
+// the unified cpc_dashboard_prefs aggregate via CloudStorage (Bot API 8.0+)
+// with a localStorage fallback — see apps/web/src/lib/cloud-storage.ts.
+// Renamed from the old localStorage-direct key "cpc:search:currentFolderOnly"
+// when we migrated to the aggregate store; the old key is left behind on
+// upgraded clients (one-time loss of this single toggle), which is acceptable
+// for a boolean with a sensible default of ON.
+const SEARCH_SCOPE_PREF = "searchCurrentFolderOnly";
+
+export interface UseActionBarModalsReturn {
+  // Modal infrastructure
+  modalNode: ReactNode;
+  status: string | null;
+  gitBranch: GitBranch | null;
+
+  // Modal triggers
+  openTodo: () => void;
+  openCommands: () => void;
+  openGitStatus: () => void;
+  openGitMenu: () => void;
+  openReconnectMenu: () => void;
+  openFileSearch: () => void;
+  openFileOptions: () => void;
+  openTldr: () => void;
+  openAudioGen: () => void;
+  handleSendToChat: () => Promise<void>;
+  handleReconnect: () => void;
+
+  // Derived state for rendering
+  isViewingMd: boolean;
+}
+
+export function useActionBarModals(props: ActionBarProps): UseActionBarModalsReturn {
+  const { onReconnect, viewingFile, currentFolder, fileShowHidden, setFileShowHidden, fileSortMode, setFileSortMode } = props;
+
+  const [status, setStatus] = useState<string | null>(null);
+  const [modal, setModal] = useState<Modal>(null);
+  const [compactFocus, setCompactFocus] = useState("");
+  const [continuityNotes, setContinuityNotes] = useState("");
+  const [renameName, setRenameName] = useState("");
+  const [forkName, setForkName] = useState("");
+  const [gitOutput, setGitOutput] = useState("");
+  const [todoContent, setTodoContent] = useState("");
+  const [sessionNames, setSessionNames] = useState<SessionName[]>([]);
+  const [deleteTarget, setDeleteTarget] = useState<SessionName | null>(null);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [searchResults, setSearchResults] = useState<SearchResult[]>([]);
+  // "Current folder only" search toggle — default ON, persisted per-user via
+  // Telegram CloudStorage (syncs across devices) with a localStorage fallback.
+  // When ON we pass the folder the user is browsing as a `scope` query param;
+  // when OFF the server falls back to the old global search across all allowed
+  // roots. (Search UX C3; migrated to unified prefs in feat/cloud-storage-prefs.)
+  const [searchCurrentFolderOnly, setSearchCurrentFolderOnly] = usePreferences<boolean>(SEARCH_SCOPE_PREF, true);
+  // Keep the latest scope value in a ref so the debounced search callback
+  // (which is a useCallback with a stable identity) can read the freshest
+  // toggle + folder without needing to rebuild on every change.
+  const searchScopeRef = useRef<string | null>(null);
+  searchScopeRef.current = searchCurrentFolderOnly && currentFolder ? currentFolder : null;
+  const [audioStatus, setAudioStatus] = useState<AudioStatus | null>(null);
+  const [audioLoading, setAudioLoading] = useState(false);
+  const [audioOp, setAudioOp] = useState<"idle" | "checking" | "generating" | "sending">("idle");
+  // Synchronous in-flight guard for audio generation/send. Mirrors the
+  // TldrModal pattern (PR #121): React hasn't necessarily committed
+  // setAudioLoading(true) by the time a fast double-tap fires the second
+  // click handler, so a ref-based lock is the only way to prevent two
+  // concurrent backend audio jobs racing each other.
+  const audioInFlightRef = useRef(false);
+  const [gitBranch, setGitBranch] = useState<GitBranch | null>(null);
+  const searchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const searchAbortRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    const loadGitBranch = async () => {
+      try {
+        setGitBranch(await fetchGitBranch());
+      } catch (err) {
+        console.error("Failed to fetch git branch:", err);
+      }
+    };
+    void loadGitBranch();
+    const interval = setInterval(loadGitBranch, 30000);
+    return () => clearInterval(interval);
+  }, []);
+
+  // Clear the debounced file-search timer and abort any in-flight fetch on
+  // unmount so the callback can't fire and setState on an unmounted
+  // component, and a slow earlier response can't overwrite nothing either.
+  // (Copilot round-3 timer review + Gemini round-3 race review.)
+  useEffect(() => {
+    return () => {
+      if (searchTimerRef.current) {
+        clearTimeout(searchTimerRef.current);
+        searchTimerRef.current = null;
+      }
+      if (searchAbortRef.current) {
+        searchAbortRef.current.abort();
+        searchAbortRef.current = null;
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!status) return;
+    const timer = setTimeout(() => setStatus(null), 4000);
+    return () => clearTimeout(timer);
+  }, [status]);
+
+  const handleAction = async (endpoint: string, label: string) => {
+    setStatus(`Running ${label}...`);
+    try {
+      const data = await postAction(endpoint);
+      if (!data.ok) {
+        haptic.error();
+        setStatus(`Failed: ${data.error || "unknown error"}`);
+      } else {
+        haptic.success();
+        setStatus(data.output || `${label}: OK`);
+      }
+    } catch (err) {
+      haptic.error();
+      setStatus(`Error: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  };
+  const loadGitStatus = async () => {
+    try { setGitOutput(await fetchGitStatus()); } catch { setGitOutput("Failed to fetch"); }
+  };
+  const loadTodo = async () => {
+    try { setTodoContent(await fetchTodo()); } catch { setTodoContent("Failed to fetch"); }
+  };
+  const loadSessionNames = async () => {
+    try { setSessionNames(await fetchSessionNames()); } catch { setSessionNames([]); }
+  };
+  const removeSessionName = async (ts: number) => {
+    try {
+      await deleteSessionName(ts);
+      setSessionNames((prev) => prev.filter((s) => s.ts !== ts));
+    } catch {}
+    setDeleteTarget(null);
+    setModal("resume");
+  };
+  const handleCompact = async (message: string, label = "Compact") => {
+    setModal(null);
+    setStatus(`${label}...`);
+    try {
+      const data = await sendCompactCommand(message);
+      if (data.ok) {
+        haptic.success();
+        setStatus(`${label} sent`);
+      } else {
+        haptic.error();
+        setStatus(`Failed: ${data.error}`);
+      }
+    } catch (err) {
+      haptic.error();
+      setStatus(`Error: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  };
+  const handleRename = async () => {
+    if (!renameName.trim()) return;
+    setModal(null);
+    setStatus("Renaming...");
+    void sendToTmux(`/rename ${renameName.trim()}`);
+    try {
+      const data = await renameSession(renameName.trim());
+      if (data.ok) {
+        haptic.success();
+        setStatus(`Renamed to "${renameName.trim()}"`);
+      } else {
+        haptic.error();
+        setStatus(`Failed: ${data.error}`);
+      }
+    } catch (err) {
+      // Previously this catch swallowed the error and optimistically reported
+      // success because the in-tmux /rename side-effect had already happened.
+      // But after jsonFetch started throwing on !res.ok (round-4 fix #1),
+      // server-side rejections (400/409) land here too, and a false success
+      // would hide real failures. Report the error instead. (Codex round-4
+      // review re-pass.)
+      haptic.error();
+      setStatus(`Failed: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  };
+  const handleFork = () => {
+    const name = forkName.trim();
+    setModal(null);
+    void sendToTmux(name ? `/fork\n/rename ${name}` : "/fork");
+    setStatus(name ? `Forked as "${name}"` : "Forked");
+  };
+  const handleGitAction = async (action: { label: string; command: string }) => {
+    setGitOutput(`Running ${action.label}...`);
+    setModal("git-status");
+    try { setGitOutput(await runGitCommand(action.command)); } catch { setGitOutput("Failed to run command"); }
+  };
+  const resetFileSearch = useCallback(() => {
+    // Cancel any pending debounce and abort any in-flight request, then
+    // clear query+results. Needed when re-opening the search sheet so a
+    // stale fetch started before the previous close can't land and
+    // repopulate results under an empty query. (Codex round-4 review.)
+    if (searchTimerRef.current) {
+      clearTimeout(searchTimerRef.current);
+      searchTimerRef.current = null;
+    }
+    if (searchAbortRef.current) {
+      searchAbortRef.current.abort();
+      searchAbortRef.current = null;
+    }
+    setSearchQuery("");
+    setSearchResults([]);
+  }, []);
+
+  // Ref to the search input handler so an effect below can re-trigger the
+  // debounced search when the scope toggle changes without the effect
+  // having to depend on `handleSearchInput` itself (which would thrash
+  // whenever any of its deps changed).
+  const handleSearchInputRef = useRef<((query: string) => void) | null>(null);
+
+  const handleSearchInput = useCallback((query: string) => {
+    setSearchQuery(query);
+    if (searchTimerRef.current) clearTimeout(searchTimerRef.current);
+    // Abort any in-flight search before kicking off the debounce for a new
+    // one, so a slow earlier response can't land after a faster later one
+    // and overwrite the displayed results. (Gemini round-3 race review.)
+    if (searchAbortRef.current) {
+      searchAbortRef.current.abort();
+      searchAbortRef.current = null;
+    }
+    searchTimerRef.current = setTimeout(async () => {
+      if (query.length < 2) { setSearchResults([]); return; }
+      const controller = new AbortController();
+      searchAbortRef.current = controller;
+      try {
+        const results = await searchFiles(query, controller.signal, searchScopeRef.current);
+        // Only commit results if this fetch is still the latest one — a
+        // later call may have aborted us between await and here.
+        if (searchAbortRef.current === controller) {
+          setSearchResults(results);
+        }
+      } catch (err) {
+        if (err instanceof DOMException && err.name === "AbortError") return;
+        if (searchAbortRef.current === controller) setSearchResults([]);
+      } finally {
+        if (searchAbortRef.current === controller) searchAbortRef.current = null;
+      }
+    }, 300);
+  }, []);
+  handleSearchInputRef.current = handleSearchInput;
+
+  // When the user flips the "current folder only" toggle (or the current
+  // folder itself changes while the sheet is open), re-run the debounced
+  // search so the visible results reflect the new scope. We intentionally
+  // don't depend on `searchQuery` — typing it already schedules its own
+  // search via onChange, so including it here would double-fire.
+  useEffect(() => {
+    if (modal !== "file-search") return;
+    if (searchQuery.length < 2) return;
+    handleSearchInputRef.current?.(searchQuery);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchCurrentFolderOnly, currentFolder, modal]);
+
+  const handleCheckAudio = async (filePath: string) => {
+    // If a generate or send is already in-flight, don't clobber its
+    // loading/op state with a check — just show the in-progress panel.
+    if (audioInFlightRef.current) return;
+    setAudioStatus(null);
+    setAudioLoading(true);
+    setAudioOp("checking");
+    try {
+      const status = await checkAudio(filePath);
+      // Guard: if generate/send started while check was in-flight, don't
+      // overwrite their loading/op state with a stale check result.
+      if (!audioInFlightRef.current) setAudioStatus(status);
+    } catch {
+      if (!audioInFlightRef.current) setAudioStatus(null);
+    } finally {
+      // Only clear loading if no generate/send started while we were checking
+      if (!audioInFlightRef.current) {
+        setAudioOp("idle");
+        setAudioLoading(false);
+      }
+    }
+  };
+  const handleGenerateAudio = async (filePath: string) => {
+    if (audioInFlightRef.current) return;
+    audioInFlightRef.current = true;
+    setAudioLoading(true);
+    setAudioOp("generating");
+    setStatus("Generating audio...");
+    try {
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), 60000);
+      try {
+        const data = await generateAudio(filePath, controller.signal);
+        if (data.ok) {
+          haptic.success();
+          setAudioStatus({ exists: true, path: data.path });
+          setStatus("Audio generated");
+        } else {
+          haptic.error();
+          setStatus(`Failed: ${data.error}`);
+        }
+      } finally {
+        // clearTimeout in finally so a thrown fetch doesn't leave the
+        // 60s timeout dangling and accumulating. (Copilot round-3 review.)
+        clearTimeout(timeout);
+      }
+    } catch (err) {
+      haptic.error();
+      setStatus(
+        err instanceof DOMException && err.name === "AbortError"
+          ? "Timed out"
+          : `Error: ${err instanceof Error ? err.message : String(err)}`
+      );
+    } finally {
+      audioInFlightRef.current = false;
+      setAudioOp("idle");
+      setAudioLoading(false);
+    }
+  };
+  const handleSendAudio = async (audioPath: string) => {
+    if (audioInFlightRef.current) return;
+    audioInFlightRef.current = true;
+    setAudioLoading(true);
+    setAudioOp("sending");
+    setStatus("Sending to Telegram...");
+    try {
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), 30000);
+      try {
+        const data = await sendAudioTelegram(audioPath, controller.signal);
+        if (data.ok) {
+          haptic.success();
+          setStatus("Sent to Telegram");
+        } else {
+          haptic.error();
+          setStatus(`Failed: ${data.error}`);
+        }
+      } finally {
+        // clearTimeout in finally so a thrown fetch doesn't leave the
+        // 30s timeout dangling and accumulating. (Copilot round-3 review.)
+        clearTimeout(timeout);
+      }
+    } catch (err) {
+      haptic.error();
+      setStatus(
+        err instanceof DOMException && err.name === "AbortError"
+          ? "Timed out"
+          : `Error: ${err instanceof Error ? err.message : String(err)}`
+      );
+    } finally {
+      audioInFlightRef.current = false;
+      setAudioOp("idle");
+      setAudioLoading(false);
+    }
+  };
+  const handleRestartSession = async () => {
+    setModal(null);
+    setStatus("Restarting session...");
+    try {
+      const data = await restartSession();
+      if (data.ok) {
+        haptic.success();
+        setStatus("Session restarted");
+      } else {
+        haptic.error();
+        setStatus(`Failed: ${data.error}`);
+      }
+    } catch (err) {
+      // Surface the server error text (now extracted by jsonFetch from a
+      // { error } body on non-2xx responses) instead of a generic message.
+      // (Codex round-4 review re-pass.)
+      haptic.error();
+      setStatus(`Restart failed: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  };
+  const handleSendToChat = async () => {
+    if (!viewingFile) return;
+    setStatus("Sharing...");
+    try {
+      const data = await sendFileToChat(viewingFile.path);
+      if (data.ok) {
+        haptic.success();
+        setStatus("Sent to chat");
+      } else {
+        haptic.error();
+        setStatus("Failed");
+      }
+    } catch {
+      haptic.error();
+      setStatus("Failed");
+    }
+  };
+
+  // Modal trigger helpers
+  const openTodo = useCallback(() => {
+    setModal("todo");
+    void loadTodo();
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const openCommands = useCallback(() => {
+    setModal("commands");
+  }, []);
+
+  const openGitStatus = useCallback(() => {
+    setModal("git-status");
+    void loadGitStatus();
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const openGitMenu = useCallback(() => {
+    setModal("git-menu");
+  }, []);
+
+  const openReconnectMenu = useCallback(() => {
+    setModal("reconnect-menu");
+  }, []);
+
+  const openFileSearch = useCallback(() => {
+    resetFileSearch();
+    setModal("file-search");
+  }, [resetFileSearch]);
+
+  const openFileOptions = useCallback(() => {
+    setModal("file-options");
+  }, []);
+
+  const openTldr = useCallback(() => {
+    setModal("tldr");
+  }, []);
+
+  const openAudioGen = useCallback(() => {
+    if (viewingFile) {
+      void handleCheckAudio(viewingFile.path);
+    }
+    setModal("audio-gen");
+  }, [viewingFile]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const handleReconnect = useCallback(() => {
+    onReconnect?.();
+  }, [onReconnect]);
+
+  let modalNode: ReactNode = null;
+  switch (modal) {
+    case "commands":
+      modalNode = (
+        <CommandsSheet
+          onClose={() => setModal(null)}
+          onEsc={() => { void sendToTmux("Escape", true); setModal(null); setStatus("Sent: Esc"); }}
+          onDigit={(digit) => { void sendToTmux(String(digit)); setModal(null); setStatus(`Sent: ${digit}`); }}
+          onShiftTab={() => { void sendToTmux("BTab", true); setModal(null); setStatus("Sent: \u21e7Tab"); }}
+          onControlB={() => { void sendToTmux("C-b", true); setModal(null); setStatus("Sent: ^B"); }}
+          onNew={() => setModal("new-confirm")}
+          onResume={() => { void loadSessionNames(); setModal("resume"); }}
+          onFork={() => { setForkName(""); setModal("fork-name"); }}
+          onRename={() => { setRenameName(""); setModal("rename"); }}
+          onCompact={() => setModal("compact-confirm")}
+          onReloadPlugins={() => { setModal(null); void handleAction("/api/terminal/reload-plugins", "Reload plugins"); }}
+        />
+      );
+      break;
+    case "rename":
+      modalNode = (
+        <RenameModal value={renameName} onChange={setRenameName} onBack={() => setModal("commands")} onSubmit={() => void handleRename()} />
+      );
+      break;
+    case "fork-name":
+      modalNode = (
+        <ForkNameModal value={forkName} onChange={setForkName} onBack={() => setModal("commands")} onSubmit={handleFork} />
+      );
+      break;
+    case "resume":
+      modalNode = (
+        <ResumeSheet
+          sessionNames={sessionNames}
+          onClose={() => setModal("commands")}
+          onResume={(session) => { setModal(null); void handleCompact(`/resume ${session.name}`, "Resume"); }}
+          onDelete={(session) => { setDeleteTarget(session); setModal("confirm-delete"); }}
+        />
+      );
+      break;
+    case "confirm-delete":
+      modalNode = deleteTarget ? (
+        <ConfirmDeleteSheet
+          deleteTarget={deleteTarget}
+          onCancel={() => { setDeleteTarget(null); setModal("resume"); }}
+          onConfirm={() => void removeSessionName(deleteTarget.ts)}
+        />
+      ) : null;
+      break;
+    case "reconnect-menu":
+      modalNode = onReconnect ? (
+        <ReconnectMenu
+          onClose={() => setModal(null)}
+          onReconnect={() => { onReconnect(); setModal(null); }}
+          onRestart={() => void handleRestartSession()}
+        />
+      ) : null;
+      break;
+    case "new-confirm":
+      modalNode = (
+        <NewConfirmModal onCancel={() => setModal("commands")} onConfirm={() => void handleCompact("/new", "New session")} />
+      );
+      break;
+    case "git-status":
+      modalNode = <GitStatusSheet gitOutput={gitOutput} onClose={() => setModal(null)} />;
+      break;
+    case "git-menu":
+      modalNode = (
+        <GitMenuSheet
+          onClose={() => setModal(null)}
+          onViewStatus={() => { void loadGitStatus(); setModal("git-status"); }}
+          onAction={(action) => void handleGitAction(action)}
+        />
+      );
+      break;
+    case "todo":
+      modalNode = <TodoSheet todoContent={todoContent} onClose={() => setModal(null)} />;
+      break;
+    case "compact-confirm":
+      modalNode = (
+        <CompactConfirmModal
+          onCompactNow={() => { setCompactFocus(""); setModal("compact-focus"); }}
+          onContinuity={() => { setContinuityNotes(""); setModal("continuity-notes"); }}
+          onCancel={() => setModal(null)}
+        />
+      );
+      break;
+    case "compact-focus":
+      modalNode = (
+        <CompactFocusModal
+          value={compactFocus}
+          onChange={setCompactFocus}
+          onBack={() => setModal("compact-confirm")}
+          onSubmit={() => void handleCompact(compactFocus.trim() ? `/compact ${compactFocus.trim()}` : "/compact")}
+        />
+      );
+      break;
+    case "continuity-notes": {
+      const continuityMsg = [
+        "Before compacting, please ensure:",
+        "1) README.md is up to date with recent changes.",
+        "2) Anything important from this session is saved to the knowledge base or memory.",
+        "3) Open work and next steps are captured in NEXT-SESSION.md and TODO.md.",
+        continuityNotes.trim() ? `Additional context from user: "${continuityNotes.trim()}".` : "",
+      ].filter(Boolean).join(" ");
+      modalNode = (
+        <ContinuityNotesModal
+          value={continuityNotes}
+          onChange={setContinuityNotes}
+          onBack={() => setModal("compact-confirm")}
+          onSubmit={() => void handleCompact(continuityMsg)}
+        />
+      );
+      break;
+    }
+    case "file-options":
+      modalNode = (
+        <FileOptionsSheet
+          fileShowHidden={fileShowHidden}
+          fileSortMode={fileSortMode}
+          setFileShowHidden={setFileShowHidden}
+          setFileSortMode={setFileSortMode}
+          onClose={() => setModal(null)}
+        />
+      );
+      break;
+    case "file-search":
+      modalNode = (
+        <FileSearchSheet
+          searchQuery={searchQuery}
+          searchResults={searchResults}
+          currentFolder={currentFolder ?? null}
+          currentFolderOnly={searchCurrentFolderOnly}
+          onToggleCurrentFolderOnly={setSearchCurrentFolderOnly}
+          onClose={() => setModal(null)}
+          onChange={handleSearchInput}
+          onSelect={(result) => {
+            setModal(null);
+            window.location.hash = `files&file=${encodeURIComponent(result.path)}`;
+            window.location.reload();
+          }}
+        />
+      );
+      break;
+    case "tldr":
+      modalNode = viewingFile ? <TldrModal viewingFile={viewingFile} onClose={() => setModal(null)} /> : null;
+      break;
+    case "audio-gen":
+      modalNode = viewingFile ? (
+        <AudioGenModal
+          viewingFile={viewingFile}
+          audioLoading={audioLoading}
+          audioOp={audioOp}
+          audioStatus={audioStatus}
+          onClose={() => setModal(null)}
+          onGenerate={() => void handleGenerateAudio(viewingFile.path)}
+          onSend={() => { if (audioStatus?.path) void handleSendAudio(audioStatus.path); }}
+        />
+      ) : null;
+      break;
+  }
+
+  const isViewingMd = Boolean(viewingFile?.name.toLowerCase().endsWith(".md"));
+
+  return {
+    modalNode,
+    status,
+    gitBranch,
+    openTodo,
+    openCommands,
+    openGitStatus,
+    openGitMenu,
+    openReconnectMenu,
+    openFileSearch,
+    openFileOptions,
+    openTldr,
+    openAudioGen,
+    handleSendToChat,
+    handleReconnect,
+    isViewingMd,
+  };
+}

--- a/apps/web/src/hooks/useDrawerGesture.ts
+++ b/apps/web/src/hooks/useDrawerGesture.ts
@@ -148,7 +148,14 @@ export function useDrawerGesture({ drawerRef, overlayRef, onSnapChange, onDragEn
   }, [drawerRef, overlayRef]);
 
   const onTouchEnd = useCallback((e: React.TouchEvent) => {
-    if (!hasMoved.current) return; // tap, not a drag — don't snap
+    if (!hasMoved.current) {
+      // Tap, not drag — re-enable Telegram swipes if we're at peek
+      if (snapRef.current === "peek") {
+        const tg = (window as any).Telegram?.WebApp;
+        tg?.enableVerticalSwipes?.();
+      }
+      return;
+    }
     e.preventDefault(); // prevent browser from synthesizing a click after a drag gesture
     e.stopPropagation();
     const vh = window.innerHeight;

--- a/apps/web/src/hooks/useDrawerGesture.ts
+++ b/apps/web/src/hooks/useDrawerGesture.ts
@@ -149,6 +149,7 @@ export function useDrawerGesture({ drawerRef, overlayRef, onSnapChange, onDragEn
 
   const onTouchEnd = useCallback((e: React.TouchEvent) => {
     if (!hasMoved.current) {
+      e.stopPropagation(); // prevent tap from bubbling to App swipe handler
       // Tap, not drag — re-enable Telegram swipes if we're at peek
       if (snapRef.current === "peek") {
         const tg = (window as any).Telegram?.WebApp;


### PR DESCRIPTION
## Summary

Closes #257

**Depends on:** #260 (Phase 2 — must merge first)

- New `useActionBarModals.tsx` hook — pure extraction of all state, effects, and handlers from ActionBar.tsx. Zero behavioral changes. 18 modal types, search debounce+abort, audio in-flight guard, git branch polling — all preserved exactly.
- New `ActionChips.tsx` — chip-style contextual action buttons consuming the hook. Context-aware per tab (terminal/files-browsing/files-viewing). Renders in drawer half/full area.
- `BottomDrawer.tsx` — `drawerContent` prop (always mounted, CSS `display:none` at peek to preserve hook state across snap transitions)
- `ActionBar.tsx` — refactored to thin wrapper calling the hook (kept as rollback, not rendered)
- `App.tsx` — ActionBar removed, ActionChips wired as drawerContent

## Key decisions

- Hook always mounted (not conditionally rendered) — preserves audioInFlightRef race guard, search abort controllers, and git branch data across peek transitions
- All modals continue via BottomSheet `createPortal(document.body)` at z-index 1000 — unaffected by drawer z-index 20 stacking context
- StatusLine rendered in ActionChips with live status + gitBranch
- `stopPropagation` on ActionChips container prevents chip interactions from reaching App swipe handler

## Review trail

2 local swarm rounds. Issues caught and fixed:
- R1: dead import, conditional mount state loss, StatusLine missing, null deref on viewingFile.name, Telegram swipe re-enable on tap, stopPropagation guard
- R2: stopPropagation in tap path of onTouchEnd (Codex low); Codex modal-clipping medium was false positive (createPortal escapes overflow context, confirmed Tier 1)

## Acceptance criteria

- [x] All existing modal flows work from chips (TODO, Git, Commands, Search, Options, TL;DR, Audio)
- [x] Chips change correctly when switching tabs
- [x] Chips change when entering/leaving file viewer
- [x] No double-mount of modal handlers
- [x] Old ActionBar removed from render tree (preserved as rollback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)