### PR TITLE
feat(nav): Phase 4 app switcher grid + message ticker (#258)

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -313,6 +313,9 @@ export function App() {
       {/* Bottom tab dock — rendered via portal to escape CSS transform containment */}
       <BottomDrawer
         snapToRef={drawerSnapRef}
+        activeTab={activeTab}
+        onTabChange={(tab) => { haptic.selection(); setIsAnimating(true); setActiveTab(tab); }}
+        connected={connected}
         drawerContent={
           <ActionChips
             onReconnect={onReconnect}

--- a/apps/web/src/components/ActionChips.tsx
+++ b/apps/web/src/components/ActionChips.tsx
@@ -31,7 +31,7 @@ export function ActionChips(props: ActionBarProps) {
       {modalNode}
       <div
         onTouchStart={(e) => e.stopPropagation()}
-        style={{ padding: "8px 12px", display: "flex", gap: 8, flexWrap: "wrap", overflowX: "auto" }}
+        style={{ padding: "8px 12px", display: "flex", gap: 8, flexWrap: "wrap" }}
       >
 
         {/* TODO — always visible */}
@@ -83,12 +83,12 @@ export function ActionChips(props: ActionBarProps) {
         {/* Files chips — browsing */}
         {activeTab === "files" && !viewingFile && <>
           <button
-            onClick={() => { openFileSearch(); }}
+            onClick={() => { haptic.impact("light"); openFileSearch(); }}
             style={{ ...chipStyle, background: "#2d3a5a", color: "var(--color-accent-blue)", border: "1px solid #3d4a6a" }}
           >
             Search
           </button>
-          <button onClick={() => openFileOptions()} style={chipStyle}>
+          <button onClick={() => { haptic.impact("light"); openFileOptions(); }} style={chipStyle}>
             Options
           </button>
         </>}

--- a/apps/web/src/components/AppSwitcher.tsx
+++ b/apps/web/src/components/AppSwitcher.tsx
@@ -1,0 +1,78 @@
+type Tab = "terminal" | "files" | "links" | "voice" | "prs";
+
+interface AppSwitcherSection {
+  id: Tab | "agents" | "settings";
+  label: string;
+  icon: string;
+  active: boolean;
+}
+
+const SECTIONS: AppSwitcherSection[] = [
+  { id: "terminal", label: "Terminal", icon: "🖥", active: true },
+  { id: "files",    label: "Files",    icon: "📁", active: true },
+  { id: "links",    label: "Links",    icon: "🔗", active: true },
+  { id: "voice",    label: "Voice",    icon: "🎤", active: true },
+  { id: "prs",      label: "PRs",      icon: "⊙",  active: true },
+  { id: "agents",   label: "Agents",   icon: "🤖", active: false },
+  { id: "settings", label: "Settings", icon: "⚙",  active: false },
+];
+
+interface AppSwitcherProps {
+  activeTab: Tab;
+  onSelect: (tab: Tab) => void;
+}
+
+export function AppSwitcher({ activeTab, onSelect }: AppSwitcherProps) {
+  return (
+    <div style={{
+      display: "grid",
+      gridTemplateColumns: "1fr 1fr",
+      gap: 12,
+      padding: "16px 16px 0",
+      flex: 1,
+      overflowY: "auto",
+    }}>
+      {SECTIONS.map((section) => (
+        <button
+          key={section.id}
+          disabled={!section.active}
+          onClick={() => {
+            if (section.active) onSelect(section.id as Tab);
+          }}
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            justifyContent: "center",
+            gap: 8,
+            padding: "20px 12px",
+            borderRadius: 12,
+            background: section.active
+              ? (section.id === activeTab ? "var(--color-accent-blue)" : "var(--color-surface)")
+              : "var(--color-bg-alt)",
+            border: "1px solid var(--color-border)",
+            cursor: section.active ? "pointer" : "default",
+            opacity: section.active ? 1 : 0.4,
+            transition: "background 200ms ease",
+          }}
+        >
+          <span style={{ fontSize: 28 }}>{section.icon}</span>
+          <span style={{
+            fontSize: 12,
+            color: section.active
+              ? (section.id === activeTab ? "#ffffff" : "var(--color-fg)")
+              : "var(--color-muted)",
+            fontWeight: section.id === activeTab ? 600 : 400,
+          }}>
+            {section.label}
+          </span>
+          {!section.active && (
+            <span style={{ fontSize: 9, color: "var(--color-muted)", marginTop: -4 }}>
+              soon
+            </span>
+          )}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/components/BottomDrawer.css
+++ b/apps/web/src/components/BottomDrawer.css
@@ -73,3 +73,28 @@
 .tab-dock-pills::-webkit-scrollbar {
   display: none;
 }
+
+.message-ticker {
+  flex-shrink: 0;
+  height: 20px;
+  overflow: hidden;
+  border-top: 1px solid var(--color-border);
+  background: var(--color-bg-alt);
+  display: flex;
+  align-items: center;
+  padding: 0 12px;
+}
+
+.message-ticker-inner {
+  font-size: 10px;
+  color: var(--color-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  animation: ticker-fade-in 0.4s ease;
+}
+
+@keyframes ticker-fade-in {
+  from { opacity: 0; transform: translateY(4px); }
+  to   { opacity: 1; transform: translateY(0); }
+}

--- a/apps/web/src/components/BottomDrawer.tsx
+++ b/apps/web/src/components/BottomDrawer.tsx
@@ -2,17 +2,24 @@ import { createPortal } from "react-dom";
 import { useRef, useState, useCallback, useEffect, useLayoutEffect } from "react";
 import { useDrawerGesture } from "../hooks/useDrawerGesture";
 import type { SnapPoint } from "../hooks/useDrawerGesture";
+import { AppSwitcher } from "./AppSwitcher";
+import { MessageTicker } from "./MessageTicker";
 import "./BottomDrawer.css";
 
+type Tab = "terminal" | "files" | "links" | "voice" | "prs";
+
 interface BottomDrawerProps {
-  children: React.ReactNode; // TabDock (always visible at bottom)
-  drawerContent?: React.ReactNode; // ActionChips (only shows in half/full)
+  children: React.ReactNode;       // TabDock (always visible at bottom)
+  drawerContent?: React.ReactNode; // ActionChips (half/full)
+  activeTab: Tab;                  // for AppSwitcher
+  onTabChange: (tab: Tab) => void; // for AppSwitcher tile tap
+  connected?: boolean;             // for MessageTicker
   onSnapChange?: (snap: SnapPoint) => void;
   // Imperative handle: parent passes a ref, we assign animateTo into it
   snapToRef?: React.MutableRefObject<((snap: SnapPoint) => void) | null>;
 }
 
-export function BottomDrawer({ children, drawerContent, onSnapChange, snapToRef }: BottomDrawerProps) {
+export function BottomDrawer({ children, drawerContent, activeTab, onTabChange, connected, onSnapChange, snapToRef }: BottomDrawerProps) {
   const drawerRef = useRef<HTMLDivElement>(null);
   const overlayRef = useRef<HTMLDivElement>(null);
   const [snap, setSnap] = useState<SnapPoint>("peek");
@@ -91,6 +98,9 @@ export function BottomDrawer({ children, drawerContent, onSnapChange, snapToRef 
           {children}
         </div>
 
+        {/* Message ticker — between tab dock and drawer content */}
+        <MessageTicker connected={connected} />
+
         {/* Drag handle — only visible when half/full */}
         <div
           className={`drawer-handle${snap !== "peek" ? " visible" : ""}`}
@@ -102,9 +112,12 @@ export function BottomDrawer({ children, drawerContent, onSnapChange, snapToRef 
           <div className="drawer-handle-bar" />
         </div>
 
-        {/* Expandable content area — ActionChips always mounted, hidden at peek via CSS to preserve state */}
+        {/* Expandable content area — full: AppSwitcher, half: ActionChips, peek: hidden */}
         <div className="drawer-content" style={snap === "peek" ? { display: "none" } : undefined}>
-          {drawerContent}
+          {snap === "full"
+            ? <AppSwitcher activeTab={activeTab} onSelect={(tab) => { onTabChange(tab); animateTo("peek"); }} />
+            : drawerContent
+          }
         </div>
       </div>
     </>,

--- a/apps/web/src/components/BottomDrawer.tsx
+++ b/apps/web/src/components/BottomDrawer.tsx
@@ -112,8 +112,9 @@ export function BottomDrawer({ children, drawerContent, activeTab, onTabChange, 
           <div className="drawer-handle-bar" />
         </div>
 
-        {/* Expandable content area — full: AppSwitcher, half: ActionChips, peek: hidden */}
-        <div className="drawer-content" style={snap === "peek" ? { display: "none" } : undefined}>
+        {/* AppSwitcher at full, ActionChips (drawerContent) at half — ActionChips remounts on full→half transition;
+            useActionBarModals state (debounce timers, audio refs) is discarded when AppSwitcher is open */}
+        <div className="drawer-content">
           {snap === "full"
             ? <AppSwitcher activeTab={activeTab} onSelect={(tab) => { onTabChange(tab); animateTo("peek"); }} />
             : drawerContent

--- a/apps/web/src/components/MessageTicker.tsx
+++ b/apps/web/src/components/MessageTicker.tsx
@@ -23,6 +23,7 @@ export function MessageTicker({ connected, extraMessages }: MessageTickerProps) 
   const [currentIdx, setCurrentIdx] = useState(0);
 
   useEffect(() => {
+    setCurrentIdx(0);
     const timer = setInterval(() => {
       setCurrentIdx((prev) => (prev + 1) % messages.length);
     }, 4000);

--- a/apps/web/src/components/MessageTicker.tsx
+++ b/apps/web/src/components/MessageTicker.tsx
@@ -1,0 +1,39 @@
+import { useState, useEffect } from "react";
+
+const DEFAULT_MESSAGES = [
+  "CPC v1.12 · Navigation Redesign v2",
+  "● Connected · All systems nominal",
+  "Swipe up for actions · Tap ⋯ for app switcher",
+];
+
+interface MessageTickerProps {
+  connected?: boolean;
+  extraMessages?: string[];
+}
+
+export function MessageTicker({ connected, extraMessages }: MessageTickerProps) {
+  const messages = [
+    connected !== undefined
+      ? `● ${connected ? "Connected" : "Offline"} · CPC v1.12`
+      : "CPC v1.12",
+    ...DEFAULT_MESSAGES.slice(1),
+    ...(extraMessages ?? []),
+  ];
+
+  const [currentIdx, setCurrentIdx] = useState(0);
+
+  useEffect(() => {
+    const timer = setInterval(() => {
+      setCurrentIdx((prev) => (prev + 1) % messages.length);
+    }, 4000);
+    return () => clearInterval(timer);
+  }, [messages.length]);
+
+  return (
+    <div className="message-ticker" aria-live="polite">
+      <div className="message-ticker-inner" key={currentIdx}>
+        {messages[currentIdx]}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/hooks/useDrawerGesture.ts
+++ b/apps/web/src/hooks/useDrawerGesture.ts
@@ -207,11 +207,17 @@ export function useDrawerGesture({ drawerRef, overlayRef, onSnapChange, onDragEn
       el.style.transition = "none";
       el.style.transform = `translateY(${y}px)`;
     }
-    // Reset overlay if cancelled while at peek — otherwise it freezes at partial opacity
-    if (snapRef.current === "peek" && overlayRef.current) {
-      overlayRef.current.style.transition = "none";
-      overlayRef.current.style.background = "rgba(0,0,0,0)";
-      overlayRef.current.style.pointerEvents = "none";
+    // Restore overlay for current snap — onTouchMove may have partially updated it during the cancelled drag
+    const overlay = overlayRef.current;
+    if (overlay) {
+      overlay.style.transition = "none";
+      if (snapRef.current === "peek") {
+        overlay.style.background = "rgba(0,0,0,0)";
+        overlay.style.pointerEvents = "none";
+      } else {
+        overlay.style.background = "rgba(0,0,0,0.4)";
+        overlay.style.pointerEvents = "auto";
+      }
     }
   }, [drawerRef, overlayRef, getTranslateYForSnap]);
 


### PR DESCRIPTION
## Summary

- Adds `AppSwitcher` component: 2-column tile grid (Terminal, Files, Links, Voice, PRs active; Agents/Settings disabled/soon), accent-blue active tile, tap selects tab + snaps drawer to peek
- Adds `MessageTicker` component: rotates 3 status messages every 4s with CSS fade-in animation, `connected` prop reflects live connection state
- Extends `BottomDrawer`: full snap → AppSwitcher, half snap → ActionChips (drawerContent prop), new props (`activeTab`, `onTabChange`, `connected`, `snapToRef`, `onSnapChange`)
- Wires `App.tsx`: `drawerSnapRef` for imperative snap, `onMore` on TabDock triggers `animateTo("full")`

## R1 fixes applied (pre-push swarm)

- **MessageTicker** — `setCurrentIdx(0)` on length change prevents blank ticker if extraMessages shrinks
- **BottomDrawer** — removed `display:none` on drawer-content at peek; translateY naturally hides content off-screen, removal lets content slide in during drag-up gesture
- **useDrawerGesture** — `onTouchCancel` now restores overlay for all snap states (was peek-only; stale overlay broke outside-tap-to-close after cancelled drag from half/full)
- **ActionChips** — removed `overflowX:"auto"` conflict with `flexWrap:"wrap"`; added `haptic.impact("light")` to Search + Options buttons

## Stacked on Phase 3

This PR targets `feat/issue-257-nav-phase-3`. Merge order: Phase 2 → Phase 3 → Phase 4 → dev.

## Test plan

- [ ] Tab dock visible in peek, full 90vh in full snap
- [ ] Drag up from peek → half shows ActionChips; drag to full shows AppSwitcher grid
- [ ] Tap tile in AppSwitcher → switches tab + snaps to peek
- [ ] MessageTicker rotates every 4s with fade animation; shows Connected/Offline based on `connected` prop
- [ ] Cancel mid-drag from half/full → overlay stays dimmed (not stale transparent)
- [ ] Haptic on all chip buttons including Search + Options

Closes #258

🤖 Generated with [Claude Code](https://claude.com/claude-code)