### PR TITLE
fix(security): bump dompurify + hono for Dependabot alerts

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -16,7 +16,7 @@
     "@hono/node-server": "^1",
     "@hono/node-ws": "^1",
     "better-sqlite3": "^12.8.0",
-    "hono": "^4",
+    "hono": "^4.12.14",
     "nanoid": "^5.1.7"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -17,5 +17,10 @@
     "@playwright/test": "^1.58.2",
     "turbo": "^2"
   },
-  "packageManager": "pnpm@10.28.1"
+  "packageManager": "pnpm@10.28.1",
+  "pnpm": {
+    "overrides": {
+      "dompurify": "^3.4.0"
+    }
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  dompurify: ^3.4.0
+
 importers:
 
   .:
@@ -19,16 +22,16 @@ importers:
     dependencies:
       '@hono/node-server':
         specifier: ^1
-        version: 1.19.13(hono@4.12.12)
+        version: 1.19.13(hono@4.12.14)
       '@hono/node-ws':
         specifier: ^1
-        version: 1.3.0(@hono/node-server@1.19.13(hono@4.12.12))(hono@4.12.12)
+        version: 1.3.0(@hono/node-server@1.19.13(hono@4.12.14))(hono@4.12.14)
       better-sqlite3:
         specifier: ^12.8.0
         version: 12.8.0
       hono:
-        specifier: ^4
-        version: 4.12.12
+        specifier: ^4.12.14
+        version: 4.12.14
       nanoid:
         specifier: ^5.1.7
         version: 5.1.7
@@ -1525,8 +1528,8 @@ packages:
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
-  dompurify@3.3.3:
-    resolution: {integrity: sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==}
+  dompurify@3.4.0:
+    resolution: {integrity: sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==}
 
   electron-to-chromium@1.5.332:
     resolution: {integrity: sha512-7OOtytmh/rINMLwaFTbcMVvYXO3AUm029X0LcyfYk0B557RlPkdpTpnH9+htMlfu5dKwOmT0+Zs2Aw+lnn6TeQ==}
@@ -1663,8 +1666,8 @@ packages:
     resolution: {integrity: sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==}
     engines: {node: '>=12.0.0'}
 
-  hono@4.12.12:
-    resolution: {integrity: sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==}
+  hono@4.12.14:
+    resolution: {integrity: sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==}
     engines: {node: '>=16.9.0'}
 
   html-encoding-sniffer@6.0.0:
@@ -2968,14 +2971,14 @@ snapshots:
 
   '@exodus/bytes@1.15.0': {}
 
-  '@hono/node-server@1.19.13(hono@4.12.12)':
+  '@hono/node-server@1.19.13(hono@4.12.14)':
     dependencies:
-      hono: 4.12.12
+      hono: 4.12.14
 
-  '@hono/node-ws@1.3.0(@hono/node-server@1.19.13(hono@4.12.12))(hono@4.12.12)':
+  '@hono/node-ws@1.3.0(@hono/node-server@1.19.13(hono@4.12.14))(hono@4.12.14)':
     dependencies:
-      '@hono/node-server': 1.19.13(hono@4.12.12)
-      hono: 4.12.12
+      '@hono/node-server': 1.19.13(hono@4.12.14)
+      hono: 4.12.14
       ws: 8.20.0
     transitivePeerDependencies:
       - bufferutil
@@ -3846,7 +3849,7 @@ snapshots:
 
   dom-accessibility-api@0.6.3: {}
 
-  dompurify@3.3.3:
+  dompurify@3.4.0:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -4022,7 +4025,7 @@ snapshots:
 
   highlight.js@11.11.1: {}
 
-  hono@4.12.12: {}
+  hono@4.12.14: {}
 
   html-encoding-sniffer@6.0.0:
     dependencies:
@@ -4379,7 +4382,7 @@ snapshots:
       d3-sankey: 0.12.3
       dagre-d3-es: 7.0.14
       dayjs: 1.11.20
-      dompurify: 3.3.3
+      dompurify: 3.4.0
       katex: 0.16.45
       khroma: 2.1.0
       lodash-es: 4.18.1


### PR DESCRIPTION
## Summary

Two moderate Dependabot security alerts resolved via version bumps only — no code changes.

| Package | Old | New | Alert |
|---|---|---|---|
| `hono` | 4.12.12 | 4.12.14 | JSX SSR HTML injection |
| `dompurify` | 3.3.3 | 3.4.0 | ADD_TAGS bypass |

**dompurify** is a transitive dependency via `mermaid`. Since mermaid's declared range (`^3.3.1`) doesn't yet pick up 3.4.0, a `pnpm.overrides` entry was added to `package.json` to force the patched version across all dependents.

## Changes

- `apps/server/package.json` — pinned `hono` to `^4.12.14`
- `package.json` — added `pnpm.overrides.dompurify: ^3.4.0`
- `pnpm-lock.yaml` — lockfile updated for both packages

## Test Results

- Build: clean (`2 tasks successful`, 0 TS errors)
- Unit tests: **246 passed** (15 test files)