### PR TITLE
feat(file-browser): expose .world allowlist + synthetic home view

### DIFF
--- a/apps/server/src/lib/path-allowed.ts
+++ b/apps/server/src/lib/path-allowed.ts
@@ -37,6 +37,7 @@ export const ALLOWED_FILE_ROOTS = [
   "/home/claude/bin",
   "/home/claude/.claude",
   "/home/claude/claudes-world/.claude",
+  "/home/claude/.world",
 ] as const;
 
 

--- a/apps/server/src/routes/__tests__/files.test.ts
+++ b/apps/server/src/routes/__tests__/files.test.ts
@@ -664,7 +664,7 @@ describe("GET /list — synthetic home view", () => {
 
     // Every returned item must be a directory whose path starts with /home/claude/
     for (const item of body.items) {
-      expect(item.type).toBe("directory");
+      expect(item.type).toBe("dir");
       expect(item.path.startsWith("/home/claude/")).toBe(true);
     }
 

--- a/apps/server/src/routes/__tests__/files.test.ts
+++ b/apps/server/src/routes/__tests__/files.test.ts
@@ -642,3 +642,53 @@ describe("POST /paste", () => {
     expect(JSON.stringify(body)).not.toContain(sandbox);
   });
 });
+
+// ---------------------------------------------------------------------------
+// GET /list — synthetic home view (/home/claude)
+// ---------------------------------------------------------------------------
+describe("GET /list — synthetic home view", () => {
+  it("returns only allowlisted subdirs of /home/claude, never disallowed siblings", async () => {
+    const res = await filesRoute.request(
+      `/list?path=${encodeURIComponent("/home/claude")}`,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      path: string;
+      parent: string | null;
+      items: Array<{ name: string; path: string; type: string }>;
+    };
+
+    expect(body.path).toBe("/home/claude");
+    expect(body.parent).toBeNull();
+    expect(Array.isArray(body.items)).toBe(true);
+
+    // Every returned item must be a directory whose path starts with /home/claude/
+    for (const item of body.items) {
+      expect(item.type).toBe("directory");
+      expect(item.path.startsWith("/home/claude/")).toBe(true);
+    }
+
+    const names = body.items.map((i) => i.name);
+
+    // Allowlisted direct children must be present
+    expect(names).toContain("claudes-world");
+    expect(names).toContain("code");
+    expect(names).toContain("bin");
+    expect(names).toContain(".claude");
+    expect(names).toContain(".world");
+
+    // Disallowed siblings must never appear
+    expect(names).not.toContain(".ssh");
+    expect(names).not.toContain(".secrets");
+    expect(names).not.toContain("claudes-world/.claude"); // nested root, not a direct child
+  });
+
+  it("returns 403 for direct file-read on /home/claude", async () => {
+    const res = await filesRoute.request(
+      `/read?path=${encodeURIComponent("/home/claude")}`,
+    );
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("Access denied");
+  });
+});

--- a/apps/server/src/routes/__tests__/path-allowed.test.ts
+++ b/apps/server/src/routes/__tests__/path-allowed.test.ts
@@ -149,6 +149,24 @@ describe("isPathAllowed", () => {
     expect(await isPathAllowed(allowedRoot, [platformRoot])).toBe(true);
   });
 
+  it("allows a path under /home/claude/.world when that root is in the allowlist", async () => {
+    // Verify that ALLOWED_FILE_ROOTS includes /home/claude/.world by importing it
+    // and checking membership, then confirm the helper resolves the path as allowed
+    // against a synthetic tmp-based root (we can't use the live .world path in CI
+    // because it may not exist on the test host).
+    const { ALLOWED_FILE_ROOTS } = await import("../../lib/path-allowed.js");
+    expect(ALLOWED_FILE_ROOTS).toContain("/home/claude/.world");
+
+    // Functional check: a nested path under an allowed root that mimics the
+    // .world layout is accepted. Uses the existing allowedRoot fixture.
+    const snapshotsDir = join(allowedRoot, "pulse", "snapshots");
+    mkdirSync(snapshotsDir, { recursive: true });
+    writeFileSync(join(snapshotsDir, "current.json"), "{}");
+    expect(
+      await isPathAllowed(join(snapshotsDir, "current.json"), [allowedRoot]),
+    ).toBe(true);
+  });
+
   it("memoizes realpath(root) via an on-disk swap of the root target", async () => {
     // Spying on `realpath` in ESM is blocked by vitest (module namespace
     // is not configurable), so we verify memoization by observing a behavior

--- a/apps/server/src/routes/files.ts
+++ b/apps/server/src/routes/files.ts
@@ -130,10 +130,37 @@ app.get("/roots", (c) => {
   });
 });
 
+// Synthetic home view — parent of all allowed roots. Constructed purely from
+// ALLOWED_ROOTS (no readdir on /home/claude) so disallowed siblings like .ssh
+// can never appear in the listing.
+const HOME_CLAUDE = "/home/claude";
+
 // List directory contents
 app.get("/list", async (c) => {
   const dir = c.req.query("path") || BASE_DIR;
   const resolved = resolve(dir);
+
+  // Synthetic home view: construct listing from allowlist, never readdir /home/claude.
+  if (resolved === HOME_CLAUDE || resolved === HOME_CLAUDE + sep) {
+    const items = ALLOWED_ROOTS
+      .map((r) => resolve(r))
+      .filter((r) => {
+        // Only include roots whose immediate parent is /home/claude
+        const parentDir = resolve(r, "..");
+        return parentDir === HOME_CLAUDE;
+      })
+      .map((r) => ({
+        name: basename(r),
+        path: r,
+        type: "directory" as const,
+      }));
+
+    return c.json({
+      path: HOME_CLAUDE,
+      parent: null,
+      items,
+    });
+  }
 
   if (!await isPathAllowed(resolved)) {
     return c.json({ error: "Access denied" }, 403);
@@ -205,6 +232,10 @@ app.get("/read", async (c) => {
   }
 
   const resolved = resolve(filePath);
+  // /home/claude itself is a synthetic virtual directory — never a real file.
+  if (resolved === HOME_CLAUDE || resolved === HOME_CLAUDE + sep) {
+    return c.json({ error: "Access denied" }, 403);
+  }
   if (!await isPathAllowed(resolved)) {
     return c.json({ error: "Access denied" }, 403);
   }

--- a/apps/server/src/routes/files.ts
+++ b/apps/server/src/routes/files.ts
@@ -152,7 +152,7 @@ app.get("/list", async (c) => {
       .map((r) => ({
         name: basename(r),
         path: r,
-        type: "directory" as const,
+        type: "dir" as const,
       }));
 
     return c.json({

--- a/apps/server/src/routes/files.ts
+++ b/apps/server/src/routes/files.ts
@@ -141,7 +141,7 @@ app.get("/list", async (c) => {
   const resolved = resolve(dir);
 
   // Synthetic home view: construct listing from allowlist, never readdir /home/claude.
-  if (resolved === HOME_CLAUDE || resolved === HOME_CLAUDE + sep) {
+  if (resolved === HOME_CLAUDE) {
     const items = ALLOWED_ROOTS
       .map((r) => resolve(r))
       .filter((r) => {
@@ -233,7 +233,7 @@ app.get("/read", async (c) => {
 
   const resolved = resolve(filePath);
   // /home/claude itself is a synthetic virtual directory — never a real file.
-  if (resolved === HOME_CLAUDE || resolved === HOME_CLAUDE + sep) {
+  if (resolved === HOME_CLAUDE) {
     return c.json({ error: "Access denied" }, 403);
   }
   if (!await isPathAllowed(resolved)) {

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -567,11 +567,11 @@ export function FileViewer({ onClose, initialFile, showHidden = false, sortMode 
           }}
         >
           {[
+            { label: "\ud83c\udfe0 home", path: "/home/claude" },
             { label: "claudes-world", path: "/home/claude/claudes-world" },
             { label: "code", path: "/home/claude/code" },
             { label: "bin", path: "/home/claude/bin" },
             { label: "\ud83c\udf10 .claude", path: "/home/claude/claudes-world/.claude" },
-            { label: "\ud83c\udfe0 .claude", path: "/home/claude/.claude" },
           ].map((root) => (
             <button
               key={root.path}


### PR DESCRIPTION
## Summary

- **Change 1:** Add `/home/claude/.world` to `ALLOWED_FILE_ROOTS` in `path-allowed.ts`
- **Change 2:** Synthetic `GET /list` for `/home/claude` — constructed from allowlist only (no `readdir`), disallowed siblings like `.ssh`/`.secrets` can never appear; `GET /read` on `/home/claude` → 403
- **Change 3:** Frontend `FileViewer.tsx` — add `🏠 home` button (first position), remove `🏠 .claude` shortcut (allowlist entry kept)

## Files touched

- `apps/server/src/lib/path-allowed.ts` — allowlist entry
- `apps/server/src/routes/files.ts` — synthetic home view + /read guard
- `apps/web/src/components/FileViewer.tsx` — nav button changes
- `apps/server/src/routes/__tests__/path-allowed.test.ts` — .world membership + nested path test
- `apps/server/src/routes/__tests__/files.test.ts` — synthetic home security test + /read 403 test

## Test results

271 passed, 0 failed (vitest unit suite). Playwright E2E skipped — browser not installed on host (pre-existing).

## Security guardrails

- `isPathAllowed` untouched — no allowlist widening at the check layer
- Synthetic listing is pure allowlist filter; `readdir /home/claude` is never called
- `.ssh`, `.secrets`, and all other non-allowlisted siblings cannot appear

Closes #264