### PR TITLE
feat(pulse): add pulse dashboard lab tab with 4 design comparisons

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -22,6 +22,7 @@ import { voiceRoute } from "./routes/voice.js";
 import { markdownRoute } from "./routes/markdown.js";
 import { readingListRoute } from "./routes/reading-list.js";
 import { prsRoute } from "./routes/prs.js";
+import { pulseRoute } from "./routes/pulse.js";
 
 // Load env from secrets file if not already set
 function loadEnv(path: string) {
@@ -88,6 +89,7 @@ app.route("/api/voice", voiceRoute);
 app.route("/api/markdown", markdownRoute);
 app.route("/api/reading-list", readingListRoute);
 app.route("/api/prs", prsRoute);
+app.route("/api/pulse", pulseRoute);
 
 // WebSocket terminal (auth handled in upgrade via query param)
 app.get("/ws/terminal", upgradeWebSocket(terminalWsRoute));

--- a/apps/server/src/routes/pulse.ts
+++ b/apps/server/src/routes/pulse.ts
@@ -1,0 +1,36 @@
+import { Hono } from "hono";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+const app = new Hono();
+
+const SNAPSHOT_PATH = join(
+  process.env.HOME ?? "/home/claude",
+  ".world/pulse/snapshots/current.json"
+);
+const CACHE_TTL_MS = 60 * 1000;
+
+let cachedSnapshot: unknown = null;
+let cacheExpiresAt = 0;
+
+app.get("/current", async (c) => {
+  const now = Date.now();
+  if (cachedSnapshot !== null && now < cacheExpiresAt) {
+    return c.json(cachedSnapshot);
+  }
+
+  try {
+    const raw = await readFile(SNAPSHOT_PATH, "utf-8");
+    cachedSnapshot = JSON.parse(raw);
+    cacheExpiresAt = now + CACHE_TTL_MS;
+    return c.json(cachedSnapshot);
+  } catch (err: any) {
+    if (err?.code === "ENOENT") {
+      return c.json({ error: "pulse snapshot not available" }, 503);
+    }
+    console.error("[pulse/current] read error:", err);
+    return c.json({ error: "pulse snapshot not available" }, 503);
+  }
+});
+
+export { app as pulseRoute };

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -22,6 +22,7 @@
     "react-dom": "^19",
     "react-icons": "^5.6.0",
     "react-markdown": "^10.1.0",
+    "recharts": "^3.8.1",
     "rehype-highlight": "^7.0.2",
     "rehype-slug": "^6.0.0",
     "remark-breaks": "^4.0.0",

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -13,9 +13,10 @@ import { haptic } from "./lib/haptic";
 import { DebugOverlay } from "./debug/DebugOverlay";
 import { PrTicker } from "./components/PrTicker";
 import { HomeScreenPrompt } from "./components/HomeScreenPrompt";
+import PulseLabPage from "./components/pulse/PulseLabPage";
 
-type Tab = "terminal" | "files" | "links" | "voice" | "prs";
-const TABS: Tab[] = ["terminal", "files", "links", "voice", "prs"];
+type Tab = "terminal" | "files" | "links" | "voice" | "prs" | "pulse";
+const TABS: Tab[] = ["terminal", "files", "links", "voice", "prs", "pulse"];
 const SWIPE_THRESHOLD = 120;
 
 
@@ -310,6 +311,9 @@ export function App() {
           </div>
           <div style={{ width: `${100 / TABS.length}%`, height: "100%", flexShrink: 0 }}>
             <PrTicker />
+          </div>
+          <div style={{ width: `${100 / TABS.length}%`, height: "100%", flexShrink: 0, overflow: "hidden", maxWidth: "100%" }}>
+            <PulseLabPage />
           </div>
         </div>
       </div>

--- a/apps/web/src/components/AppSwitcher.tsx
+++ b/apps/web/src/components/AppSwitcher.tsx
@@ -1,4 +1,4 @@
-type Tab = "terminal" | "files" | "links" | "voice" | "prs";
+type Tab = "terminal" | "files" | "links" | "voice" | "prs" | "pulse";
 
 interface AppSwitcherSection {
   id: Tab | "agents" | "settings";
@@ -13,6 +13,7 @@ const SECTIONS: AppSwitcherSection[] = [
   { id: "links",    label: "Links",    icon: "🔗", active: true },
   { id: "voice",    label: "Voice",    icon: "🎤", active: true },
   { id: "prs",      label: "PRs",      icon: "⊙",  active: true },
+  { id: "pulse",    label: "Pulse",    icon: "📊", active: true },
   { id: "agents",   label: "Agents",   icon: "🤖", active: false },
   { id: "settings", label: "Settings", icon: "⚙",  active: false },
 ];

--- a/apps/web/src/components/BottomDrawer.tsx
+++ b/apps/web/src/components/BottomDrawer.tsx
@@ -6,7 +6,7 @@ import { AppSwitcher } from "./AppSwitcher";
 import { MessageTicker } from "./MessageTicker";
 import "./BottomDrawer.css";
 
-type Tab = "terminal" | "files" | "links" | "voice" | "prs";
+type Tab = "terminal" | "files" | "links" | "voice" | "prs" | "pulse";
 
 interface BottomDrawerProps {
   children: React.ReactNode;       // TabDock (always visible at bottom)

--- a/apps/web/src/components/TabDock.tsx
+++ b/apps/web/src/components/TabDock.tsx
@@ -1,4 +1,4 @@
-type Tab = "terminal" | "files" | "links" | "voice" | "prs";
+type Tab = "terminal" | "files" | "links" | "voice" | "prs" | "pulse";
 
 const TAB_LABELS: Record<Tab, string> = {
   terminal: "Terminal",
@@ -6,9 +6,10 @@ const TAB_LABELS: Record<Tab, string> = {
   links: "Links",
   voice: "Voice",
   prs: "PRs",
+  pulse: "Pulse",
 };
 
-const TABS: Tab[] = ["terminal", "files", "links", "voice", "prs"];
+const TABS: Tab[] = ["terminal", "files", "links", "voice", "prs", "pulse"];
 
 interface TabDockProps {
   activeTab: Tab;

--- a/apps/web/src/components/pulse/AlertFirstDashboard.tsx
+++ b/apps/web/src/components/pulse/AlertFirstDashboard.tsx
@@ -1,0 +1,687 @@
+import { useState } from "react";
+import type { PulseSnapshot } from "./MinimalistDashboard";
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+interface FieldStatus {
+  status: "success" | "failed" | "partial" | "scope_missing";
+  error_note: string | null;
+}
+
+interface VulnAlert {
+  severity: "CRITICAL" | "HIGH" | "MODERATE" | "LOW";
+  ghsa_id: string;
+  package_name: string;
+  ecosystem: string;
+  age_days: number;
+  dependabot_pr_number: number | null;
+}
+
+interface PR {
+  number: number;
+  title: string;
+  author: string;
+  is_draft: boolean;
+  is_dependabot: boolean;
+  is_renovate: boolean;
+  stalled: boolean;
+  hours_idle: number;
+  updated_at: string;
+}
+
+interface RepoSnapshot {
+  org: string;
+  name: string;
+  is_fork: boolean;
+  is_archived: boolean;
+  capture_status: "success" | "partial" | "failed";
+  field_statuses: Record<string, FieldStatus>;
+  upstream: { status: string; commits_behind: number; commits_ahead: number } | null;
+  vulnerability_alerts: VulnAlert[] | null;
+  prs: PR[];
+  issues: { number: number; title: string; labels: string[]; stalled: boolean; hours_idle: number }[];
+  releases: { tag_name: string; name: string; is_prerelease: boolean; created_at: string }[];
+}
+
+type AlertKind =
+  | "capture_failed"
+  | "vuln_critical"
+  | "stalled_pr"
+  | "vuln_high"
+  | "scope_missing"
+  | "capture_partial"
+  | "vuln_moderate"
+  | "vuln_low";
+
+interface Alert {
+  id: string;
+  kind: AlertKind;
+  priority: number;
+  repo: string;
+  org: string;
+  title: string;
+  subtitle: string;
+  meta: string;
+  detail: string | null;
+}
+
+interface Props {
+  data: PulseSnapshot;
+}
+
+// ── Priority weights (lower = more urgent) ───────────────────────────────────
+
+const PRIORITY: Record<AlertKind, number> = {
+  capture_failed: 0,
+  vuln_critical: 1,
+  stalled_pr: 2,
+  vuln_high: 3,
+  scope_missing: 4,
+  capture_partial: 5,
+  vuln_moderate: 6,
+  vuln_low: 7,
+};
+
+// ── Alert generation ─────────────────────────────────────────────────────────
+
+function buildAlerts(repos: RepoSnapshot[]): Alert[] {
+  const alerts: Alert[] = [];
+
+  for (const repo of repos) {
+    const repoKey = `${repo.org}/${repo.name}`;
+
+    // 1. Capture failure
+    if (repo.capture_status === "failed") {
+      const firstError = Object.values(repo.field_statuses)
+        .find((f) => f.status === "failed")
+        ?.error_note ?? "Unknown capture error";
+      alerts.push({
+        id: `capture_failed:${repoKey}`,
+        kind: "capture_failed",
+        priority: PRIORITY.capture_failed,
+        repo: repo.name,
+        org: repo.org,
+        title: "Capture failed",
+        subtitle: repo.name,
+        meta: firstError,
+        detail: Object.entries(repo.field_statuses)
+          .filter(([, v]) => v.status === "failed")
+          .map(([field, v]) => `${field}: ${v.error_note}`)
+          .join("\n"),
+      });
+    }
+
+    // 2. Vulnerability alerts (null = scope_missing, handled below)
+    if (repo.vulnerability_alerts !== null) {
+      for (const vuln of repo.vulnerability_alerts) {
+        const kind: AlertKind =
+          vuln.severity === "CRITICAL"
+            ? "vuln_critical"
+            : vuln.severity === "HIGH"
+            ? "vuln_high"
+            : vuln.severity === "MODERATE"
+            ? "vuln_moderate"
+            : "vuln_low";
+
+        alerts.push({
+          id: `${kind}:${repoKey}:${vuln.ghsa_id}`,
+          kind,
+          priority: PRIORITY[kind],
+          repo: repo.name,
+          org: repo.org,
+          title: `${vuln.severity} vuln — ${vuln.package_name}`,
+          subtitle: `${vuln.ghsa_id} · ${vuln.ecosystem}`,
+          meta: `${vuln.age_days}d old${vuln.dependabot_pr_number ? ` · PR #${vuln.dependabot_pr_number}` : " · no PR"}`,
+          detail: vuln.dependabot_pr_number
+            ? `Dependabot PR #${vuln.dependabot_pr_number} open. Review and merge to remediate.`
+            : `No dependabot PR exists. Manual remediation required for ${vuln.package_name} (${vuln.ecosystem}).`,
+        });
+      }
+    }
+
+    // 3. Stalled PRs (human-authored only — skip dependabot/renovate)
+    for (const pr of repo.prs) {
+      if (pr.stalled && !pr.is_dependabot && !pr.is_renovate) {
+        const days = Math.round(pr.hours_idle / 24);
+        alerts.push({
+          id: `stalled_pr:${repoKey}:#${pr.number}`,
+          kind: "stalled_pr",
+          priority: PRIORITY.stalled_pr,
+          repo: repo.name,
+          org: repo.org,
+          title: `Stalled PR #${pr.number}`,
+          subtitle: pr.title,
+          meta: `${days}d idle · @${pr.author}${pr.is_draft ? " · draft" : ""}`,
+          detail: `Last updated: ${new Date(pr.updated_at).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" })}. No activity for ${pr.hours_idle}h.`,
+        });
+      }
+    }
+
+    // 4. Scope-missing fields (vuln_alerts: null means the whole field is missing)
+    if (repo.vulnerability_alerts === null) {
+      const note = repo.field_statuses["vulnerability_alerts"]?.error_note;
+      alerts.push({
+        id: `scope_missing:${repoKey}:vulnerability_alerts`,
+        kind: "scope_missing",
+        priority: PRIORITY.scope_missing,
+        repo: repo.name,
+        org: repo.org,
+        title: "Scope missing — vulnerability_alerts",
+        subtitle: repo.name,
+        meta: "Cannot read vuln data",
+        detail: note ?? "Token lacks security_events scope. Re-auth required to capture vulnerability data for this repo.",
+      });
+    }
+
+    // 5. Other scope_missing / failed fields (not already caught above)
+    for (const [field, fs] of Object.entries(repo.field_statuses)) {
+      if (fs.status === "scope_missing" && field !== "vulnerability_alerts") {
+        alerts.push({
+          id: `scope_missing:${repoKey}:${field}`,
+          kind: "scope_missing",
+          priority: PRIORITY.scope_missing,
+          repo: repo.name,
+          org: repo.org,
+          title: `Scope missing — ${field}`,
+          subtitle: repo.name,
+          meta: fs.error_note ?? "Permission gap",
+          detail: fs.error_note,
+        });
+      }
+    }
+
+    // 6. Partial capture (repo-level, not already failed)
+    if (repo.capture_status === "partial") {
+      const partialFields = Object.entries(repo.field_statuses)
+        .filter(([, v]) => v.status === "partial" || v.status === "failed")
+        .map(([field]) => field);
+      if (partialFields.length > 0) {
+        alerts.push({
+          id: `capture_partial:${repoKey}`,
+          kind: "capture_partial",
+          priority: PRIORITY.capture_partial,
+          repo: repo.name,
+          org: repo.org,
+          title: "Partial capture",
+          subtitle: `Fields affected: ${partialFields.join(", ")}`,
+          meta: repo.name,
+          detail: partialFields
+            .map((f) => `${f}: ${repo.field_statuses[f]?.error_note ?? "partial"}`)
+            .join("\n"),
+        });
+      }
+    }
+  }
+
+  // Deduplicate by id then sort
+  const seen = new Set<string>();
+  const unique = alerts.filter((a) => {
+    if (seen.has(a.id)) return false;
+    seen.add(a.id);
+    return true;
+  });
+
+  return unique.sort((a, b) => a.priority - b.priority);
+}
+
+// ── Styles ───────────────────────────────────────────────────────────────────
+
+const css = `
+  *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+
+  .ap-root {
+    max-width: 100%;
+    margin: 0 auto;
+    background: var(--tg-theme-bg-color, #0f0f0f);
+    color: var(--tg-theme-text-color, #e8e8e8);
+    padding-top: var(--tg-content-safe-area-inset-top, 0px);
+    min-height: 100%;
+    overflow-x: hidden;
+  }
+
+  .ap-header {
+    padding: 12px 16px 8px;
+    border-bottom: 1px solid rgba(255,255,255,0.08);
+  }
+
+  .ap-header-row {
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+  }
+
+  .ap-title {
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: rgba(255,255,255,0.4);
+  }
+
+  .ap-timestamp {
+    font-size: 11px;
+    color: rgba(255,255,255,0.3);
+  }
+
+  .ap-alert-count {
+    font-size: 11px;
+    font-weight: 700;
+    color: #ff4d4d;
+    margin-left: auto;
+  }
+
+  .ap-list {
+    list-style: none;
+  }
+
+  .ap-card {
+    border-bottom: 1px solid rgba(255,255,255,0.06);
+    cursor: pointer;
+    user-select: none;
+  }
+
+  .ap-card:active {
+    background: rgba(255,255,255,0.04);
+  }
+
+  .ap-card-main {
+    display: flex;
+    align-items: stretch;
+    min-height: 64px;
+    padding: 0;
+  }
+
+  .ap-card-stripe {
+    width: 4px;
+    flex-shrink: 0;
+    border-radius: 0;
+  }
+
+  .stripe-capture_failed  { background: #ff4d4d; }
+  .stripe-vuln_critical   { background: #ff4d4d; }
+  .stripe-stalled_pr      { background: #ff9500; }
+  .stripe-vuln_high       { background: #ffcc00; }
+  .stripe-scope_missing   { background: #a78bfa; }
+  .stripe-capture_partial { background: #60a5fa; }
+  .stripe-vuln_moderate   { background: #94a3b8; }
+  .stripe-vuln_low        { background: #475569; }
+
+  .ap-card-body {
+    flex: 1;
+    padding: 10px 12px;
+    min-width: 0;
+  }
+
+  .ap-card-top {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    margin-bottom: 3px;
+  }
+
+  .ap-badge {
+    font-size: 10px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    padding: 1px 5px;
+    border-radius: 3px;
+    flex-shrink: 0;
+  }
+
+  .badge-capture_failed  { background: rgba(255,77,77,0.2);  color: #ff4d4d; }
+  .badge-vuln_critical   { background: rgba(255,77,77,0.2);  color: #ff4d4d; }
+  .badge-stalled_pr      { background: rgba(255,149,0,0.2);  color: #ff9500; }
+  .badge-vuln_high       { background: rgba(255,204,0,0.2);  color: #ffcc00; }
+  .badge-scope_missing   { background: rgba(167,139,250,0.2);color: #a78bfa; }
+  .badge-capture_partial { background: rgba(96,165,250,0.2); color: #60a5fa; }
+  .badge-vuln_moderate   { background: rgba(148,163,184,0.2);color: #94a3b8; }
+  .badge-vuln_low        { background: rgba(71,85,105,0.3);  color: #94a3b8; }
+
+  .ap-repo-label {
+    font-size: 11px;
+    font-weight: 600;
+    color: rgba(255,255,255,0.5);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .ap-card-title {
+    font-size: 13px;
+    font-weight: 600;
+    color: #e8e8e8;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .ap-card-subtitle {
+    font-size: 12px;
+    color: rgba(255,255,255,0.45);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    margin-top: 1px;
+  }
+
+  .ap-card-meta {
+    font-size: 11px;
+    color: rgba(255,255,255,0.3);
+    margin-top: 4px;
+  }
+
+  .ap-expand-icon {
+    width: 32px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: rgba(255,255,255,0.2);
+    font-size: 10px;
+    flex-shrink: 0;
+  }
+
+  .ap-card-detail {
+    padding: 10px 12px 12px 16px;
+    background: rgba(255,255,255,0.03);
+    border-top: 1px solid rgba(255,255,255,0.05);
+    font-size: 12px;
+    color: rgba(255,255,255,0.5);
+    white-space: pre-line;
+    line-height: 1.5;
+  }
+
+  .ap-section-header {
+    padding: 8px 16px;
+    font-size: 10px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: rgba(255,255,255,0.25);
+    background: rgba(255,255,255,0.02);
+    border-top: 1px solid rgba(255,255,255,0.06);
+    border-bottom: 1px solid rgba(255,255,255,0.06);
+  }
+
+  .ap-healthy-toggle {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 14px 16px;
+    cursor: pointer;
+    border-bottom: 1px solid rgba(255,255,255,0.06);
+    user-select: none;
+    min-height: 44px;
+  }
+
+  .ap-healthy-toggle:active {
+    background: rgba(255,255,255,0.04);
+  }
+
+  .ap-healthy-label {
+    font-size: 13px;
+    color: rgba(255,255,255,0.4);
+  }
+
+  .ap-healthy-label strong {
+    color: #4ade80;
+  }
+
+  .ap-healthy-chevron {
+    font-size: 10px;
+    color: rgba(255,255,255,0.2);
+    transition: transform 0.15s ease;
+  }
+
+  .ap-healthy-list {
+    list-style: none;
+  }
+
+  .ap-healthy-repo {
+    display: flex;
+    align-items: center;
+    padding: 10px 16px;
+    border-bottom: 1px solid rgba(255,255,255,0.04);
+    gap: 8px;
+  }
+
+  .ap-healthy-dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: #4ade80;
+    flex-shrink: 0;
+  }
+
+  .ap-healthy-name {
+    font-size: 13px;
+    color: rgba(255,255,255,0.6);
+    flex: 1;
+  }
+
+  .ap-healthy-prs {
+    font-size: 11px;
+    color: rgba(255,255,255,0.3);
+  }
+
+  .ap-empty-state {
+    padding: 40px 24px;
+    text-align: center;
+    color: rgba(255,255,255,0.3);
+    font-size: 14px;
+  }
+
+  .ap-empty-icon {
+    font-size: 32px;
+    margin-bottom: 12px;
+  }
+
+  .ap-footer {
+    padding: 16px;
+    text-align: center;
+    font-size: 11px;
+    color: rgba(255,255,255,0.2);
+    line-height: 1.5;
+  }
+
+  .ap-warmup-note {
+    display: inline-block;
+    background: rgba(255,204,0,0.08);
+    border: 1px solid rgba(255,204,0,0.15);
+    color: rgba(255,204,0,0.6);
+    border-radius: 4px;
+    padding: 4px 8px;
+    font-size: 10px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+  }
+
+  .ap-no-alerts {
+    padding: 32px 24px;
+    text-align: center;
+  }
+
+  .ap-no-alerts-icon {
+    font-size: 28px;
+    margin-bottom: 8px;
+  }
+
+  .ap-no-alerts-text {
+    font-size: 14px;
+    color: #4ade80;
+    font-weight: 600;
+  }
+
+  .ap-no-alerts-sub {
+    font-size: 12px;
+    color: rgba(255,255,255,0.3);
+    margin-top: 4px;
+  }
+`;
+
+// ── Badge label mapping ───────────────────────────────────────────────────────
+
+const BADGE_LABEL: Record<AlertKind, string> = {
+  capture_failed: "Failed",
+  vuln_critical: "Critical",
+  stalled_pr: "Stalled",
+  vuln_high: "High",
+  scope_missing: "Scope",
+  capture_partial: "Partial",
+  vuln_moderate: "Moderate",
+  vuln_low: "Low",
+};
+
+// ── AlertCard component ───────────────────────────────────────────────────────
+
+interface AlertCardProps {
+  alert: Alert;
+  expanded: boolean;
+  onToggle: () => void;
+}
+
+function AlertCard({ alert, expanded, onToggle }: AlertCardProps) {
+  return (
+    <li className="ap-card" onClick={onToggle}>
+      <div className="ap-card-main">
+        <div className={`ap-card-stripe stripe-${alert.kind}`} />
+        <div className="ap-card-body">
+          <div className="ap-card-top">
+            <span className={`ap-badge badge-${alert.kind}`}>
+              {BADGE_LABEL[alert.kind]}
+            </span>
+            <span className="ap-repo-label">{alert.repo}</span>
+          </div>
+          <div className="ap-card-title">{alert.title}</div>
+          <div className="ap-card-subtitle">{alert.subtitle}</div>
+          {alert.meta && <div className="ap-card-meta">{alert.meta}</div>}
+        </div>
+        <div className="ap-expand-icon">{expanded ? "▲" : "▼"}</div>
+      </div>
+      {expanded && alert.detail && (
+        <div className="ap-card-detail">{alert.detail}</div>
+      )}
+    </li>
+  );
+}
+
+// ── Main component ────────────────────────────────────────────────────────────
+
+export default function AlertFirstDashboard({ data }: Props) {
+  const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set());
+  const [showHealthy, setShowHealthy] = useState(false);
+
+  const repos = data.repos as RepoSnapshot[];
+  const alerts = buildAlerts(repos);
+
+  const healthyRepos = repos.filter(
+    (r) =>
+      r.capture_status === "success" &&
+      (r.vulnerability_alerts === null || r.vulnerability_alerts.length === 0) &&
+      r.prs.every((pr) => !pr.stalled || pr.is_dependabot || pr.is_renovate)
+  );
+
+  const toggleAlert = (id: string) => {
+    setExpandedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  };
+
+  return (
+    <>
+      <style>{css}</style>
+      <div className="ap-root">
+        {/* Header */}
+        <div className="ap-header">
+          <div className="ap-header-row">
+            <span className="ap-title">Org Pulse</span>
+            <span className="ap-timestamp">{data.captured_at_et}</span>
+            {alerts.length > 0 && (
+              <span className="ap-alert-count">{alerts.length} alerts</span>
+            )}
+          </div>
+        </div>
+
+        {/* Alert list */}
+        {alerts.length === 0 ? (
+          <div className="ap-no-alerts">
+            <div className="ap-no-alerts-icon">✓</div>
+            <div className="ap-no-alerts-text">All systems healthy</div>
+            <div className="ap-no-alerts-sub">No alerts at {data.captured_at_et}</div>
+          </div>
+        ) : (
+          <ul className="ap-list">
+            {alerts.map((alert) => (
+              <AlertCard
+                key={alert.id}
+                alert={alert}
+                expanded={expandedIds.has(alert.id)}
+                onToggle={() => toggleAlert(alert.id)}
+              />
+            ))}
+          </ul>
+        )}
+
+        {/* Healthy repos section */}
+        {healthyRepos.length > 0 && (
+          <>
+            <div
+              className="ap-healthy-toggle"
+              onClick={() => setShowHealthy((v) => !v)}
+            >
+              <span className="ap-healthy-label">
+                <strong>{healthyRepos.length}</strong> repo{healthyRepos.length !== 1 ? "s" : ""} healthy
+                {!showHealthy && " — show"}
+              </span>
+              <span
+                className="ap-healthy-chevron"
+                style={{ transform: showHealthy ? "rotate(180deg)" : undefined }}
+              >
+                ▼
+              </span>
+            </div>
+            {showHealthy && (
+              <ul className="ap-healthy-list">
+                {healthyRepos.map((repo) => (
+                  <li key={`${repo.org}/${repo.name}`} className="ap-healthy-repo">
+                    <div className="ap-healthy-dot" />
+                    <span className="ap-healthy-name">{repo.name}</span>
+                    <span className="ap-healthy-prs">
+                      {repo.prs.length > 0
+                        ? `${repo.prs.length} PR${repo.prs.length !== 1 ? "s" : ""}`
+                        : "no PRs"}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </>
+        )}
+
+        {/* Footer */}
+        <div className="ap-footer">
+          {data.warm_up_active && (
+            <>
+              <span className="ap-warmup-note">
+                Warm-up — trend data available {data.warm_up_fill_date}
+              </span>
+              <br />
+              <br />
+            </>
+          )}
+          Snapshot {data.snapshot_id} · {data.repos_succeeded}✓{" "}
+          {data.repos_partial}~ {data.repos_failed}✗ repos ·{" "}
+          {(data.duration_ms / 1000).toFixed(1)}s
+        </div>
+      </div>
+    </>
+  );
+}

--- a/apps/web/src/components/pulse/MinimalistDashboard.tsx
+++ b/apps/web/src/components/pulse/MinimalistDashboard.tsx
@@ -1,0 +1,601 @@
+import { useState, ReactNode } from "react";
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+interface VulnAlert {
+  severity: "CRITICAL" | "HIGH" | "MODERATE" | "LOW";
+  ghsa_id: string;
+  package_name: string;
+  ecosystem: string;
+  age_days: number;
+  dependabot_pr_number: number | null;
+}
+
+interface PR {
+  number: number;
+  title: string;
+  author: string;
+  is_draft: boolean;
+  is_dependabot: boolean;
+  is_renovate: boolean;
+  stalled: boolean;
+  hours_idle: number;
+  updated_at: string;
+}
+
+interface Issue {
+  number: number;
+  title: string;
+  labels: string[];
+  stalled: boolean;
+  hours_idle: number;
+}
+
+interface Release {
+  tag_name: string;
+  name: string;
+  is_prerelease: boolean;
+  created_at: string;
+}
+
+interface FieldStatus {
+  status: "success" | "failed" | "partial" | "scope_missing";
+  error_note: string | null;
+}
+
+interface RepoSnapshot {
+  org: string;
+  name: string;
+  is_fork: boolean;
+  is_archived: boolean;
+  capture_status: "success" | "partial" | "failed";
+  field_statuses: Record<string, FieldStatus>;
+  upstream: { status: string; commits_behind: number; commits_ahead: number } | null;
+  vulnerability_alerts: VulnAlert[] | null;
+  prs: PR[];
+  issues: Issue[];
+  releases: Release[];
+}
+
+interface ReviewerActivity {
+  total: number;
+  approved: number;
+  change_requested: number;
+  commented: number;
+  dismissed: number;
+}
+
+export interface PulseSnapshot {
+  snapshot_id: string;
+  captured_at_et: string;
+  capture_status: string;
+  duration_ms: number;
+  repos_succeeded: number;
+  repos_failed: number;
+  repos_partial: number;
+  warm_up_active: boolean;
+  warm_up_fill_date: string | null;
+  reviewer_activity_7d: Record<string, ReviewerActivity>;
+  repos: RepoSnapshot[];
+}
+
+interface Props {
+  data: PulseSnapshot;
+}
+
+// ── Color helpers ──────────────────────────────────────────────────────────
+
+const C = {
+  red: "#f87171",
+  yellow: "#fbbf24",
+  green: "#4ade80",
+  dim: "#6b7280",
+  fg: "#e5e7eb",
+  fg2: "#9ca3af",
+  bg: "#0f1117",
+  bgRow: "#161b22",
+  bgExpanded: "#0d1117",
+  border: "#21262d",
+} as const;
+
+function captureColor(status: string): string {
+  if (status === "success") return C.green;
+  if (status === "partial") return C.yellow;
+  return C.red;
+}
+
+function captureLabel(status: string): string {
+  if (status === "success") return "OK  ";
+  if (status === "partial") return "PART";
+  return "FAIL";
+}
+
+function sevColor(sev: string): string {
+  if (sev === "CRITICAL") return C.red;
+  if (sev === "HIGH") return C.yellow;
+  if (sev === "MODERATE") return C.fg2;
+  return C.dim;
+}
+
+// ── Sub-components ─────────────────────────────────────────────────────────
+
+function VulnSummary({ alerts }: { alerts: VulnAlert[] | null }) {
+  if (alerts === null) {
+    return <span style={{ color: C.yellow, fontStyle: "italic" }}>scope?</span>;
+  }
+  if (alerts.length === 0) {
+    return <span style={{ color: C.dim }}>0 vulns</span>;
+  }
+  const counts: Record<string, number> = {};
+  for (const a of alerts) counts[a.severity] = (counts[a.severity] ?? 0) + 1;
+  const parts: ReactNode[] = [];
+  const order = ["CRITICAL", "HIGH", "MODERATE", "LOW"] as const;
+  for (const sev of order) {
+    if (counts[sev]) {
+      parts.push(
+        <span key={sev} style={{ color: sevColor(sev) }}>
+          {sev[0]}{counts[sev]}
+        </span>
+      );
+    }
+  }
+  return <>{parts.map((p, i) => <span key={i}>{p}{i < parts.length - 1 ? " " : ""}</span>)}</>;
+}
+
+function PRLine({ pr }: { pr: PR }) {
+  const badges: ReactNode[] = [];
+  if (pr.is_draft) badges.push(<span key="draft" style={{ color: C.dim }}>[DRAFT]</span>);
+  if (pr.stalled) badges.push(<span key="stall" style={{ color: C.red }}>[STALLED {pr.hours_idle}h]</span>);
+  if (pr.is_dependabot || pr.is_renovate) {
+    badges.push(<span key="bot" style={{ color: C.dim }}>[bot]</span>);
+  }
+
+  const titleColor = pr.is_dependabot || pr.is_renovate ? C.dim : pr.stalled ? C.red : C.fg;
+  const titleTrunc = pr.title.length > 38 ? pr.title.slice(0, 35) + "…" : pr.title;
+
+  return (
+    <div style={{ display: "flex", gap: 6, alignItems: "baseline", paddingLeft: 12, paddingTop: 2 }}>
+      <span style={{ color: C.dim, minWidth: 28, textAlign: "right" }}>#{pr.number}</span>
+      <span style={{ color: titleColor, flex: 1, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+        {titleTrunc}
+      </span>
+      <span style={{ color: C.dim, whiteSpace: "nowrap" }}>{pr.author}</span>
+      {badges.map((b, i) => <span key={i} style={{ whiteSpace: "nowrap" }}>{b}</span>)}
+    </div>
+  );
+}
+
+function IssueLine({ issue }: { issue: Issue }) {
+  const titleTrunc = issue.title.length > 44 ? issue.title.slice(0, 41) + "…" : issue.title;
+  return (
+    <div style={{ display: "flex", gap: 6, alignItems: "baseline", paddingLeft: 12, paddingTop: 2 }}>
+      <span style={{ color: C.dim, minWidth: 28, textAlign: "right" }}>#{issue.number}</span>
+      <span style={{ color: issue.stalled ? C.yellow : C.fg, flex: 1, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+        {titleTrunc}
+      </span>
+      {issue.stalled && (
+        <span style={{ color: C.yellow, whiteSpace: "nowrap" }}>[{issue.hours_idle}h idle]</span>
+      )}
+    </div>
+  );
+}
+
+function VulnLine({ v }: { v: VulnAlert }) {
+  return (
+    <div style={{ display: "flex", gap: 6, alignItems: "baseline", paddingLeft: 12, paddingTop: 2 }}>
+      <span style={{ color: sevColor(v.severity), minWidth: 48 }}>{v.severity.slice(0, 4)}</span>
+      <span style={{ color: C.fg }}>{v.package_name}</span>
+      <span style={{ color: C.dim }}>({v.ecosystem})</span>
+      <span style={{ color: C.dim }}>{v.age_days}d</span>
+      {v.dependabot_pr_number && (
+        <span style={{ color: C.dim }}>PR#{v.dependabot_pr_number}</span>
+      )}
+    </div>
+  );
+}
+
+function FieldStatusLines({ field_statuses }: { field_statuses: Record<string, FieldStatus> }) {
+  const problems = Object.entries(field_statuses).filter(
+    ([, v]) => v.status !== "success"
+  );
+  if (problems.length === 0) return null;
+  return (
+    <div style={{ paddingLeft: 12, paddingTop: 4 }}>
+      <div style={{ color: C.dim, fontSize: 10 }}>field errors:</div>
+      {problems.map(([field, fs]) => (
+        <div key={field} style={{ display: "flex", gap: 6, paddingLeft: 8, paddingTop: 1 }}>
+          <span style={{ color: fs.status === "scope_missing" ? C.yellow : C.red, minWidth: 80 }}>
+            {field}
+          </span>
+          <span style={{ color: C.dim, fontSize: 11 }}>
+            {fs.status === "scope_missing" ? "scope missing" : fs.error_note ?? fs.status}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function RepoRow({ repo }: { repo: RepoSnapshot }) {
+  const [expanded, setExpanded] = useState(false);
+
+  const stalledPRs = repo.prs.filter((p) => p.stalled && !p.is_dependabot && !p.is_renovate);
+  const humanPRs = repo.prs.filter((p) => !p.is_dependabot && !p.is_renovate);
+  const botPRs = repo.prs.filter((p) => p.is_dependabot || p.is_renovate);
+  const stalledIssues = repo.issues.filter((i) => i.stalled);
+  const latestRelease = repo.releases[0];
+
+  const nameDisplay = repo.name.length > 20 ? repo.name.slice(0, 18) + "…" : repo.name.padEnd(20);
+
+  const upstreamStr =
+    repo.is_fork && repo.upstream
+      ? ` ↓${repo.upstream.commits_behind}↑${repo.upstream.commits_ahead}`
+      : "";
+
+  const rowBg = repo.capture_status === "failed" ? "#1a0d0d" : expanded ? C.bgExpanded : C.bgRow;
+
+  return (
+    <div
+      style={{
+        backgroundColor: rowBg,
+        borderBottom: `1px solid ${C.border}`,
+        cursor: "pointer",
+        userSelect: "none",
+        WebkitUserSelect: "none",
+      }}
+    >
+      {/* Summary row */}
+      <div
+        onClick={() => setExpanded((e) => !e)}
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 8,
+          padding: "5px 8px",
+          fontFamily: "ui-monospace, 'Cascadia Code', 'Fira Code', monospace",
+          fontSize: 12,
+          lineHeight: 1.4,
+          whiteSpace: "nowrap",
+          overflowX: "hidden",
+        }}
+        role="button"
+        aria-expanded={expanded}
+      >
+        {/* Status */}
+        <span style={{ color: captureColor(repo.capture_status), minWidth: 32 }}>
+          {captureLabel(repo.capture_status)}
+        </span>
+
+        {/* Repo name */}
+        <span style={{ color: C.fg, flex: "0 0 152px", overflow: "hidden", textOverflow: "ellipsis" }}>
+          {nameDisplay}
+        </span>
+
+        {/* PR / stalled */}
+        <span style={{ color: stalledPRs.length > 0 ? C.red : C.fg2, minWidth: 36 }}>
+          PR:{humanPRs.length}{stalledPRs.length > 0 ? `!${stalledPRs.length}` : ""}
+        </span>
+
+        {/* Issues */}
+        <span style={{ color: stalledIssues.length > 0 ? C.yellow : C.dim, minWidth: 28 }}>
+          I:{repo.issues.length}
+        </span>
+
+        {/* Vulns */}
+        <span style={{ minWidth: 48 }}>
+          <VulnSummary alerts={repo.vulnerability_alerts} />
+        </span>
+
+        {/* Upstream drift */}
+        {repo.is_fork && repo.upstream && (
+          <span style={{ color: repo.upstream.commits_behind > 0 ? C.yellow : C.dim }}>
+            {upstreamStr}
+          </span>
+        )}
+
+        {/* Latest release */}
+        {latestRelease && (
+          <span style={{ color: C.dim, marginLeft: "auto" }}>{latestRelease.tag_name}</span>
+        )}
+
+        {/* Expand indicator */}
+        <span style={{ color: C.dim, marginLeft: 4 }}>{expanded ? "▾" : "▸"}</span>
+      </div>
+
+      {/* Expanded detail */}
+      {expanded && (
+        <div
+          style={{
+            fontFamily: "ui-monospace, 'Cascadia Code', 'Fira Code', monospace",
+            fontSize: 11,
+            lineHeight: 1.5,
+            paddingBottom: 8,
+            borderTop: `1px solid ${C.border}`,
+          }}
+        >
+          {/* FAILED repo — show error details only */}
+          {repo.capture_status === "failed" ? (
+            <div style={{ padding: "6px 12px", color: C.red }}>
+              FAILED — no data captured
+              <FieldStatusLines field_statuses={repo.field_statuses} />
+            </div>
+          ) : (
+            <>
+              {/* Field status errors for partial repos */}
+              {repo.capture_status === "partial" && (
+                <FieldStatusLines field_statuses={repo.field_statuses} />
+              )}
+
+              {/* PRs — human */}
+              {humanPRs.length > 0 && (
+                <div style={{ paddingTop: 6 }}>
+                  <div style={{ paddingLeft: 8, color: C.dim, fontSize: 10, letterSpacing: "0.05em" }}>
+                    PULL REQUESTS ({humanPRs.length})
+                  </div>
+                  {humanPRs.map((pr) => <PRLine key={pr.number} pr={pr} />)}
+                </div>
+              )}
+
+              {/* PRs — bots */}
+              {botPRs.length > 0 && (
+                <div style={{ paddingTop: 4 }}>
+                  <div style={{ paddingLeft: 8, color: C.dim, fontSize: 10 }}>
+                    BOT PRS ({botPRs.length})
+                  </div>
+                  {botPRs.map((pr) => <PRLine key={pr.number} pr={pr} />)}
+                </div>
+              )}
+
+              {/* Issues */}
+              {repo.issues.length > 0 && (
+                <div style={{ paddingTop: 6 }}>
+                  <div style={{ paddingLeft: 8, color: C.dim, fontSize: 10, letterSpacing: "0.05em" }}>
+                    ISSUES ({repo.issues.length})
+                  </div>
+                  {repo.issues.map((iss) => <IssueLine key={iss.number} issue={iss} />)}
+                </div>
+              )}
+
+              {/* Vulns */}
+              {repo.vulnerability_alerts === null ? (
+                <div style={{ paddingTop: 6, paddingLeft: 12, color: C.yellow, fontSize: 11 }}>
+                  vulns: scope missing — re-auth required
+                </div>
+              ) : repo.vulnerability_alerts.length > 0 ? (
+                <div style={{ paddingTop: 6 }}>
+                  <div style={{ paddingLeft: 8, color: C.dim, fontSize: 10, letterSpacing: "0.05em" }}>
+                    VULNERABILITIES ({repo.vulnerability_alerts.length})
+                  </div>
+                  {repo.vulnerability_alerts.map((v) => <VulnLine key={v.ghsa_id} v={v} />)}
+                </div>
+              ) : (
+                <div style={{ paddingTop: 6, paddingLeft: 12, color: C.dim, fontSize: 11 }}>
+                  vulns: 0
+                </div>
+              )}
+
+              {/* Upstream */}
+              {repo.is_fork && repo.upstream && (
+                <div style={{ paddingTop: 6, paddingLeft: 12, color: C.dim, fontSize: 11 }}>
+                  upstream:{" "}
+                  <span style={{ color: repo.upstream.commits_behind > 0 ? C.yellow : C.green }}>
+                    {repo.upstream.commits_behind} behind, {repo.upstream.commits_ahead} ahead
+                  </span>
+                </div>
+              )}
+
+              {/* Releases */}
+              {repo.releases.length > 0 && (
+                <div style={{ paddingTop: 4, paddingLeft: 12, color: C.dim, fontSize: 11 }}>
+                  latest:{" "}
+                  <span style={{ color: C.fg2 }}>{repo.releases[0].tag_name}</span>{" "}
+                  — {repo.releases[0].name}
+                </div>
+              )}
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ReviewerTable({
+  activity,
+}: {
+  activity: Record<string, ReviewerActivity>;
+}) {
+  const entries = Object.entries(activity);
+  const humans = entries.filter(([k]) => k.startsWith("human:"));
+  const bots = entries.filter(([k]) => !k.startsWith("human:"));
+  const sorted = (arr: typeof entries) =>
+    [...arr].sort(([, a], [, b]) => b.total - a.total);
+
+  const Row = ({ name, data }: { name: string; data: ReviewerActivity }) => {
+    const label = name.startsWith("human:") ? name.slice(6) : name;
+    const approvalPct = data.total > 0 ? Math.round((data.approved / data.total) * 100) : 0;
+    return (
+      <div
+        style={{
+          display: "flex",
+          gap: 8,
+          padding: "2px 8px",
+          fontFamily: "ui-monospace, 'Cascadia Code', 'Fira Code', monospace",
+          fontSize: 11,
+        }}
+      >
+        <span style={{ color: name.startsWith("human:") ? C.fg : C.dim, minWidth: 90 }}>
+          {label}
+        </span>
+        <span style={{ color: C.fg2, minWidth: 30, textAlign: "right" }}>{data.total}</span>
+        <span style={{ color: C.green, minWidth: 30, textAlign: "right" }}>✓{data.approved}</span>
+        <span style={{ color: data.change_requested > 0 ? C.red : C.dim, minWidth: 30, textAlign: "right" }}>
+          ✗{data.change_requested}
+        </span>
+        <span style={{ color: C.dim, minWidth: 30, textAlign: "right" }}>{approvalPct}%</span>
+      </div>
+    );
+  };
+
+  return (
+    <div style={{ marginBottom: 8 }}>
+      <div
+        style={{
+          display: "flex",
+          gap: 8,
+          padding: "2px 8px",
+          fontFamily: "ui-monospace, 'Cascadia Code', 'Fira Code', monospace",
+          fontSize: 10,
+          color: C.dim,
+          borderBottom: `1px solid ${C.border}`,
+          letterSpacing: "0.05em",
+        }}
+      >
+        <span style={{ minWidth: 90 }}>REVIEWER</span>
+        <span style={{ minWidth: 30, textAlign: "right" }}>TOT</span>
+        <span style={{ minWidth: 30, textAlign: "right" }}>APR</span>
+        <span style={{ minWidth: 30, textAlign: "right" }}>REQ</span>
+        <span style={{ minWidth: 30, textAlign: "right" }}>APR%</span>
+      </div>
+      {sorted(humans).map(([k, v]) => <Row key={k} name={k} data={v} />)}
+      <div style={{ borderBottom: `1px dashed ${C.border}`, margin: "2px 0" }} />
+      {sorted(bots).map(([k, v]) => <Row key={k} name={k} data={v} />)}
+    </div>
+  );
+}
+
+// ── Main component ─────────────────────────────────────────────────────────
+
+export default function MinimalistDashboard({ data }: Props) {
+  const globalStatusColor = captureColor(data.capture_status);
+  const totalRepos = data.repos_succeeded + data.repos_failed + data.repos_partial;
+
+  return (
+    <div
+      style={{
+        backgroundColor: C.bg,
+        minHeight: "100%",
+        paddingTop: "var(--tg-content-safe-area-inset-top, 0px)",
+        color: C.fg,
+        fontFamily: "ui-monospace, 'Cascadia Code', 'Fira Code', monospace",
+        fontSize: 12,
+        boxSizing: "border-box",
+        overflowX: "hidden",
+        maxWidth: "100%",
+      }}
+    >
+      {/* CSS reset baseline */}
+      <style>{`
+        *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+      `}</style>
+
+      {/* Warm-up banner */}
+      {data.warm_up_active && (
+        <div
+          style={{
+            backgroundColor: "#1c1a0a",
+            borderBottom: `1px solid ${C.yellow}`,
+            padding: "4px 8px",
+            color: C.yellow,
+            fontFamily: "ui-monospace, 'Cascadia Code', 'Fira Code', monospace",
+            fontSize: 11,
+          }}
+        >
+          WARM-UP — window fills {data.warm_up_fill_date ?? "unknown"} — no trend data yet
+        </div>
+      )}
+
+      {/* Header */}
+      <div
+        style={{
+          padding: "6px 8px",
+          borderBottom: `1px solid ${C.border}`,
+          display: "flex",
+          alignItems: "center",
+          gap: 10,
+          flexWrap: "wrap",
+        }}
+      >
+        <span style={{ color: globalStatusColor, fontWeight: "bold" }}>
+          ORG-PULSE
+        </span>
+        <span style={{ color: C.dim }}>
+          {data.captured_at_et}
+        </span>
+        <span style={{ color: globalStatusColor }}>
+          [{captureLabel(data.capture_status).trim()}]
+        </span>
+        <span style={{ color: C.dim, marginLeft: "auto" }}>
+          {totalRepos} repos — {data.repos_succeeded} ok{" "}
+          {data.repos_partial > 0 && (
+            <span style={{ color: C.yellow }}>{data.repos_partial} part </span>
+          )}
+          {data.repos_failed > 0 && (
+            <span style={{ color: C.red }}>{data.repos_failed} fail</span>
+          )}
+        </span>
+        <span style={{ color: C.dim }}>
+          {(data.duration_ms / 1000).toFixed(1)}s
+        </span>
+      </div>
+
+      {/* Reviewer activity */}
+      <div>
+        <div
+          style={{
+            padding: "4px 8px",
+            color: C.dim,
+            fontSize: 10,
+            letterSpacing: "0.08em",
+            borderBottom: `1px solid ${C.border}`,
+            backgroundColor: "#0d1117",
+          }}
+        >
+          REVIEWER ACTIVITY — 7 DAYS
+        </div>
+        <ReviewerTable activity={data.reviewer_activity_7d} />
+      </div>
+
+      {/* Repo list header */}
+      <div
+        style={{
+          display: "flex",
+          gap: 8,
+          padding: "3px 8px",
+          color: C.dim,
+          fontSize: 10,
+          letterSpacing: "0.05em",
+          backgroundColor: "#0d1117",
+          borderBottom: `1px solid ${C.border}`,
+          borderTop: `1px solid ${C.border}`,
+        }}
+      >
+        <span style={{ minWidth: 32 }}>STAT</span>
+        <span style={{ flex: "0 0 152px" }}>REPO</span>
+        <span style={{ minWidth: 36 }}>PRs</span>
+        <span style={{ minWidth: 28 }}>ISS</span>
+        <span style={{ minWidth: 48 }}>VULNS</span>
+      </div>
+
+      {/* Repos */}
+      <div>
+        {data.repos.map((repo) => (
+          <RepoRow key={`${repo.org}/${repo.name}`} repo={repo} />
+        ))}
+      </div>
+
+      {/* Footer */}
+      <div
+        style={{
+          padding: "6px 8px",
+          color: C.dim,
+          fontSize: 10,
+          borderTop: `1px solid ${C.border}`,
+          marginTop: 8,
+        }}
+      >
+        snap {data.snapshot_id} — tap row to expand
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/pulse/PulseDashboardPage.tsx
+++ b/apps/web/src/components/pulse/PulseDashboardPage.tsx
@@ -1,0 +1,126 @@
+import { useState, useEffect, Suspense, lazy, ComponentType } from "react";
+import { getAuthHeaders } from "../../lib/telegram";
+import type { PulseSnapshot } from "./MinimalistDashboard";
+import MinimalistDashboard from "./MinimalistDashboard";
+import TabularDashboard from "./TabularDashboard";
+import AlertFirstDashboard from "./AlertFirstDashboard";
+
+// Lazy-load VisualChartDashboard (imports recharts, ~50kB)
+const VisualChartDashboard = lazy(() => import("./VisualChartDashboard"));
+
+export type DashboardId = "minimalist" | "visual-chart" | "tabular" | "alert-first";
+
+interface Props {
+  dashboardId: DashboardId;
+}
+
+function LoadingSkeletonInner() {
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: 8,
+        padding: 16,
+        background: "#0f1117",
+        minHeight: "100%",
+      }}
+    >
+      {[80, 60, 90, 50, 70].map((w, i) => (
+        <div
+          key={i}
+          style={{
+            height: 16,
+            borderRadius: 4,
+            background: "#1f2937",
+            width: `${w}%`,
+            opacity: 0.6,
+          }}
+        />
+      ))}
+    </div>
+  );
+}
+
+function ErrorState({ message }: { message: string }) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+        minHeight: "60%",
+        padding: 24,
+        color: "#9ca3af",
+        fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
+        fontSize: 13,
+        textAlign: "center",
+        gap: 8,
+      }}
+    >
+      <div style={{ fontSize: 24 }}>⚠</div>
+      <div style={{ color: "#f87171", fontWeight: 600 }}>Pulse snapshot unavailable</div>
+      <div style={{ color: "#6b7280", fontSize: 12 }}>{message}</div>
+    </div>
+  );
+}
+
+function resolveDashboard(id: DashboardId): ComponentType<{ data: PulseSnapshot }> | null {
+  switch (id) {
+    case "minimalist": return MinimalistDashboard;
+    case "tabular": return TabularDashboard;
+    case "alert-first": return AlertFirstDashboard;
+    default: return null; // visual-chart handled via Suspense/lazy
+  }
+}
+
+export default function PulseDashboardPage({ dashboardId }: Props) {
+  const [snapshot, setSnapshot] = useState<PulseSnapshot | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+
+    fetch("/api/pulse/current", { headers: getAuthHeaders() })
+      .then(async (res) => {
+        if (!res.ok) {
+          const body = await res.json().catch(() => ({}));
+          throw new Error((body as { error?: string }).error ?? `HTTP ${res.status}`);
+        }
+        return res.json() as Promise<PulseSnapshot>;
+      })
+      .then((data) => {
+        if (!cancelled) {
+          setSnapshot(data);
+          setLoading(false);
+        }
+      })
+      .catch((err: Error) => {
+        if (!cancelled) {
+          setError(err.message);
+          setLoading(false);
+        }
+      });
+
+    return () => { cancelled = true; };
+  }, []);
+
+  if (loading) return <LoadingSkeletonInner />;
+  if (error || !snapshot) return <ErrorState message={error ?? "No snapshot data"} />;
+
+  if (dashboardId === "visual-chart") {
+    return (
+      <Suspense fallback={<LoadingSkeletonInner />}>
+        <VisualChartDashboard data={snapshot} />
+      </Suspense>
+    );
+  }
+
+  const Dashboard = resolveDashboard(dashboardId);
+  if (!Dashboard) return <ErrorState message={`Unknown dashboard: ${dashboardId}`} />;
+  return <Dashboard data={snapshot} />;
+}

--- a/apps/web/src/components/pulse/PulseLabPage.tsx
+++ b/apps/web/src/components/pulse/PulseLabPage.tsx
@@ -1,0 +1,159 @@
+import { useState } from "react";
+import PulseDashboardPage, { type DashboardId } from "./PulseDashboardPage";
+
+interface DashboardMeta {
+  id: DashboardId;
+  name: string;
+  description: string;
+}
+
+const DASHBOARDS: DashboardMeta[] = [
+  {
+    id: "minimalist",
+    name: "Minimalist Text",
+    description: "Terminal-first triage surface. Dense monospace rows, color-coded by severity.",
+  },
+  {
+    id: "visual-chart",
+    name: "Visual Chart",
+    description: "Leads with donut + bar charts for instant org health at a glance.",
+  },
+  {
+    id: "tabular",
+    name: "Tabular Terminal",
+    description: "Sortable table with filter bar. Every metric a first-class column.",
+  },
+  {
+    id: "alert-first",
+    name: "Alert First",
+    description: "Inverted hierarchy — highest-priority alerts at pixel zero, no summary.",
+  },
+];
+
+export default function PulseLabPage() {
+  const [activeDashboard, setActiveDashboard] = useState<DashboardId | null>(null);
+
+  if (activeDashboard) {
+    return (
+      <div style={{ height: "100%", display: "flex", flexDirection: "column" }}>
+        {/* Back header */}
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 10,
+            padding: "8px 14px",
+            borderBottom: "1px solid #1f2937",
+            background: "#0f1117",
+            flexShrink: 0,
+          }}
+        >
+          <button
+            onClick={() => setActiveDashboard(null)}
+            style={{
+              background: "none",
+              border: "none",
+              color: "#60a5fa",
+              fontSize: 13,
+              cursor: "pointer",
+              padding: "4px 0",
+              display: "flex",
+              alignItems: "center",
+              gap: 4,
+            }}
+          >
+            ← Back
+          </button>
+          <span style={{ color: "#9ca3af", fontSize: 12 }}>
+            {DASHBOARDS.find((d) => d.id === activeDashboard)?.name}
+          </span>
+        </div>
+        {/* Dashboard fills remaining height */}
+        <div style={{ flex: 1, minHeight: 0, overflowY: "auto" }}>
+          <PulseDashboardPage dashboardId={activeDashboard} />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      style={{
+        height: "100%",
+        overflowY: "auto",
+        background: "#0f1117",
+        color: "#e5e7eb",
+        fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
+        boxSizing: "border-box",
+        maxWidth: "100%",
+      }}
+    >
+      {/* Header */}
+      <div
+        style={{
+          padding: "16px 16px 12px",
+          borderBottom: "1px solid #1f2937",
+        }}
+      >
+        <div style={{ fontSize: 16, fontWeight: 700, color: "#f3f4f6" }}>
+          Dashboard Lab
+        </div>
+        <div style={{ fontSize: 12, color: "#6b7280", marginTop: 4 }}>
+          4 design concepts for Org Pulse v2. Tap a card to preview.
+        </div>
+      </div>
+
+      {/* Cards */}
+      <div style={{ padding: "12px 12px 32px" }}>
+        {DASHBOARDS.map((d, i) => (
+          <button
+            key={d.id}
+            onClick={() => setActiveDashboard(d.id)}
+            style={{
+              width: "100%",
+              background: "#111827",
+              border: "1px solid #1f2937",
+              borderRadius: 10,
+              padding: "14px 16px",
+              marginBottom: 10,
+              cursor: "pointer",
+              textAlign: "left",
+              display: "flex",
+              alignItems: "center",
+              gap: 12,
+              minHeight: 64,
+            }}
+          >
+            <div
+              style={{
+                width: 32,
+                height: 32,
+                borderRadius: 8,
+                background: "#1f2937",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                fontSize: 13,
+                fontWeight: 700,
+                color: "#60a5fa",
+                flexShrink: 0,
+                fontFamily: "monospace",
+              }}
+            >
+              {i + 1}
+            </div>
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <div style={{ fontSize: 14, fontWeight: 600, color: "#f3f4f6", marginBottom: 3 }}>
+                {d.name}
+              </div>
+              <div style={{ fontSize: 12, color: "#6b7280", lineHeight: 1.4 }}>
+                {d.description}
+              </div>
+            </div>
+            <span style={{ color: "#374151", fontSize: 16, flexShrink: 0 }}>›</span>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/pulse/TabularDashboard.tsx
+++ b/apps/web/src/components/pulse/TabularDashboard.tsx
@@ -368,6 +368,7 @@ function ColHeader({
   onSort,
   align = "right",
   title,
+  sticky = false,
 }: {
   label: string;
   sortKey: SortKey;
@@ -376,6 +377,7 @@ function ColHeader({
   onSort: (k: SortKey) => void;
   align?: "left" | "right";
   title?: string;
+  sticky?: boolean;
 }) {
   const active = currentKey === sortKey;
   return (
@@ -396,6 +398,7 @@ function ColHeader({
         minHeight: 44,
         verticalAlign: "bottom",
         background: "#0d0d0d",
+        ...(sticky ? { position: "sticky", left: 0, zIndex: 2, borderRight: "1px solid #1e1e1e" } : {}),
       }}
     >
       {label}
@@ -591,6 +594,7 @@ export default function TabularDashboard({ data }: Props) {
                 currentDir={sortDir}
                 onSort={handleSort}
                 align="left"
+                sticky
               />
               <ColHeader
                 label="STATUS"

--- a/apps/web/src/components/pulse/TabularDashboard.tsx
+++ b/apps/web/src/components/pulse/TabularDashboard.tsx
@@ -1,0 +1,828 @@
+import { useState, useMemo, Fragment } from "react";
+import type { PulseSnapshot } from "./MinimalistDashboard";
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+interface VulnAlert {
+  severity: "CRITICAL" | "HIGH" | "MODERATE" | "LOW";
+  ghsa_id: string;
+  package_name: string;
+  ecosystem: string;
+  age_days: number;
+  dependabot_pr_number: number | null;
+}
+
+interface PR {
+  number: number;
+  title: string;
+  author: string;
+  is_draft: boolean;
+  is_dependabot: boolean;
+  is_renovate: boolean;
+  stalled: boolean;
+  hours_idle: number;
+  updated_at: string;
+}
+
+interface Issue {
+  number: number;
+  title: string;
+  labels: string[];
+  stalled: boolean;
+  hours_idle: number;
+}
+
+interface RepoSnapshot {
+  org: string;
+  name: string;
+  is_fork: boolean;
+  is_archived: boolean;
+  capture_status: "success" | "partial" | "failed";
+  field_statuses: Record<string, { status: string; error_note: string | null }>;
+  upstream: { status: string; commits_behind: number; commits_ahead: number } | null;
+  vulnerability_alerts: VulnAlert[] | null;
+  prs: PR[];
+  issues: Issue[];
+  releases: { tag_name: string; name: string; is_prerelease: boolean; created_at: string }[];
+}
+
+type SortKey =
+  | "name"
+  | "capture_status"
+  | "open_prs"
+  | "stalled_prs"
+  | "crit"
+  | "high"
+  | "mod"
+  | "low"
+  | "oldest_idle";
+type SortDir = "asc" | "desc";
+type StatusFilter = "ALL" | "success" | "partial" | "failed";
+
+interface Props {
+  data: PulseSnapshot;
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function vulnCount(alerts: VulnAlert[] | null, severity: string): string {
+  if (alerts === null) return "scope?";
+  return String(alerts.filter((a) => a.severity === severity).length);
+}
+
+function oldestIdleHours(prs: PR[]): number | null {
+  if (prs.length === 0) return null;
+  return Math.max(...prs.map((p) => p.hours_idle));
+}
+
+function captureStatusOrder(s: "success" | "partial" | "failed"): number {
+  return s === "failed" ? 0 : s === "partial" ? 1 : 2;
+}
+
+function sortableValue(repo: RepoSnapshot, key: SortKey): number | string {
+  switch (key) {
+    case "name":
+      return repo.name;
+    case "capture_status":
+      return captureStatusOrder(repo.capture_status);
+    case "open_prs":
+      return repo.prs.length;
+    case "stalled_prs":
+      return repo.prs.filter((p) => p.stalled).length;
+    case "crit":
+      return repo.vulnerability_alerts === null
+        ? -1
+        : repo.vulnerability_alerts.filter((v) => v.severity === "CRITICAL").length;
+    case "high":
+      return repo.vulnerability_alerts === null
+        ? -1
+        : repo.vulnerability_alerts.filter((v) => v.severity === "HIGH").length;
+    case "mod":
+      return repo.vulnerability_alerts === null
+        ? -1
+        : repo.vulnerability_alerts.filter((v) => v.severity === "MODERATE").length;
+    case "low":
+      return repo.vulnerability_alerts === null
+        ? -1
+        : repo.vulnerability_alerts.filter((v) => v.severity === "LOW").length;
+    case "oldest_idle":
+      return oldestIdleHours(repo.prs) ?? -1;
+    default:
+      return 0;
+  }
+}
+
+function compareRepos(a: RepoSnapshot, b: RepoSnapshot, key: SortKey, dir: SortDir): number {
+  const av = sortableValue(a, key);
+  const bv = sortableValue(b, key);
+  let cmp = 0;
+  if (typeof av === "string" && typeof bv === "string") {
+    cmp = av.localeCompare(bv);
+  } else {
+    cmp = (av as number) - (bv as number);
+  }
+  return dir === "asc" ? cmp : -cmp;
+}
+
+// ── Sub-components ────────────────────────────────────────────────────────────
+
+function StatusBadge({ status }: { status: "success" | "partial" | "failed" | string }) {
+  const map: Record<string, { label: string; bg: string; color: string }> = {
+    success: { label: "OK", bg: "#1a3a1a", color: "#4caf50" },
+    partial: { label: "PARTIAL", bg: "#3a2e00", color: "#ffc107" },
+    failed: { label: "FAILED", bg: "#3a0a0a", color: "#f44336" },
+  };
+  const cfg = map[status] ?? { label: status.toUpperCase(), bg: "#222", color: "#aaa" };
+  return (
+    <span
+      style={{
+        background: cfg.bg,
+        color: cfg.color,
+        borderRadius: 3,
+        padding: "1px 5px",
+        fontSize: 10,
+        fontFamily: "monospace",
+        fontWeight: 700,
+        letterSpacing: "0.04em",
+        border: `1px solid ${cfg.color}44`,
+      }}
+    >
+      {cfg.label}
+    </span>
+  );
+}
+
+function VulnCell({ alerts, severity }: { alerts: VulnAlert[] | null; severity: string }) {
+  const val = vulnCount(alerts, severity);
+  const isScope = val === "scope?";
+  const num = parseInt(val, 10);
+  const isCrit = severity === "CRITICAL" && num > 0;
+  const isHigh = severity === "HIGH" && num > 0;
+  return (
+    <span
+      style={{
+        color: isScope ? "#888" : isCrit ? "#f44336" : isHigh ? "#ffc107" : num > 0 ? "#ff9800" : "#555",
+        fontStyle: isScope ? "italic" : "normal",
+        fontFamily: "monospace",
+        fontSize: 12,
+      }}
+    >
+      {val}
+    </span>
+  );
+}
+
+function PRRow({ pr }: { pr: PR }) {
+  const idle =
+    pr.hours_idle >= 24
+      ? `${Math.floor(pr.hours_idle / 24)}d`
+      : `${pr.hours_idle}h`;
+  return (
+    <div
+      style={{
+        display: "flex",
+        gap: 6,
+        alignItems: "baseline",
+        padding: "3px 0",
+        borderBottom: "1px solid #1e1e1e",
+        fontSize: 11,
+      }}
+    >
+      <span style={{ color: "#666", minWidth: 28, fontFamily: "monospace" }}>#{pr.number}</span>
+      <span style={{ flex: 1, color: pr.stalled ? "#f44336" : "#ccc", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+        {pr.is_draft && <span style={{ color: "#888", marginRight: 4 }}>[DRAFT]</span>}
+        {(pr.is_dependabot || pr.is_renovate) && (
+          <span style={{ color: "#7986cb", marginRight: 4 }}>[bot]</span>
+        )}
+        {pr.title}
+      </span>
+      <span
+        style={{
+          minWidth: 32,
+          textAlign: "right",
+          fontFamily: "monospace",
+          color: pr.stalled ? "#f44336" : pr.hours_idle > 24 ? "#ffc107" : "#888",
+        }}
+      >
+        {idle}
+      </span>
+      {pr.stalled && (
+        <span style={{ color: "#f44336", fontSize: 10, fontFamily: "monospace" }}>STALL</span>
+      )}
+    </div>
+  );
+}
+
+function IssueRow({ issue }: { issue: Issue }) {
+  const idle =
+    issue.hours_idle >= 24
+      ? `${Math.floor(issue.hours_idle / 24)}d`
+      : `${issue.hours_idle}h`;
+  return (
+    <div
+      style={{
+        display: "flex",
+        gap: 6,
+        alignItems: "baseline",
+        padding: "3px 0",
+        borderBottom: "1px solid #1e1e1e",
+        fontSize: 11,
+      }}
+    >
+      <span style={{ color: "#666", minWidth: 28, fontFamily: "monospace" }}>#{issue.number}</span>
+      <span style={{ flex: 1, color: issue.stalled ? "#ffc107" : "#ccc", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+        {issue.title}
+      </span>
+      <span style={{ color: "#888", minWidth: 32, textAlign: "right", fontFamily: "monospace" }}>{idle}</span>
+      {issue.stalled && (
+        <span style={{ color: "#ffc107", fontSize: 10, fontFamily: "monospace" }}>STALL</span>
+      )}
+    </div>
+  );
+}
+
+function VulnRow({ alert }: { alert: VulnAlert }) {
+  const sevColor: Record<string, string> = {
+    CRITICAL: "#f44336",
+    HIGH: "#ff9800",
+    MODERATE: "#ffc107",
+    LOW: "#8bc34a",
+  };
+  return (
+    <div
+      style={{
+        display: "flex",
+        gap: 6,
+        alignItems: "baseline",
+        padding: "3px 0",
+        borderBottom: "1px solid #1e1e1e",
+        fontSize: 11,
+      }}
+    >
+      <span
+        style={{
+          minWidth: 60,
+          color: sevColor[alert.severity] ?? "#aaa",
+          fontFamily: "monospace",
+          fontWeight: 700,
+          fontSize: 10,
+        }}
+      >
+        {alert.severity.slice(0, 4)}
+      </span>
+      <span style={{ flex: 1, color: "#ccc", fontFamily: "monospace" }}>
+        {alert.package_name}
+      </span>
+      <span style={{ color: "#888", fontSize: 10, minWidth: 32, textAlign: "right" }}>
+        {alert.age_days}d
+      </span>
+      {alert.dependabot_pr_number !== null && (
+        <span style={{ color: "#7986cb", fontSize: 10, fontFamily: "monospace" }}>
+          #{alert.dependabot_pr_number}
+        </span>
+      )}
+    </div>
+  );
+}
+
+function RepoDetail({ repo }: { repo: RepoSnapshot }) {
+  const hasPRs = repo.prs.length > 0;
+  const hasIssues = repo.issues.length > 0;
+  const hasVulns = repo.vulnerability_alerts !== null && repo.vulnerability_alerts.length > 0;
+  const vulnsNull = repo.vulnerability_alerts === null;
+
+  return (
+    <tr>
+      <td
+        colSpan={9}
+        style={{
+          background: "#111",
+          padding: "8px 8px 8px 16px",
+          borderBottom: "1px solid #333",
+        }}
+      >
+        {repo.capture_status === "failed" && (
+          <div style={{ color: "#f44336", fontFamily: "monospace", fontSize: 11, marginBottom: 6 }}>
+            CAPTURE FAILED — data unavailable. Check field_statuses for error details.
+          </div>
+        )}
+
+        {/* PRs */}
+        <div style={{ marginBottom: hasPRs ? 8 : 0 }}>
+          <div style={{ color: "#666", fontSize: 10, fontFamily: "monospace", marginBottom: 3, textTransform: "uppercase", letterSpacing: "0.08em" }}>
+            Pull Requests ({repo.prs.length})
+          </div>
+          {hasPRs ? (
+            repo.prs.map((pr) => <PRRow key={pr.number} pr={pr} />)
+          ) : (
+            <div style={{ color: "#444", fontSize: 11 }}>none</div>
+          )}
+        </div>
+
+        {/* Issues */}
+        <div style={{ marginBottom: hasIssues ? 8 : 0, marginTop: 8 }}>
+          <div style={{ color: "#666", fontSize: 10, fontFamily: "monospace", marginBottom: 3, textTransform: "uppercase", letterSpacing: "0.08em" }}>
+            Issues ({repo.issues.length})
+          </div>
+          {hasIssues ? (
+            repo.issues.map((issue) => <IssueRow key={issue.number} issue={issue} />)
+          ) : (
+            <div style={{ color: "#444", fontSize: 11 }}>none</div>
+          )}
+        </div>
+
+        {/* Vulns */}
+        <div style={{ marginTop: 8 }}>
+          <div style={{ color: "#666", fontSize: 10, fontFamily: "monospace", marginBottom: 3, textTransform: "uppercase", letterSpacing: "0.08em" }}>
+            Vulnerabilities{vulnsNull ? " (scope missing)" : ` (${repo.vulnerability_alerts!.length})`}
+          </div>
+          {vulnsNull ? (
+            <div style={{ color: "#888", fontSize: 11, fontStyle: "italic" }}>
+              scope? — security_events scope missing; re-auth required
+            </div>
+          ) : hasVulns ? (
+            repo.vulnerability_alerts!.map((v) => <VulnRow key={v.ghsa_id} alert={v} />)
+          ) : (
+            <div style={{ color: "#4caf50", fontSize: 11 }}>no vulnerabilities</div>
+          )}
+        </div>
+
+        {/* Upstream drift */}
+        {repo.is_fork && repo.upstream && (
+          <div style={{ marginTop: 8, color: "#888", fontSize: 11, fontFamily: "monospace" }}>
+            upstream: {repo.upstream.commits_behind}↓ {repo.upstream.commits_ahead}↑
+          </div>
+        )}
+      </td>
+    </tr>
+  );
+}
+
+// ── Column header with sort indicator ────────────────────────────────────────
+
+function ColHeader({
+  label,
+  sortKey,
+  currentKey,
+  currentDir,
+  onSort,
+  align = "right",
+  title,
+}: {
+  label: string;
+  sortKey: SortKey;
+  currentKey: SortKey;
+  currentDir: SortDir;
+  onSort: (k: SortKey) => void;
+  align?: "left" | "right";
+  title?: string;
+}) {
+  const active = currentKey === sortKey;
+  return (
+    <th
+      onClick={() => onSort(sortKey)}
+      title={title}
+      style={{
+        cursor: "pointer",
+        userSelect: "none",
+        padding: "10px 8px",
+        textAlign: align,
+        whiteSpace: "nowrap",
+        color: active ? "#90caf9" : "#888",
+        fontSize: 11,
+        fontFamily: "monospace",
+        fontWeight: active ? 700 : 500,
+        borderBottom: "2px solid #333",
+        minHeight: 44,
+        verticalAlign: "bottom",
+        background: "#0d0d0d",
+      }}
+    >
+      {label}
+      {active && (
+        <span style={{ marginLeft: 3, fontSize: 9 }}>
+          {currentDir === "asc" ? "▲" : "▼"}
+        </span>
+      )}
+    </th>
+  );
+}
+
+// ── Main Component ────────────────────────────────────────────────────────────
+
+export default function TabularDashboard({ data }: Props) {
+  const repos = data.repos as RepoSnapshot[];
+
+  const [sortKey, setSortKey] = useState<SortKey>("capture_status");
+  const [sortDir, setSortDir] = useState<SortDir>("asc");
+  const [nameFilter, setNameFilter] = useState("");
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>("ALL");
+  const [expandedRepo, setExpandedRepo] = useState<string | null>(null);
+
+  function handleSort(key: SortKey) {
+    if (key === sortKey) {
+      setSortDir((d) => (d === "asc" ? "desc" : "asc"));
+    } else {
+      setSortKey(key);
+      setSortDir("asc");
+    }
+  }
+
+  function handleRowClick(name: string) {
+    setExpandedRepo((prev) => (prev === name ? null : name));
+  }
+
+  const filtered = useMemo(() => {
+    return repos
+      .filter((r) => {
+        const nameMatch = r.name.toLowerCase().includes(nameFilter.toLowerCase());
+        const statusMatch = statusFilter === "ALL" || r.capture_status === statusFilter;
+        return nameMatch && statusMatch;
+      })
+      .sort((a, b) => compareRepos(a, b, sortKey, sortDir));
+  }, [repos, nameFilter, statusFilter, sortKey, sortDir]);
+
+  const statusPills: StatusFilter[] = ["ALL", "success", "partial", "failed"];
+  const pillLabel: Record<StatusFilter, string> = {
+    ALL: "ALL",
+    success: "OK",
+    partial: "PARTIAL",
+    failed: "FAILED",
+  };
+  const pillColor: Record<StatusFilter, string> = {
+    ALL: "#90caf9",
+    success: "#4caf50",
+    partial: "#ffc107",
+    failed: "#f44336",
+  };
+
+  return (
+    <div
+      style={{
+        margin: 0,
+        padding: 0,
+        background: "#0a0a0a",
+        color: "#ccc",
+        minHeight: "100%",
+        fontFamily: "monospace",
+        paddingTop: "var(--tg-content-safe-area-inset-top, 0px)",
+        boxSizing: "border-box",
+        maxWidth: "100%",
+        overflowX: "hidden",
+      }}
+    >
+      {/* Warm-up banner */}
+      {data.warm_up_active && (
+        <div
+          style={{
+            background: "#2a2000",
+            borderBottom: "1px solid #ffc107",
+            color: "#ffc107",
+            fontSize: 11,
+            padding: "6px 12px",
+            fontFamily: "monospace",
+          }}
+        >
+          ⚠ WARM-UP MODE — trend data unavailable until {data.warm_up_fill_date ?? "?"}
+        </div>
+      )}
+
+      {/* Header bar */}
+      <div
+        style={{
+          background: "#111",
+          borderBottom: "1px solid #222",
+          padding: "8px 12px",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          flexWrap: "wrap",
+          gap: 4,
+        }}
+      >
+        <div>
+          <span style={{ color: "#90caf9", fontWeight: 700, fontSize: 13 }}>org-pulse</span>
+          <span style={{ color: "#444", fontSize: 11, marginLeft: 8 }}>
+            {data.captured_at_et}
+          </span>
+        </div>
+        <div style={{ fontSize: 11, color: "#666" }}>
+          <span style={{ color: "#4caf50" }}>{data.repos_succeeded}✓</span>
+          {" "}
+          <span style={{ color: "#ffc107" }}>{data.repos_partial}~</span>
+          {" "}
+          <span style={{ color: "#f44336" }}>{data.repos_failed}✗</span>
+          {" "}
+          <span style={{ color: "#555" }}>{(data.duration_ms / 1000).toFixed(1)}s</span>
+        </div>
+      </div>
+
+      {/* Filter bar */}
+      <div
+        style={{
+          background: "#0d0d0d",
+          borderBottom: "1px solid #1e1e1e",
+          padding: "6px 12px",
+          display: "flex",
+          alignItems: "center",
+          gap: 8,
+          flexWrap: "wrap",
+        }}
+      >
+        <input
+          type="text"
+          placeholder="filter repo…"
+          value={nameFilter}
+          onChange={(e) => setNameFilter(e.target.value)}
+          style={{
+            background: "#1a1a1a",
+            border: "1px solid #333",
+            borderRadius: 4,
+            color: "#ccc",
+            fontFamily: "monospace",
+            fontSize: 12,
+            padding: "4px 8px",
+            outline: "none",
+            width: 140,
+          }}
+        />
+        <div style={{ display: "flex", gap: 4 }}>
+          {statusPills.map((s) => (
+            <button
+              key={s}
+              onClick={() => setStatusFilter(s)}
+              style={{
+                background: statusFilter === s ? pillColor[s] + "22" : "transparent",
+                border: `1px solid ${statusFilter === s ? pillColor[s] : "#333"}`,
+                borderRadius: 3,
+                color: statusFilter === s ? pillColor[s] : "#666",
+                fontFamily: "monospace",
+                fontSize: 10,
+                padding: "3px 7px",
+                cursor: "pointer",
+                fontWeight: statusFilter === s ? 700 : 400,
+                minHeight: 28,
+              }}
+            >
+              {pillLabel[s]}
+            </button>
+          ))}
+        </div>
+        <span style={{ marginLeft: "auto", color: "#555", fontSize: 11 }}>
+          {filtered.length}/{repos.length}
+        </span>
+      </div>
+
+      {/* Scrollable table */}
+      <div style={{ overflowX: "auto", WebkitOverflowScrolling: "touch" }}>
+        <table
+          style={{
+            borderCollapse: "collapse",
+            width: "max-content",
+            minWidth: "100%",
+          }}
+        >
+          <thead>
+            <tr>
+              <ColHeader
+                label="REPO"
+                sortKey="name"
+                currentKey={sortKey}
+                currentDir={sortDir}
+                onSort={handleSort}
+                align="left"
+              />
+              <ColHeader
+                label="STATUS"
+                sortKey="capture_status"
+                currentKey={sortKey}
+                currentDir={sortDir}
+                onSort={handleSort}
+                align="left"
+              />
+              <ColHeader
+                label="PRs"
+                sortKey="open_prs"
+                currentKey={sortKey}
+                currentDir={sortDir}
+                onSort={handleSort}
+                title="Open PRs"
+              />
+              <ColHeader
+                label="STALL"
+                sortKey="stalled_prs"
+                currentKey={sortKey}
+                currentDir={sortDir}
+                onSort={handleSort}
+                title="Stalled PRs (>72h idle)"
+              />
+              <ColHeader
+                label="CRIT"
+                sortKey="crit"
+                currentKey={sortKey}
+                currentDir={sortDir}
+                onSort={handleSort}
+                title="Critical vulnerabilities"
+              />
+              <ColHeader
+                label="HIGH"
+                sortKey="high"
+                currentKey={sortKey}
+                currentDir={sortDir}
+                onSort={handleSort}
+                title="High vulnerabilities"
+              />
+              <ColHeader
+                label="MOD"
+                sortKey="mod"
+                currentKey={sortKey}
+                currentDir={sortDir}
+                onSort={handleSort}
+                title="Moderate vulnerabilities"
+              />
+              <ColHeader
+                label="LOW"
+                sortKey="low"
+                currentKey={sortKey}
+                currentDir={sortDir}
+                onSort={handleSort}
+                title="Low vulnerabilities"
+              />
+              <ColHeader
+                label="IDLE"
+                sortKey="oldest_idle"
+                currentKey={sortKey}
+                currentDir={sortDir}
+                onSort={handleSort}
+                title="Hours idle on oldest PR"
+              />
+            </tr>
+          </thead>
+          <tbody>
+            {filtered.map((repo) => {
+              const isExpanded = expandedRepo === repo.name;
+              const isFailed = repo.capture_status === "failed";
+              const oldestIdle = oldestIdleHours(repo.prs);
+
+              return (
+                <Fragment key={repo.name}>
+                  <tr
+                    onClick={() => handleRowClick(repo.name)}
+                    style={{
+                      cursor: "pointer",
+                      background: isExpanded ? "#141414" : "transparent",
+                      borderBottom: isExpanded ? "none" : "1px solid #1a1a1a",
+                      transition: "background 0.1s",
+                    }}
+                  >
+                    {/* Sticky repo name column */}
+                    <td
+                      style={{
+                        position: "sticky",
+                        left: 0,
+                        background: isExpanded ? "#141414" : "#0a0a0a",
+                        padding: "8px 8px 8px 12px",
+                        whiteSpace: "nowrap",
+                        fontSize: 12,
+                        color: isFailed ? "#f44336" : isExpanded ? "#90caf9" : "#e0e0e0",
+                        fontWeight: isExpanded ? 700 : 400,
+                        borderRight: "1px solid #1e1e1e",
+                        minWidth: 120,
+                        zIndex: 1,
+                      }}
+                    >
+                      {repo.name}
+                      {repo.is_fork && (
+                        <span style={{ color: "#555", fontSize: 10, marginLeft: 4 }}>fork</span>
+                      )}
+                    </td>
+
+                    {/* Status */}
+                    <td style={{ padding: "8px", whiteSpace: "nowrap" }}>
+                      <StatusBadge status={repo.capture_status} />
+                    </td>
+
+                    {/* Open PRs */}
+                    <td
+                      style={{
+                        padding: "8px",
+                        textAlign: "right",
+                        fontSize: 12,
+                        fontFamily: "monospace",
+                        color: isFailed ? "#555" : repo.prs.length > 0 ? "#ccc" : "#444",
+                      }}
+                    >
+                      {isFailed ? "N/A" : repo.prs.length}
+                    </td>
+
+                    {/* Stalled PRs */}
+                    <td
+                      style={{
+                        padding: "8px",
+                        textAlign: "right",
+                        fontSize: 12,
+                        fontFamily: "monospace",
+                      }}
+                    >
+                      {isFailed ? (
+                        <span style={{ color: "#555" }}>N/A</span>
+                      ) : (
+                        <span
+                          style={{
+                            color:
+                              repo.prs.filter((p) => p.stalled).length > 0
+                                ? "#f44336"
+                                : "#444",
+                          }}
+                        >
+                          {repo.prs.filter((p) => p.stalled).length}
+                        </span>
+                      )}
+                    </td>
+
+                    {/* Vuln columns */}
+                    {(["CRITICAL", "HIGH", "MODERATE", "LOW"] as const).map((sev) => (
+                      <td key={sev} style={{ padding: "8px", textAlign: "right" }}>
+                        {isFailed ? (
+                          <span style={{ color: "#555", fontFamily: "monospace", fontSize: 12 }}>
+                            N/A
+                          </span>
+                        ) : (
+                          <VulnCell alerts={repo.vulnerability_alerts} severity={sev} />
+                        )}
+                      </td>
+                    ))}
+
+                    {/* Oldest idle */}
+                    <td
+                      style={{
+                        padding: "8px 12px 8px 8px",
+                        textAlign: "right",
+                        fontSize: 12,
+                        fontFamily: "monospace",
+                        color: isFailed
+                          ? "#555"
+                          : oldestIdle === null
+                          ? "#444"
+                          : oldestIdle > 72
+                          ? "#f44336"
+                          : oldestIdle > 24
+                          ? "#ffc107"
+                          : "#888",
+                        whiteSpace: "nowrap",
+                      }}
+                    >
+                      {isFailed
+                        ? "N/A"
+                        : oldestIdle === null
+                        ? "—"
+                        : oldestIdle >= 24
+                        ? `${Math.floor(oldestIdle / 24)}d`
+                        : `${oldestIdle}h`}
+                    </td>
+                  </tr>
+
+                  {/* Inline expansion */}
+                  {isExpanded && <RepoDetail repo={repo} />}
+                </Fragment>
+              );
+            })}
+
+            {filtered.length === 0 && (
+              <tr>
+                <td
+                  colSpan={9}
+                  style={{
+                    padding: "24px",
+                    textAlign: "center",
+                    color: "#555",
+                    fontFamily: "monospace",
+                    fontSize: 12,
+                  }}
+                >
+                  no repos match filter
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Footer */}
+      <div
+        style={{
+          padding: "8px 12px",
+          borderTop: "1px solid #1a1a1a",
+          fontSize: 10,
+          color: "#444",
+          fontFamily: "monospace",
+          display: "flex",
+          justifyContent: "space-between",
+        }}
+      >
+        <span>{data.snapshot_id}</span>
+        <span>tap row to expand · tap header to sort</span>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/pulse/VisualChartDashboard.tsx
+++ b/apps/web/src/components/pulse/VisualChartDashboard.tsx
@@ -1,0 +1,1051 @@
+import { useState, useMemo } from "react";
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  Legend,
+  Cell,
+  PieChart,
+  Pie,
+  ResponsiveContainer,
+} from "recharts";
+import type { PulseSnapshot } from "./MinimalistDashboard";
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+interface VulnAlert {
+  severity: "CRITICAL" | "HIGH" | "MODERATE" | "LOW";
+  ghsa_id: string;
+  package_name: string;
+  ecosystem: string;
+  age_days: number;
+  dependabot_pr_number: number | null;
+}
+
+interface PR {
+  number: number;
+  title: string;
+  author: string;
+  is_draft: boolean;
+  is_dependabot: boolean;
+  is_renovate: boolean;
+  stalled: boolean;
+  hours_idle: number;
+  updated_at: string;
+}
+
+interface Issue {
+  number: number;
+  title: string;
+  labels: string[];
+  stalled: boolean;
+  hours_idle: number;
+}
+
+interface RepoSnapshot {
+  org: string;
+  name: string;
+  is_fork: boolean;
+  is_archived: boolean;
+  capture_status: "success" | "partial" | "failed";
+  field_statuses: Record<string, { status: string; error_note: string | null }>;
+  upstream: { status: string; commits_behind: number; commits_ahead: number } | null;
+  vulnerability_alerts: VulnAlert[] | null;
+  prs: PR[];
+  issues: Issue[];
+  releases: { tag_name: string; name: string; is_prerelease: boolean; created_at: string }[];
+}
+
+interface ReviewerBucket {
+  total: number;
+  approved: number;
+  change_requested: number;
+  commented: number;
+  dismissed: number;
+}
+
+interface Props {
+  data: PulseSnapshot;
+}
+
+// ── Color palette ────────────────────────────────────────────────────────────
+
+const COLORS = {
+  CRITICAL: "#ef4444",
+  HIGH: "#f97316",
+  MODERATE: "#eab308",
+  LOW: "#22c55e",
+  UNKNOWN: "#6b7280",
+  stalled: "#f59e0b",
+  draft: "#60a5fa",
+  bot: "#9ca3af",
+  active: "#34d399",
+  approved: "#22c55e",
+  change_requested: "#ef4444",
+  commented: "#60a5fa",
+  dismissed: "#9ca3af",
+  failed: "#ef4444",
+  partial: "#f59e0b",
+  success: "#22c55e",
+};
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function vulnSeverityScore(v: VulnAlert): number {
+  return { CRITICAL: 4, HIGH: 3, MODERATE: 2, LOW: 1 }[v.severity] ?? 0;
+}
+
+function repoSeverityScore(repo: RepoSnapshot): number {
+  if (repo.capture_status === "failed") return 100;
+  let score = 0;
+  if (repo.prs.some((p) => p.stalled)) score += 20;
+  if (repo.vulnerability_alerts) {
+    for (const v of repo.vulnerability_alerts) score += vulnSeverityScore(v) * 5;
+  }
+  if (repo.capture_status === "partial") score += 10;
+  return score;
+}
+
+function formatReviewerLabel(key: string): string {
+  if (key.startsWith("human:")) return key.slice(6);
+  return key;
+}
+
+function relativeTime(isoStr: string): string {
+  const ms = Date.now() - new Date(isoStr).getTime();
+  const h = Math.floor(ms / 3600000);
+  if (h < 24) return `${h}h ago`;
+  return `${Math.floor(h / 24)}d ago`;
+}
+
+// ── Sub-components ───────────────────────────────────────────────────────────
+
+function StatusChip({ status }: { status: "success" | "partial" | "failed" }) {
+  const labels = { success: "OK", partial: "PARTIAL", failed: "FAILED" };
+  const colors: Record<string, string> = {
+    success: "#22c55e",
+    partial: "#f59e0b",
+    failed: "#ef4444",
+  };
+  return (
+    <span
+      style={{
+        fontSize: 11,
+        fontWeight: 700,
+        letterSpacing: "0.05em",
+        padding: "2px 7px",
+        borderRadius: 4,
+        backgroundColor: colors[status] + "22",
+        color: colors[status],
+        border: `1px solid ${colors[status]}55`,
+        flexShrink: 0,
+      }}
+    >
+      {labels[status]}
+    </span>
+  );
+}
+
+function SeverityBadge({
+  severity,
+  count,
+}: {
+  severity: string;
+  count: number;
+}) {
+  const color = COLORS[severity as keyof typeof COLORS] ?? COLORS.UNKNOWN;
+  return (
+    <span
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 3,
+        fontSize: 11,
+        fontWeight: 700,
+        padding: "2px 6px",
+        borderRadius: 4,
+        backgroundColor: color + "22",
+        color: color,
+        border: `1px solid ${color}55`,
+      }}
+    >
+      {severity[0]} <span style={{ fontWeight: 500 }}>{count}</span>
+    </span>
+  );
+}
+
+function PRItem({ pr }: { pr: PR }) {
+  const isBot = pr.is_dependabot || pr.is_renovate;
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "flex-start",
+        gap: 6,
+        padding: "6px 0",
+        borderBottom: "1px solid #1f2937",
+        fontSize: 13,
+      }}
+    >
+      <span style={{ color: "#6b7280", flexShrink: 0, marginTop: 1 }}>
+        #{pr.number}
+      </span>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div
+          style={{
+            color: pr.stalled ? "#f59e0b" : "#e5e7eb",
+            whiteSpace: "nowrap",
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+          }}
+        >
+          {pr.title}
+        </div>
+        <div style={{ display: "flex", gap: 5, marginTop: 3, flexWrap: "wrap" }}>
+          {pr.is_draft && (
+            <span
+              style={{
+                fontSize: 10,
+                padding: "1px 5px",
+                borderRadius: 3,
+                backgroundColor: "#1e40af44",
+                color: "#60a5fa",
+                border: "1px solid #60a5fa44",
+              }}
+            >
+              DRAFT
+            </span>
+          )}
+          {pr.stalled && (
+            <span
+              style={{
+                fontSize: 10,
+                padding: "1px 5px",
+                borderRadius: 3,
+                backgroundColor: "#78350f44",
+                color: "#f59e0b",
+                border: "1px solid #f59e0b44",
+              }}
+            >
+              STALLED {pr.hours_idle}h
+            </span>
+          )}
+          {isBot && (
+            <span
+              style={{
+                fontSize: 10,
+                padding: "1px 5px",
+                borderRadius: 3,
+                backgroundColor: "#37415144",
+                color: "#9ca3af",
+                border: "1px solid #9ca3af44",
+              }}
+            >
+              {pr.is_dependabot ? "dependabot" : "renovate"}
+            </span>
+          )}
+          <span style={{ fontSize: 10, color: "#6b7280" }}>
+            {relativeTime(pr.updated_at)}
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function VulnItem({ v }: { v: VulnAlert }) {
+  const color = COLORS[v.severity] ?? COLORS.UNKNOWN;
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 8,
+        padding: "5px 0",
+        borderBottom: "1px solid #1f2937",
+        fontSize: 12,
+      }}
+    >
+      <span
+        style={{
+          flexShrink: 0,
+          fontWeight: 700,
+          fontSize: 10,
+          padding: "2px 5px",
+          borderRadius: 3,
+          backgroundColor: color + "22",
+          color,
+        }}
+      >
+        {v.severity}
+      </span>
+      <span style={{ flex: 1, color: "#d1d5db", minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+        {v.package_name}
+      </span>
+      <span style={{ flexShrink: 0, color: "#6b7280", fontSize: 11 }}>
+        {v.age_days}d
+      </span>
+      {v.dependabot_pr_number && (
+        <span style={{ flexShrink: 0, fontSize: 10, color: "#60a5fa" }}>
+          PR#{v.dependabot_pr_number}
+        </span>
+      )}
+    </div>
+  );
+}
+
+function RepoCard({
+  repo,
+  highlighted,
+}: {
+  repo: RepoSnapshot;
+  highlighted: boolean;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const isFailed = repo.capture_status === "failed";
+  const vulnMissing =
+    repo.field_statuses.vulnerability_alerts?.status === "scope_missing";
+
+  const vulnCounts = useMemo(() => {
+    if (!repo.vulnerability_alerts) return null;
+    const c: Record<string, number> = {};
+    for (const v of repo.vulnerability_alerts) {
+      c[v.severity] = (c[v.severity] ?? 0) + 1;
+    }
+    return c;
+  }, [repo.vulnerability_alerts]);
+
+  const stalledPRs = repo.prs.filter((p) => p.stalled);
+  const draftPRs = repo.prs.filter((p) => p.is_draft && !p.stalled);
+  const botPRs = repo.prs.filter(
+    (p) => (p.is_dependabot || p.is_renovate) && !p.stalled
+  );
+  const activePRs = repo.prs.filter(
+    (p) => !p.stalled && !p.is_draft && !p.is_dependabot && !p.is_renovate
+  );
+
+  return (
+    <div
+      style={{
+        backgroundColor: "#111827",
+        border: `1px solid ${
+          isFailed
+            ? "#ef444455"
+            : highlighted
+            ? "#6366f155"
+            : "#1f2937"
+        }`,
+        borderRadius: 10,
+        marginBottom: 10,
+        overflow: "hidden",
+        opacity: isFailed ? 0.85 : 1,
+        transition: "border-color 0.2s",
+      }}
+    >
+      {/* Card header */}
+      <button
+        onClick={() => !isFailed && setExpanded((x) => !x)}
+        style={{
+          width: "100%",
+          background: "none",
+          border: "none",
+          padding: "12px 14px",
+          cursor: isFailed ? "default" : "pointer",
+          textAlign: "left",
+          display: "flex",
+          alignItems: "center",
+          gap: 8,
+          minHeight: 44,
+        }}
+      >
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 6,
+              flexWrap: "wrap",
+            }}
+          >
+            <span
+              style={{
+                fontWeight: 600,
+                fontSize: 15,
+                color: isFailed ? "#9ca3af" : "#f3f4f6",
+                whiteSpace: "nowrap",
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                maxWidth: "200px",
+              }}
+            >
+              {repo.name}
+            </span>
+            <StatusChip status={repo.capture_status} />
+            {repo.is_fork && (
+              <span style={{ fontSize: 10, color: "#6b7280" }}>fork</span>
+            )}
+          </div>
+
+          {!isFailed && (
+            <div
+              style={{
+                display: "flex",
+                gap: 6,
+                marginTop: 6,
+                flexWrap: "wrap",
+                alignItems: "center",
+              }}
+            >
+              {/* PR pills */}
+              {stalledPRs.length > 0 && (
+                <span
+                  style={{
+                    fontSize: 11,
+                    padding: "1px 6px",
+                    borderRadius: 4,
+                    backgroundColor: "#78350f44",
+                    color: "#f59e0b",
+                    border: "1px solid #f59e0b44",
+                  }}
+                >
+                  {stalledPRs.length} stalled
+                </span>
+              )}
+              {draftPRs.length > 0 && (
+                <span
+                  style={{
+                    fontSize: 11,
+                    padding: "1px 6px",
+                    borderRadius: 4,
+                    backgroundColor: "#1e3a8a44",
+                    color: "#93c5fd",
+                    border: "1px solid #93c5fd44",
+                  }}
+                >
+                  {draftPRs.length} draft
+                </span>
+              )}
+              {activePRs.length > 0 && (
+                <span
+                  style={{
+                    fontSize: 11,
+                    padding: "1px 6px",
+                    borderRadius: 4,
+                    backgroundColor: "#06402144",
+                    color: "#34d399",
+                    border: "1px solid #34d39944",
+                  }}
+                >
+                  {activePRs.length} PR{activePRs.length !== 1 ? "s" : ""}
+                </span>
+              )}
+              {botPRs.length > 0 && (
+                <span
+                  style={{
+                    fontSize: 11,
+                    padding: "1px 6px",
+                    borderRadius: 4,
+                    backgroundColor: "#37415144",
+                    color: "#9ca3af",
+                    border: "1px solid #9ca3af44",
+                  }}
+                >
+                  {botPRs.length} bot
+                </span>
+              )}
+
+              {/* Vuln badges */}
+              {vulnMissing && (
+                <span
+                  style={{
+                    fontSize: 11,
+                    padding: "1px 6px",
+                    borderRadius: 4,
+                    backgroundColor: "#37415144",
+                    color: "#9ca3af",
+                    border: "1px solid #9ca3af44",
+                  }}
+                >
+                  vulns: scope missing
+                </span>
+              )}
+              {vulnCounts &&
+                (["CRITICAL", "HIGH", "MODERATE", "LOW"] as const).map(
+                  (sev) =>
+                    vulnCounts[sev] ? (
+                      <SeverityBadge
+                        key={sev}
+                        severity={sev}
+                        count={vulnCounts[sev]}
+                      />
+                    ) : null
+                )}
+
+              {/* Fork drift */}
+              {repo.upstream && repo.upstream.commits_behind > 0 && (
+                <span style={{ fontSize: 11, color: "#6b7280" }}>
+                  ↓{repo.upstream.commits_behind} behind
+                </span>
+              )}
+            </div>
+          )}
+
+          {isFailed && (
+            <div style={{ marginTop: 4, fontSize: 12, color: "#ef4444" }}>
+              {Object.values(repo.field_statuses).find((f) => f.error_note)
+                ?.error_note ?? "Capture failed"}
+            </div>
+          )}
+        </div>
+
+        {!isFailed && (
+          <span style={{ color: "#4b5563", fontSize: 16, flexShrink: 0 }}>
+            {expanded ? "▲" : "▼"}
+          </span>
+        )}
+      </button>
+
+      {/* Expanded detail */}
+      {expanded && !isFailed && (
+        <div
+          style={{
+            padding: "0 14px 12px",
+            borderTop: "1px solid #1f2937",
+          }}
+        >
+          {repo.prs.length > 0 && (
+            <div style={{ marginTop: 10 }}>
+              <div
+                style={{
+                  fontSize: 11,
+                  fontWeight: 700,
+                  color: "#6b7280",
+                  textTransform: "uppercase",
+                  letterSpacing: "0.08em",
+                  marginBottom: 4,
+                }}
+              >
+                Pull Requests
+              </div>
+              {repo.prs.map((pr) => (
+                <PRItem key={pr.number} pr={pr} />
+              ))}
+            </div>
+          )}
+
+          {repo.vulnerability_alerts && repo.vulnerability_alerts.length > 0 && (
+            <div style={{ marginTop: 12 }}>
+              <div
+                style={{
+                  fontSize: 11,
+                  fontWeight: 700,
+                  color: "#6b7280",
+                  textTransform: "uppercase",
+                  letterSpacing: "0.08em",
+                  marginBottom: 4,
+                }}
+              >
+                Vulnerabilities
+              </div>
+              {repo.vulnerability_alerts
+                .sort((a, b) => vulnSeverityScore(b) - vulnSeverityScore(a))
+                .map((v) => (
+                  <VulnItem key={v.ghsa_id} v={v} />
+                ))}
+            </div>
+          )}
+
+          {repo.issues.length > 0 && (
+            <div style={{ marginTop: 12 }}>
+              <div
+                style={{
+                  fontSize: 11,
+                  fontWeight: 700,
+                  color: "#6b7280",
+                  textTransform: "uppercase",
+                  letterSpacing: "0.08em",
+                  marginBottom: 4,
+                }}
+              >
+                Issues
+              </div>
+              {repo.issues.map((issue) => (
+                <div
+                  key={issue.number}
+                  style={{
+                    display: "flex",
+                    gap: 6,
+                    padding: "5px 0",
+                    borderBottom: "1px solid #1f2937",
+                    fontSize: 13,
+                    alignItems: "flex-start",
+                  }}
+                >
+                  <span style={{ color: "#6b7280", flexShrink: 0 }}>
+                    #{issue.number}
+                  </span>
+                  <span
+                    style={{
+                      flex: 1,
+                      color: issue.stalled ? "#f59e0b" : "#e5e7eb",
+                      overflow: "hidden",
+                      textOverflow: "ellipsis",
+                      whiteSpace: "nowrap",
+                    }}
+                  >
+                    {issue.title}
+                  </span>
+                  {issue.stalled && (
+                    <span style={{ fontSize: 10, color: "#f59e0b", flexShrink: 0 }}>
+                      {issue.hours_idle}h idle
+                    </span>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+
+          {repo.releases.length > 0 && (
+            <div style={{ marginTop: 10, fontSize: 12, color: "#6b7280" }}>
+              Latest: {repo.releases[0].tag_name} —{" "}
+              {relativeTime(repo.releases[0].created_at)}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Main chart helpers ────────────────────────────────────────────────────────
+
+function buildVulnDonutData(repos: RepoSnapshot[]) {
+  const counts: Record<string, number> = {
+    CRITICAL: 0,
+    HIGH: 0,
+    MODERATE: 0,
+    LOW: 0,
+    UNKNOWN: 0,
+  };
+  for (const repo of repos) {
+    if (repo.vulnerability_alerts === null) {
+      counts.UNKNOWN += 1;
+    } else {
+      for (const v of repo.vulnerability_alerts) {
+        counts[v.severity] = (counts[v.severity] ?? 0) + 1;
+      }
+    }
+  }
+  return Object.entries(counts)
+    .filter(([, v]) => v > 0)
+    .map(([name, value]) => ({ name, value }));
+}
+
+function buildPRHealthData(repos: RepoSnapshot[]) {
+  let draft = 0, stalled = 0, bot = 0, active = 0;
+  for (const repo of repos) {
+    for (const pr of repo.prs) {
+      if (pr.stalled) stalled++;
+      else if (pr.is_draft) draft++;
+      else if (pr.is_dependabot || pr.is_renovate) bot++;
+      else active++;
+    }
+  }
+  return [
+    { name: "Active", value: active, fill: COLORS.active },
+    { name: "Stalled", value: stalled, fill: COLORS.stalled },
+    { name: "Draft", value: draft, fill: COLORS.draft },
+    { name: "Bot", value: bot, fill: COLORS.bot },
+  ].filter((d) => d.value > 0);
+}
+
+function buildReviewerData(activity: Record<string, ReviewerBucket>) {
+  return Object.entries(activity).map(([key, bucket]) => ({
+    name: formatReviewerLabel(key),
+    Approved: bucket.approved,
+    "Changes Req": bucket.change_requested,
+    Commented: bucket.commented,
+  }));
+}
+
+// ── Dashboard component ───────────────────────────────────────────────────────
+
+export default function VisualChartDashboard({ data }: Props) {
+  const [highlightSeverity, setHighlightSeverity] = useState<string | null>(null);
+
+  const repos = data.repos as RepoSnapshot[];
+
+  const sortedRepos = useMemo(
+    () => [...repos].sort((a, b) => repoSeverityScore(b) - repoSeverityScore(a)),
+    [repos]
+  );
+
+  const vulnDonutData = useMemo(() => buildVulnDonutData(repos), [repos]);
+  const prHealthData = useMemo(() => buildPRHealthData(repos), [repos]);
+  const reviewerData = useMemo(
+    () => buildReviewerData(data.reviewer_activity_7d as Record<string, ReviewerBucket>),
+    [data.reviewer_activity_7d]
+  );
+
+  const totalVulns = vulnDonutData
+    .filter((d) => d.name !== "UNKNOWN")
+    .reduce((s, d) => s + d.value, 0);
+
+  const captureColor =
+    data.capture_status === "success"
+      ? COLORS.success
+      : data.capture_status === "partial"
+      ? COLORS.partial
+      : COLORS.failed;
+
+  return (
+    <div
+      style={{
+        maxWidth: "100%",
+        margin: "0 auto",
+        backgroundColor: "#0f1117",
+        minHeight: "100%",
+        paddingTop: "var(--tg-content-safe-area-inset-top, 0px)",
+        color: "#e5e7eb",
+        fontFamily:
+          '-apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
+        boxSizing: "border-box",
+        overflowX: "hidden",
+      }}
+    >
+      {/* Safe-area CSS reset */}
+      <style>{`
+        *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+        button { font-family: inherit; }
+      `}</style>
+
+      {/* Warm-up banner */}
+      {data.warm_up_active && (
+        <div
+          style={{
+            backgroundColor: "#1c1917",
+            borderBottom: "1px solid #f59e0b44",
+            padding: "8px 16px",
+            fontSize: 12,
+            color: "#fbbf24",
+            display: "flex",
+            gap: 6,
+            alignItems: "center",
+          }}
+        >
+          <span>⏳</span>
+          <span>
+            Warm-up active — trend data available{" "}
+            {data.warm_up_fill_date ?? "soon"}
+          </span>
+        </div>
+      )}
+
+      {/* Header */}
+      <div
+        style={{
+          padding: "14px 16px 10px",
+          borderBottom: "1px solid #1f2937",
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+        }}
+      >
+        <div>
+          <div style={{ fontSize: 16, fontWeight: 700, color: "#f3f4f6" }}>
+            Org Pulse
+          </div>
+          <div style={{ fontSize: 11, color: "#6b7280", marginTop: 2 }}>
+            {data.captured_at_et}
+          </div>
+        </div>
+        <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+          <span
+            style={{
+              fontSize: 11,
+              color: captureColor,
+              fontWeight: 600,
+              textTransform: "uppercase",
+            }}
+          >
+            {data.capture_status}
+          </span>
+          <span style={{ fontSize: 11, color: "#4b5563" }}>
+            {data.repos_succeeded}✓ {data.repos_failed}✗ {data.repos_partial}~
+          </span>
+        </div>
+      </div>
+
+      {/* ── Chart 1: Vuln Donut ─────────────────────────────────────────────── */}
+      <div
+        style={{
+          padding: "16px 16px 8px",
+          borderBottom: "1px solid #1f2937",
+        }}
+      >
+        <div
+          style={{
+            fontSize: 11,
+            fontWeight: 700,
+            color: "#6b7280",
+            textTransform: "uppercase",
+            letterSpacing: "0.08em",
+            marginBottom: 10,
+          }}
+        >
+          Vulnerabilities
+        </div>
+        <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+          <div style={{ width: 130, height: 130, flexShrink: 0 }}>
+            <ResponsiveContainer width="100%" height="100%">
+              <PieChart>
+                <Pie
+                  data={vulnDonutData}
+                  cx="50%"
+                  cy="50%"
+                  innerRadius={38}
+                  outerRadius={58}
+                  dataKey="value"
+                  paddingAngle={2}
+                  onClick={(entry) =>
+                    setHighlightSeverity(
+                      highlightSeverity === entry.name ? null : (entry.name ?? null)
+                    )
+                  }
+                  style={{ cursor: "pointer" }}
+                >
+                  {vulnDonutData.map((entry) => (
+                    <Cell
+                      key={entry.name}
+                      fill={
+                        COLORS[entry.name as keyof typeof COLORS] ??
+                        COLORS.UNKNOWN
+                      }
+                      opacity={
+                        highlightSeverity && highlightSeverity !== entry.name
+                          ? 0.3
+                          : 1
+                      }
+                    />
+                  ))}
+                </Pie>
+                <Tooltip
+                  contentStyle={{
+                    backgroundColor: "#1f2937",
+                    border: "1px solid #374151",
+                    borderRadius: 6,
+                    fontSize: 12,
+                  }}
+                />
+              </PieChart>
+            </ResponsiveContainer>
+          </div>
+          <div style={{ flex: 1 }}>
+            <div
+              style={{ fontSize: 28, fontWeight: 700, color: "#f3f4f6", lineHeight: 1 }}
+            >
+              {totalVulns}
+            </div>
+            <div style={{ fontSize: 12, color: "#6b7280", marginBottom: 10 }}>
+              vulns across org
+            </div>
+            <div style={{ display: "flex", flexDirection: "column", gap: 5 }}>
+              {vulnDonutData.map((d) => {
+                const color =
+                  COLORS[d.name as keyof typeof COLORS] ?? COLORS.UNKNOWN;
+                return (
+                  <div
+                    key={d.name}
+                    style={{
+                      display: "flex",
+                      alignItems: "center",
+                      gap: 6,
+                      fontSize: 12,
+                      opacity:
+                        highlightSeverity && highlightSeverity !== d.name
+                          ? 0.4
+                          : 1,
+                    }}
+                  >
+                    <span
+                      style={{
+                        width: 8,
+                        height: 8,
+                        borderRadius: "50%",
+                        backgroundColor: color,
+                        flexShrink: 0,
+                      }}
+                    />
+                    <span style={{ color: "#9ca3af", minWidth: 70 }}>
+                      {d.name === "UNKNOWN" ? "scope missing" : d.name}
+                    </span>
+                    <span style={{ color, fontWeight: 600 }}>{d.value}</span>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        </div>
+        {highlightSeverity && (
+          <div style={{ fontSize: 11, color: "#6b7280", marginTop: 6 }}>
+            Tap card below to see {highlightSeverity} vulns ·{" "}
+            <button
+              onClick={() => setHighlightSeverity(null)}
+              style={{
+                background: "none",
+                border: "none",
+                color: "#60a5fa",
+                cursor: "pointer",
+                fontSize: 11,
+                padding: 0,
+              }}
+            >
+              clear
+            </button>
+          </div>
+        )}
+      </div>
+
+      {/* ── Chart 2: PR Health bar ──────────────────────────────────────────── */}
+      <div
+        style={{
+          padding: "16px 16px 8px",
+          borderBottom: "1px solid #1f2937",
+        }}
+      >
+        <div
+          style={{
+            fontSize: 11,
+            fontWeight: 700,
+            color: "#6b7280",
+            textTransform: "uppercase",
+            letterSpacing: "0.08em",
+            marginBottom: 10,
+          }}
+        >
+          PR Health
+        </div>
+        <div style={{ height: 60 }}>
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart
+              layout="vertical"
+              data={prHealthData}
+              barSize={16}
+              margin={{ left: 0, right: 20, top: 0, bottom: 0 }}
+            >
+              <XAxis type="number" hide />
+              <YAxis
+                type="category"
+                dataKey="name"
+                width={55}
+                tick={{ fill: "#9ca3af", fontSize: 11 }}
+                axisLine={false}
+                tickLine={false}
+              />
+              <Tooltip
+                contentStyle={{
+                  backgroundColor: "#1f2937",
+                  border: "1px solid #374151",
+                  borderRadius: 6,
+                  fontSize: 12,
+                }}
+              />
+              <Bar dataKey="value" radius={[0, 3, 3, 0]}>
+                {prHealthData.map((d) => (
+                  <Cell key={d.name} fill={d.fill} />
+                ))}
+              </Bar>
+            </BarChart>
+          </ResponsiveContainer>
+        </div>
+      </div>
+
+      {/* ── Chart 3: Reviewer activity ──────────────────────────────────────── */}
+      <div
+        style={{
+          padding: "16px 16px 12px",
+          borderBottom: "1px solid #1f2937",
+        }}
+      >
+        <div
+          style={{
+            fontSize: 11,
+            fontWeight: 700,
+            color: "#6b7280",
+            textTransform: "uppercase",
+            letterSpacing: "0.08em",
+            marginBottom: 10,
+          }}
+        >
+          Reviewer Activity (7d)
+        </div>
+        <div style={{ height: 160 }}>
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart
+              layout="vertical"
+              data={reviewerData}
+              barSize={12}
+              margin={{ left: 8, right: 20, top: 0, bottom: 0 }}
+            >
+              <XAxis type="number" hide />
+              <YAxis
+                type="category"
+                dataKey="name"
+                width={80}
+                tick={{ fill: "#9ca3af", fontSize: 11 }}
+                axisLine={false}
+                tickLine={false}
+              />
+              <Tooltip
+                contentStyle={{
+                  backgroundColor: "#1f2937",
+                  border: "1px solid #374151",
+                  borderRadius: 6,
+                  fontSize: 12,
+                }}
+              />
+              <Legend
+                wrapperStyle={{ fontSize: 11, paddingTop: 4, color: "#9ca3af" }}
+              />
+              <Bar dataKey="Approved" stackId="a" fill={COLORS.approved} radius={[0, 0, 0, 0]} />
+              <Bar dataKey="Changes Req" stackId="a" fill={COLORS.change_requested} radius={[0, 0, 0, 0]} />
+              <Bar dataKey="Commented" stackId="a" fill={COLORS.commented} radius={[0, 3, 3, 0]} />
+            </BarChart>
+          </ResponsiveContainer>
+        </div>
+      </div>
+
+      {/* ── Repo cards ─────────────────────────────────────────────────────── */}
+      <div style={{ padding: "14px 12px 32px" }}>
+        <div
+          style={{
+            fontSize: 11,
+            fontWeight: 700,
+            color: "#6b7280",
+            textTransform: "uppercase",
+            letterSpacing: "0.08em",
+            marginBottom: 10,
+            paddingLeft: 2,
+          }}
+        >
+          Repos ({repos.length})
+        </div>
+        {sortedRepos.map((repo) => {
+          const hasHighlightedSeverity =
+            highlightSeverity !== null &&
+            repo.vulnerability_alerts !== null &&
+            repo.vulnerability_alerts.some((v) => v.severity === highlightSeverity);
+          return (
+            <RepoCard
+              key={`${repo.org}/${repo.name}`}
+              repo={repo}
+              highlighted={hasHighlightedSeverity}
+            />
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,6 +81,9 @@ importers:
       react-markdown:
         specifier: ^10.1.0
         version: 10.1.0(@types/react@19.2.14)(react@19.2.4)
+      recharts:
+        specifier: ^3.8.1
+        version: 3.8.1(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-is@17.0.2)(react@19.2.4)(redux@5.0.1)
       rehype-highlight:
         specifier: ^7.0.2
         version: 7.0.2
@@ -674,6 +677,17 @@ packages:
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
 
+  '@reduxjs/toolkit@2.11.2':
+    resolution: {integrity: sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==}
+    peerDependencies:
+      react: ^16.9.0 || ^17.0.0 || ^18 || ^19
+      react-redux: ^7.2.1 || ^8.1.3 || ^9.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-redux:
+        optional: true
+
   '@rolldown/pluginutils@1.0.0-beta.27':
     resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
 
@@ -804,6 +818,9 @@ packages:
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@standard-schema/utils@0.3.0':
+    resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
 
   '@tailwindcss/node@4.2.2':
     resolution: {integrity: sha512-pXS+wJ2gZpVXqFaUEjojq7jzMpTGf8rU6ipJz5ovJV6PUGmlJ+jvIwGrzdHdQ80Sg+wmQxUFuoW1UAAwHNEdFA==}
@@ -1112,6 +1129,9 @@ packages:
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
+  '@types/use-sync-external-store@0.0.6':
+    resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
+
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
 
@@ -1276,6 +1296,10 @@ packages:
   cliui@9.0.1:
     resolution: {integrity: sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==}
     engines: {node: '>=20'}
+
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
 
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
@@ -1482,6 +1506,9 @@ packages:
       supports-color:
         optional: true
 
+  decimal.js-light@2.5.1:
+    resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
+
   decimal.js@10.6.0:
     resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
@@ -1551,6 +1578,9 @@ packages:
   es-module-lexer@2.0.0:
     resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
 
+  es-toolkit@1.46.0:
+    resolution: {integrity: sha512-IToJ6ct9OLl5zz6WsC/1vZEwfSZ7Myil+ygl5Tf30Xjn9AEkzNB4kqp2G7VUJKF1DtTx/ra5M5KLlXvzOg51BA==}
+
   esbuild@0.25.12:
     resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
     engines: {node: '>=18'}
@@ -1574,6 +1604,9 @@ packages:
 
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  eventemitter3@5.0.4:
+    resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
   expand-template@2.0.3:
     resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
@@ -1683,6 +1716,12 @@ packages:
 
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
+  immer@10.2.0:
+    resolution: {integrity: sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==}
+
+  immer@11.1.4:
+    resolution: {integrity: sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==}
 
   indent-string@4.0.0:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
@@ -2169,6 +2208,18 @@ packages:
       '@types/react': '>=18'
       react: '>=18'
 
+  react-redux@9.2.0:
+    resolution: {integrity: sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==}
+    peerDependencies:
+      '@types/react': ^18.2.25 || ^19
+      react: ^18.0 || ^19
+      redux: ^5.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      redux:
+        optional: true
+
   react-refresh@0.17.0:
     resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
     engines: {node: '>=0.10.0'}
@@ -2181,9 +2232,25 @@ packages:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
     engines: {node: '>= 6'}
 
+  recharts@3.8.1:
+    resolution: {integrity: sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-is: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
+
+  redux-thunk@3.1.0:
+    resolution: {integrity: sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==}
+    peerDependencies:
+      redux: ^5.0.0
+
+  redux@5.0.1:
+    resolution: {integrity: sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==}
 
   rehype-highlight@7.0.2:
     resolution: {integrity: sha512-k158pK7wdC2qL3M5NcZROZ2tR/l7zOzjxXd5VGdcfIyoijjQqpHd3JKtYSBDpDZ38UI2WJWuFAtkMDxmx5kstA==}
@@ -2213,6 +2280,9 @@ packages:
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
+
+  reselect@5.1.1:
+    resolution: {integrity: sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==}
 
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
@@ -2348,6 +2418,9 @@ packages:
     resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
     engines: {node: '>=6'}
 
+  tiny-invariant@1.3.3:
+    resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
+
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
@@ -2446,6 +2519,11 @@ packages:
     peerDependencies:
       browserslist: '>= 4.21.0'
 
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
@@ -2458,6 +2536,9 @@ packages:
 
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
+
+  victory-vendor@37.3.6:
+    resolution: {integrity: sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==}
 
   vite@6.4.2:
     resolution: {integrity: sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==}
@@ -3021,6 +3102,18 @@ snapshots:
 
   '@polka/url@1.0.0-next.29': {}
 
+  '@reduxjs/toolkit@2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.2.4)(redux@5.0.1))(react@19.2.4)':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@standard-schema/utils': 0.3.0
+      immer: 11.1.4
+      redux: 5.0.1
+      redux-thunk: 3.1.0(redux@5.0.1)
+      reselect: 5.1.1
+    optionalDependencies:
+      react: 19.2.4
+      react-redux: 9.2.0(@types/react@19.2.14)(react@19.2.4)(redux@5.0.1)
+
   '@rolldown/pluginutils@1.0.0-beta.27': {}
 
   '@rollup/rollup-android-arm-eabi@4.60.1':
@@ -3099,6 +3192,8 @@ snapshots:
     optional: true
 
   '@standard-schema/spec@1.1.0': {}
+
+  '@standard-schema/utils@0.3.0': {}
 
   '@tailwindcss/node@4.2.2':
     dependencies:
@@ -3412,6 +3507,8 @@ snapshots:
 
   '@types/unist@3.0.3': {}
 
+  '@types/use-sync-external-store@0.0.6': {}
+
   '@ungap/structured-clone@1.3.0': {}
 
   '@upsetjs/venn.js@2.0.0':
@@ -3587,6 +3684,8 @@ snapshots:
       string-width: 7.2.0
       strip-ansi: 7.2.0
       wrap-ansi: 9.0.2
+
+  clsx@2.1.1: {}
 
   comma-separated-tokens@2.0.3: {}
 
@@ -3812,6 +3911,8 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  decimal.js-light@2.5.1: {}
+
   decimal.js@10.6.0: {}
 
   decode-named-character-reference@1.3.0:
@@ -3869,6 +3970,8 @@ snapshots:
   entities@6.0.1: {}
 
   es-module-lexer@2.0.0: {}
+
+  es-toolkit@1.46.0: {}
 
   esbuild@0.25.12:
     optionalDependencies:
@@ -3937,6 +4040,8 @@ snapshots:
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.8
+
+  eventemitter3@5.0.4: {}
 
   expand-template@2.0.3: {}
 
@@ -4040,6 +4145,10 @@ snapshots:
       safer-buffer: 2.1.2
 
   ieee754@1.2.1: {}
+
+  immer@10.2.0: {}
+
+  immer@11.1.4: {}
 
   indent-string@4.0.0: {}
 
@@ -4748,6 +4857,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  react-redux@9.2.0(@types/react@19.2.14)(react@19.2.4)(redux@5.0.1):
+    dependencies:
+      '@types/use-sync-external-store': 0.0.6
+      react: 19.2.4
+      use-sync-external-store: 1.6.0(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      redux: 5.0.1
+
   react-refresh@0.17.0: {}
 
   react@19.2.4: {}
@@ -4758,10 +4876,36 @@ snapshots:
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
 
+  recharts@3.8.1(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-is@17.0.2)(react@19.2.4)(redux@5.0.1):
+    dependencies:
+      '@reduxjs/toolkit': 2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.2.4)(redux@5.0.1))(react@19.2.4)
+      clsx: 2.1.1
+      decimal.js-light: 2.5.1
+      es-toolkit: 1.46.0
+      eventemitter3: 5.0.4
+      immer: 10.2.0
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      react-is: 17.0.2
+      react-redux: 9.2.0(@types/react@19.2.14)(react@19.2.4)(redux@5.0.1)
+      reselect: 5.1.1
+      tiny-invariant: 1.3.3
+      use-sync-external-store: 1.6.0(react@19.2.4)
+      victory-vendor: 37.3.6
+    transitivePeerDependencies:
+      - '@types/react'
+      - redux
+
   redent@3.0.0:
     dependencies:
       indent-string: 4.0.0
       strip-indent: 3.0.0
+
+  redux-thunk@3.1.0(redux@5.0.1):
+    dependencies:
+      redux: 5.0.1
+
+  redux@5.0.1: {}
 
   rehype-highlight@7.0.2:
     dependencies:
@@ -4824,6 +4968,8 @@ snapshots:
       unified: 11.0.5
 
   require-from-string@2.0.2: {}
+
+  reselect@5.1.1: {}
 
   resolve-pkg-maps@1.0.0: {}
 
@@ -4976,6 +5122,8 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
+  tiny-invariant@1.3.3: {}
+
   tinybench@2.9.0: {}
 
   tinyexec@1.1.1: {}
@@ -5081,6 +5229,10 @@ snapshots:
       escalade: 3.2.0
       picocolors: 1.1.1
 
+  use-sync-external-store@1.6.0(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+
   util-deprecate@1.0.2: {}
 
   uuid@11.1.0: {}
@@ -5094,6 +5246,23 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
+
+  victory-vendor@37.3.6:
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/d3-ease': 3.0.2
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-scale': 4.0.9
+      '@types/d3-shape': 3.1.8
+      '@types/d3-time': 3.0.4
+      '@types/d3-timer': 3.0.2
+      d3-array: 3.2.4
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-scale: 4.0.2
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-timer: 3.0.1
 
   vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0):
     dependencies:


### PR DESCRIPTION
## Summary

Closes #268

Integrates 4 Pulse v2 dashboard design concepts as a comparison lab in CPC.

- **Backend** (`apps/server/src/routes/pulse.ts`): `GET /api/pulse/current` reads `~/.world/pulse/snapshots/current.json` with 60s in-memory cache; returns 503 when file missing; auth covered by global `telegramAuth` middleware
- **4 dashboard components** adapted from `toolbox/docs/pulse-v2/`:
  - `MinimalistDashboard` — dense monospace triage surface
  - `VisualChartDashboard` — Recharts donut + bar charts (lazy-loaded via `React.lazy`)
  - `TabularDashboard` — sortable/filterable table with sticky REPO column
  - `AlertFirstDashboard` — priority-sorted alert list, inverted hierarchy
- **PulseDashboardPage** — fetches `/api/pulse/current`, shows loading skeleton + error state, passes data to selected dashboard
- **PulseLabPage** — index with 4 cards navigating to sub-views via local state
- **Tab wiring** — `"pulse"` added to `Tab` type in `App.tsx`, `TabDock`, `BottomDrawer`, `AppSwitcher`

## Bundle note

`VisualChartDashboard` (Recharts, ~95kB gzip) is lazy-loaded — confirmed separate chunk in build output: `VisualChartDashboard-BHKt9pDB.js`. Other 3 dashboards pay zero Recharts cost.

## Mobile

All dashboards use `overflow-x: hidden` + `max-width: 100%` wrappers. Tabular dashboard sticky REPO header fixed (addresses horizontal-scroll misalignment on 375px).

## Test plan

- [x] `pnpm run build` — clean, no TS errors
- [x] `pnpm --filter @cpc/web test` — 246 tests pass
- [x] `pnpm --filter @cpc/server test` — 271 tests pass
- [x] 3-tier local swarm: Tier 1 (Claude) CLEAN, Tier 2 (Codex) sandbox issue/no output, Tier 3 (Gemini) CLEAN after sticky-header fix applied
- [ ] Smoke test on device — tap Pulse tab, verify all 4 dashboard cards render, verify loading/error states

## Deferred

- `resolveDashboard` switch has a `null` default for `visual-chart` (handled by caller) — cosmetic, low risk, deferred
- `VisualChartDashboard` donut chart mixes vulns-count and repos-count for UNKNOWN slice — this is the upstream source's design, not changed per spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)