### PR TITLE
fix(server): CPC phase 4 OTEL hardening — security + lifecycle + coverage

### DIFF
--- a/apps/server/src/__tests__/otel.test.ts
+++ b/apps/server/src/__tests__/otel.test.ts
@@ -1,16 +1,40 @@
-import { describe, expect, it, vi, beforeEach } from "vitest";
+import { describe, expect, it, beforeAll, afterAll } from "vitest";
+import { SpanStatusCode, trace } from "@opentelemetry/api";
+import {
+  InMemorySpanExporter,
+  SimpleSpanProcessor,
+  BasicTracerProvider,
+  type ReadableSpan,
+} from "@opentelemetry/sdk-trace-base";
 
 /**
- * Smoke tests for the OTEL module.
+ * Smoke + integration tests for the OTEL module.
  *
- * Test 1: Module imports without throwing (side-effect initialisation is safe).
- * Test 2: tracedQuery-style helper returns correct value and emits a span —
- *         validated by mocking @opentelemetry/api's trace.getTracer().
+ *  - otel module smoke: import side-effects + getTracer shape.
+ *  - tracedQuery: the REAL exported helper (formerly the test duplicated the
+ *    function body inline, which meant future db.ts edits couldn't fail the
+ *    test). We now import from db.ts directly so the test tracks reality.
+ *  - DB proxy iterate / configurator coverage: exercises the fixes for
+ *    phase-4 orch swarm HIGH findings H3 (iterate span lifecycle) and H4
+ *    (pluck/raw return the raw Statement, bypassing tracing).
+ *
+ * We install an InMemorySpanExporter via a throwaway BasicTracerProvider
+ * registered as the GLOBAL tracer provider BEFORE importing ../db.js or
+ * ../lib/otel.js. That way the shipping code's `trace.getTracer(...)` calls
+ * resolve to our in-memory provider, and we can inspect the spans that
+ * actually flow through the real code paths.
  */
+
+const memoryExporter = new InMemorySpanExporter();
+const testProvider = new BasicTracerProvider();
+testProvider.addSpanProcessor(new SimpleSpanProcessor(memoryExporter));
+// Register as the global provider BEFORE any code under test imports and
+// calls getTracer. Once a tracer is vended from the global provider, it
+// stays bound to it for the lifetime of that Tracer instance.
+trace.setGlobalTracerProvider(testProvider);
 
 describe("otel module", () => {
   it("imports without throwing", async () => {
-    // Dynamic import — if module-level OTLP setup throws we'd see it here.
     await expect(import("../lib/otel.js")).resolves.not.toThrow();
   });
 
@@ -22,97 +46,139 @@ describe("otel module", () => {
   });
 });
 
-describe("tracedQuery pattern", () => {
-  beforeEach(() => {
-    vi.restoreAllMocks();
+describe("tracedQuery (real export from db.ts)", () => {
+  beforeAll(() => {
+    memoryExporter.reset();
   });
 
-  it("returns the correct value and calls span.end()", () => {
-    // Build a minimal mock span
-    const spanEnd = vi.fn();
-    const spanSetStatus = vi.fn();
-    const spanRecordException = vi.fn();
-    const mockSpan = {
-      end: spanEnd,
-      setStatus: spanSetStatus,
-      recordException: spanRecordException,
-    };
+  it("emits a db.<op> span and returns the callback result", async () => {
+    memoryExporter.reset();
+    const { tracedQuery } = await import("../db.js");
 
-    // Mock getTracer to return a tracer that produces our mock span
-    const startSpan = vi.fn().mockReturnValue(mockSpan);
-    const mockTracer = { startSpan };
-
-    // Replicate the tracedQuery logic to test the pattern
-    function tracedQuery<T>(
-      tracer: typeof mockTracer,
-      op: string,
-      table: string,
-      fn: () => T,
-    ): T {
-      const span = tracer.startSpan(`db.${op.toLowerCase()}`, {
-        attributes: { "db.system": "sqlite", "db.operation": op, "db.sql.table": table },
-      });
-      try {
-        return fn();
-      } catch (err) {
-        span.recordException(err instanceof Error ? err : String(err));
-        span.setStatus({ code: 2 }); // SpanStatusCode.ERROR = 2
-        throw err;
-      } finally {
-        span.end();
-      }
-    }
-
-    const result = tracedQuery(mockTracer, "SELECT", "transcripts", () => 42);
-
+    const result = tracedQuery("SELECT", "transcripts", () => 42);
     expect(result).toBe(42);
-    expect(startSpan).toHaveBeenCalledWith("db.select", {
-      attributes: {
-        "db.system": "sqlite",
-        "db.operation": "SELECT",
-        "db.sql.table": "transcripts",
-      },
-    });
-    expect(spanEnd).toHaveBeenCalledOnce();
-    expect(spanSetStatus).not.toHaveBeenCalled();
+
+    const spans = memoryExporter.getFinishedSpans();
+    const match = spans.find((s: ReadableSpan) => s.name === "db.select");
+    expect(match).toBeDefined();
+    expect(match!.attributes["db.system"]).toBe("sqlite");
+    expect(match!.attributes["db.operation"]).toBe("SELECT");
+    expect(match!.attributes["db.sql.table"]).toBe("transcripts");
+    // Non-error default status is UNSET (code 0), not ERROR (2).
+    expect(match!.status.code).not.toBe(SpanStatusCode.ERROR);
   });
 
-  it("records exception and sets ERROR status when fn throws", () => {
-    const spanEnd = vi.fn();
-    const spanSetStatus = vi.fn();
-    const spanRecordException = vi.fn();
-    const mockSpan = {
-      end: spanEnd,
-      setStatus: spanSetStatus,
-      recordException: spanRecordException,
-    };
-    const startSpan = vi.fn().mockReturnValue(mockSpan);
-    const mockTracer = { startSpan };
-
-    function tracedQuery<T>(
-      tracer: typeof mockTracer,
-      op: string,
-      table: string,
-      fn: () => T,
-    ): T {
-      const span = tracer.startSpan(`db.${op.toLowerCase()}`, {
-        attributes: { "db.system": "sqlite", "db.operation": op, "db.sql.table": table },
-      });
-      try {
-        return fn();
-      } catch (err) {
-        span.recordException(err instanceof Error ? err : String(err));
-        span.setStatus({ code: 2 });
-        throw err;
-      } finally {
-        span.end();
-      }
-    }
+  it("records exception and sets ERROR status when fn throws", async () => {
+    memoryExporter.reset();
+    const { tracedQuery } = await import("../db.js");
 
     const boom = new Error("db exploded");
-    expect(() => tracedQuery(mockTracer, "INSERT", "transcripts", () => { throw boom; })).toThrow("db exploded");
-    expect(spanRecordException).toHaveBeenCalledWith(boom);
-    expect(spanSetStatus).toHaveBeenCalledWith({ code: 2 });
-    expect(spanEnd).toHaveBeenCalledOnce();
+    expect(() =>
+      tracedQuery("INSERT", "transcripts", () => {
+        throw boom;
+      })
+    ).toThrow("db exploded");
+
+    const spans = memoryExporter.getFinishedSpans();
+    const match = spans.find((s: ReadableSpan) => s.name === "db.insert");
+    expect(match).toBeDefined();
+    expect(match!.status.code).toBe(SpanStatusCode.ERROR);
+    // recordException writes an "exception" event onto the span.
+    expect(match!.events.some((e) => e.name === "exception")).toBe(true);
+  });
+});
+
+describe("db Proxy tracing coverage", () => {
+  let dbMod: typeof import("../db.js");
+
+  beforeAll(async () => {
+    dbMod = await import("../db.js");
+  });
+
+  afterAll(() => {
+    // Best-effort: remove any rows this suite inserted to keep the
+    // on-disk dev DB tidy. Harmless if rows already gone.
+    try {
+      dbMod.db
+        .prepare("DELETE FROM transcripts WHERE user_id IN (?, ?)")
+        .run("u-iter", "u-pluck");
+    } catch {
+      /* ignore */
+    }
+  });
+
+  /**
+   * H3: `.iterate()` must NOT end its span before the caller consumes the
+   * iterator. Verify the span's duration spans the full consumption, not
+   * just the synchronous iterate() setup.
+   */
+  it("iterate() span stays open across full consumption", () => {
+    memoryExporter.reset();
+
+    const id = `iter-${Date.now()}-${Math.random()}`;
+    dbMod.db
+      .prepare(
+        `INSERT INTO transcripts (id, user_id, title, body, word_count, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`
+      )
+      .run(id, "u-iter", "t", "b", 1, Date.now(), Date.now());
+
+    const stmt = dbMod.db.prepare("SELECT id FROM transcripts WHERE id = ?");
+    const iter = (
+      stmt as { iterate: (id: string) => IterableIterator<unknown> }
+    ).iterate(id);
+
+    // Before consumption, the iterate span is OPEN — no finished db.select
+    // span should have appeared from the iterate call itself. (There will
+    // be insert-related db.insert spans from setup; we filter for select.)
+    const spansBeforeConsume = memoryExporter
+      .getFinishedSpans()
+      .filter((s: ReadableSpan) => s.name === "db.select");
+    expect(spansBeforeConsume.length).toBe(0);
+
+    // Drain. Sleep briefly between consume and assertion to ensure the
+    // SimpleSpanProcessor has processed the end.
+    const rows = Array.from(iter);
+    expect(rows.length).toBeGreaterThanOrEqual(1);
+
+    const spansAfterConsume = memoryExporter
+      .getFinishedSpans()
+      .filter((s: ReadableSpan) => s.name === "db.select");
+    expect(spansAfterConsume.length).toBe(1);
+
+    // Cleanup
+    dbMod.db.prepare("DELETE FROM transcripts WHERE id = ?").run(id);
+  });
+
+  /**
+   * H4: `.pluck()` must return a traced proxy, not the raw Statement.
+   * Regression shape: if pluck returns the raw stmt, the chained .get() is
+   * unproxied and emits zero spans.
+   */
+  it("pluck() chain still emits a db.select span on .get()", () => {
+    const id = `pluck-${Date.now()}-${Math.random()}`;
+    dbMod.db
+      .prepare(
+        `INSERT INTO transcripts (id, user_id, title, body, word_count, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`
+      )
+      .run(id, "u-pluck", "t", "b", 1, Date.now(), Date.now());
+
+    memoryExporter.reset();
+
+    const stmt = dbMod.db.prepare(
+      "SELECT id FROM transcripts WHERE id = ?"
+    );
+    const plucked = (stmt as { pluck: () => typeof stmt }).pluck();
+    const result = plucked.get(id);
+    expect(result).toBe(id);
+
+    const selects = memoryExporter
+      .getFinishedSpans()
+      .filter((s: ReadableSpan) => s.name === "db.select");
+    expect(selects.length).toBe(1);
+
+    // Cleanup
+    dbMod.db.prepare("DELETE FROM transcripts WHERE id = ?").run(id);
   });
 });

--- a/apps/server/src/db.ts
+++ b/apps/server/src/db.ts
@@ -51,19 +51,24 @@ export function tracedQuery<T>(op: string, table: string, fn: () => T): T {
 //     any error raised during iteration. Instead we hand back an iterator that
 //     starts the span eagerly and ends it on exhaustion, early return, or throw.
 //
-//  3. CONFIGURATOR_METHODS (`pluck`, `expand`, `raw`, `safeIntegers`, `columns`,
-//     `bind`) — mutate the statement and return `this` for chaining. Returning
-//     the raw `s` here would hand the caller an UNPROXIED statement, so the
-//     subsequent `.get()/.all()/.iterate()` would bypass all tracing. We
-//     re-route these to run the configurator on `s` and return the outer
-//     Proxy so tracing stays intact across the chain.
+//  3. CONFIGURATOR_METHODS (`pluck`, `expand`, `raw`, `safeIntegers`, `bind`) —
+//     mutate the statement and return `this` for chaining. Returning the raw
+//     `s` here would hand the caller an UNPROXIED statement, so the subsequent
+//     `.get()/.all()/.iterate()` would bypass all tracing. We re-route these
+//     to run the configurator on `s` and return the outer Proxy so tracing
+//     stays intact across the chain.
+//
+//     NOTE: `columns()` is deliberately EXCLUDED. Despite being a configurator-
+//     adjacent introspection API, it returns `ColumnDefinition[]`, not `this`
+//     — wrapping it here would replace that array with the statement proxy and
+//     break callers. It falls through to the default branch which returns the
+//     method bound to the real statement.
 const TRACED_SYNC_METHODS = new Set(['get', 'all', 'run']);
 const CONFIGURATOR_METHODS = new Set([
   'pluck',
   'expand',
   'raw',
   'safeIntegers',
-  'columns',
   'bind',
 ]);
 

--- a/apps/server/src/db.ts
+++ b/apps/server/src/db.ts
@@ -22,7 +22,7 @@ function extractOperation(sql: string): string {
 
 const dbTracer = getTracer('cpc-server-db');
 
-function tracedQuery<T>(op: string, table: string, fn: () => T): T {
+export function tracedQuery<T>(op: string, table: string, fn: () => T): T {
   const span = dbTracer.startSpan(`db.${op.toLowerCase()}`, {
     attributes: { 'db.system': 'sqlite', 'db.operation': op, 'db.sql.table': table },
   });
@@ -38,11 +38,34 @@ function tracedQuery<T>(op: string, table: string, fn: () => T): T {
 }
 
 // Proxy wrapping ALL .prepare() usage.
-// Only trace actual execution methods — pluck/expand/raw are configurators that
-// return `this` for chaining (e.g. stmt.pluck().get(params)). Intercepting them
-// with tracedQuery would return the unproxied statement, losing span coverage on
-// the subsequent .get()/.all()/.run() call.
-const TRACED_STMT_METHODS = ['get', 'all', 'run', 'iterate'] as const;
+//
+// Three classes of method need distinct handling:
+//
+//  1. TRACED_SYNC_METHODS (`get`, `all`, `run`) — synchronous execute-and-return.
+//     Wrap the whole call in tracedQuery so the span captures elapsed time +
+//     any thrown error.
+//
+//  2. `iterate` — returns a lazy iterator SYNCHRONOUSLY; the actual row fetches
+//     happen later as the caller consumes the iterator. Wrapping it like a sync
+//     method ends the span before any row is pulled, recording ~0µs and missing
+//     any error raised during iteration. Instead we hand back an iterator that
+//     starts the span eagerly and ends it on exhaustion, early return, or throw.
+//
+//  3. CONFIGURATOR_METHODS (`pluck`, `expand`, `raw`, `safeIntegers`, `columns`,
+//     `bind`) — mutate the statement and return `this` for chaining. Returning
+//     the raw `s` here would hand the caller an UNPROXIED statement, so the
+//     subsequent `.get()/.all()/.iterate()` would bypass all tracing. We
+//     re-route these to run the configurator on `s` and return the outer
+//     Proxy so tracing stays intact across the chain.
+const TRACED_SYNC_METHODS = new Set(['get', 'all', 'run']);
+const CONFIGURATOR_METHODS = new Set([
+  'pluck',
+  'expand',
+  'raw',
+  'safeIntegers',
+  'columns',
+  'bind',
+]);
 
 export const db: DatabaseType = new Proxy(rawDb, {
   get(target, prop) {
@@ -51,17 +74,106 @@ export const db: DatabaseType = new Proxy(rawDb, {
         const stmt = target.prepare(sql);
         const table = extractTable(sql);
         const op = extractOperation(sql);
-        return new Proxy(stmt, {
+        const stmtProxy: typeof stmt = new Proxy(stmt, {
           get(s, method) {
-            if ((TRACED_STMT_METHODS as readonly string[]).includes(method as string)) {
+            const methodStr = method as string;
+
+            if (TRACED_SYNC_METHODS.has(methodStr)) {
               return (...args: unknown[]) =>
-                tracedQuery(op, table, () => Reflect.apply(s[method as keyof typeof s] as Function, s, args));
+                tracedQuery(op, table, () =>
+                  Reflect.apply(s[method as keyof typeof s] as Function, s, args)
+                );
             }
+
+            if (methodStr === 'iterate') {
+              return (...args: unknown[]) => {
+                // Start the span BEFORE invoking iterate so we capture
+                // any throw from the prepare/bind phase, and keep it
+                // open across the full consumer loop. We end it on
+                // StopIteration, caller-initiated .return(), or .throw().
+                const span = dbTracer.startSpan(`db.${op.toLowerCase()}`, {
+                  attributes: {
+                    'db.system': 'sqlite',
+                    'db.operation': op,
+                    'db.sql.table': table,
+                  },
+                });
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                let innerIter: IterableIterator<unknown> & { return?: (value?: any) => IteratorResult<unknown> };
+                try {
+                  innerIter = Reflect.apply(
+                    s.iterate as Function,
+                    s,
+                    args
+                  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                  ) as any;
+                } catch (err) {
+                  span.recordException(err instanceof Error ? err : String(err));
+                  span.setStatus({ code: SpanStatusCode.ERROR });
+                  span.end();
+                  throw err;
+                }
+                // Hand back a wrapper iterator that delegates to the inner
+                // better-sqlite3 iterator but ends the span exactly once,
+                // on whichever exit path fires first. Using an explicit
+                // iterator object (not a generator) avoids double-calling
+                // `.return()` on the underlying cursor, which previously
+                // left the DB connection in a "busy" state.
+                let ended = false;
+                const endOnce = () => {
+                  if (ended) return;
+                  ended = true;
+                  span.end();
+                };
+                const wrapper: IterableIterator<unknown> = {
+                  [Symbol.iterator]() { return this; },
+                  next() {
+                    try {
+                      const result = innerIter.next();
+                      if (result.done) endOnce();
+                      return result;
+                    } catch (err) {
+                      span.recordException(err instanceof Error ? err : String(err));
+                      span.setStatus({ code: SpanStatusCode.ERROR });
+                      endOnce();
+                      throw err;
+                    }
+                  },
+                  return(value?: unknown): IteratorResult<unknown> {
+                    try {
+                      const r = innerIter.return?.(value) ?? { value: undefined, done: true };
+                      endOnce();
+                      return r;
+                    } catch (err) {
+                      span.recordException(err instanceof Error ? err : String(err));
+                      span.setStatus({ code: SpanStatusCode.ERROR });
+                      endOnce();
+                      throw err;
+                    }
+                  },
+                };
+                return wrapper;
+              };
+            }
+
+            if (CONFIGURATOR_METHODS.has(methodStr)) {
+              const orig = s[method as keyof typeof s] as Function | undefined;
+              if (typeof orig !== 'function') return orig;
+              return (...args: unknown[]) => {
+                // Run the configurator on the underlying statement, then
+                // return the outer proxy so subsequent chained calls
+                // (.get / .all / .iterate) remain traced.
+                Reflect.apply(orig, s, args);
+                return stmtProxy;
+              };
+            }
+
             const val = s[method as keyof typeof s];
             if (typeof val === 'function') return (val as Function).bind(s);
             return val;
           },
         });
+        return stmtProxy;
       };
     }
     const val = target[prop as keyof typeof target];

--- a/apps/server/src/db.ts
+++ b/apps/server/src/db.ts
@@ -156,6 +156,35 @@ export const db: DatabaseType = new Proxy(rawDb, {
                       throw err;
                     }
                   },
+                  // `throw()` is rarely used but part of the Iterator protocol;
+                  // forward to the inner iterator if it supports throw, otherwise
+                  // record the error, end the span, and re-throw so the caller
+                  // still sees the exception.
+                  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                  throw(err?: any): IteratorResult<unknown> {
+                    try {
+                      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                      const innerThrow = (innerIter as any).throw as
+                        | ((e?: unknown) => IteratorResult<unknown>)
+                        | undefined;
+                      if (typeof innerThrow === 'function') {
+                        const r = innerThrow.call(innerIter, err);
+                        endOnce();
+                        return r;
+                      }
+                      // No inner throw — simulate protocol by recording +
+                      // rethrowing. Caller gets the error they handed us.
+                      span.recordException(err instanceof Error ? err : String(err));
+                      span.setStatus({ code: SpanStatusCode.ERROR });
+                      endOnce();
+                      throw err;
+                    } catch (thrownErr) {
+                      span.recordException(thrownErr instanceof Error ? thrownErr : String(thrownErr));
+                      span.setStatus({ code: SpanStatusCode.ERROR });
+                      endOnce();
+                      throw thrownErr;
+                    }
+                  },
                 };
                 return wrapper;
               };

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -69,13 +69,48 @@ app.use('/api/*', async (c, next) => {
   c.req.raw.headers.forEach((v, k) => { headers[k] = v; });
   const parentCtx = propagation.extract(otelContext.active(), headers);
 
+  // Start with the middleware mount path as the route; we refine it after
+  // next() runs, once Hono has resolved the matched handler. `c.req.routePath`
+  // inside middleware returns the MIDDLEWARE's own pattern (`/api/*`), not the
+  // matched handler's path — so we must wait until after next() and read the
+  // matched-route metadata instead. See Hono docs on `matchedRoutes`.
   const span = httpTracer.startSpan(`${c.req.method} /api/*`, {
     attributes: { 'http.method': c.req.method },
   }, parentCtx);
   await otelContext.with(trace.setSpan(parentCtx, span), async () => {
     try {
       await next();
-      span.setAttribute('http.route', c.req.routePath);
+      // Resolve the matched handler's route after next() has returned.
+      // Prefer the last entry in `matchedRoutes` that isn't this middleware's
+      // own mount pattern; fall back to `routePath`, then `/api/*`.
+      let matchedPath = '/api/*';
+      try {
+        // hono exposes `matchedRoutes` as an array of `{ path, method, handler }`.
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const matched = (c.req as any).matchedRoutes as
+          | Array<{ path: string; method?: string }>
+          | undefined;
+        if (Array.isArray(matched) && matched.length > 0) {
+          // Walk from the end looking for a specific route (not a catch-all
+          // middleware mount like `/api/*`). This covers the common case
+          // where the matched application handler is the last entry.
+          for (let i = matched.length - 1; i >= 0; i--) {
+            const p = matched[i]?.path;
+            if (p && !p.endsWith('/*')) { matchedPath = p; break; }
+          }
+          if (matchedPath === '/api/*') {
+            // Fall back to the last matched path even if it's a wildcard.
+            matchedPath = matched[matched.length - 1]?.path ?? matchedPath;
+          }
+        } else {
+          matchedPath = c.req.routePath ?? matchedPath;
+        }
+      } catch {
+        // Hono getter threw — keep the /api/* default rather than 500 the
+        // request (defence-in-depth around a telemetry-only attribute).
+      }
+      span.setAttribute('http.route', matchedPath);
+      span.updateName(`${c.req.method} ${matchedPath}`);
       span.setAttribute('http.status_code', c.res.status);
       if (c.res.status >= 500) span.setStatus({ code: SpanStatusCode.ERROR });
     } catch (err) {

--- a/apps/server/src/lib/otel.ts
+++ b/apps/server/src/lib/otel.ts
@@ -1,6 +1,12 @@
 import fs from 'node:fs/promises';
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
-import { BatchSpanProcessor, SimpleSpanProcessor, ConsoleSpanExporter } from '@opentelemetry/sdk-trace-base';
+import {
+  BatchSpanProcessor,
+  SimpleSpanProcessor,
+  ConsoleSpanExporter,
+  ParentBasedSampler,
+  TraceIdRatioBasedSampler,
+} from '@opentelemetry/sdk-trace-base';
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
 import { MeterProvider, PeriodicExportingMetricReader } from '@opentelemetry/sdk-metrics';
 import { OTLPMetricExporter } from '@opentelemetry/exporter-metrics-otlp-http';
@@ -16,7 +22,20 @@ const resource = new Resource({
 });
 
 // ── Traces ────────────────────────────────────────────────────────────────────
-const provider = new NodeTracerProvider({ resource });
+// Sampling: default to 10% of root traces — the previous always-on default
+// combined with per-call spans (isPathAllowed, db statements) could overflow
+// BatchSpanProcessor's buffer under load, silently dropping spans. The env
+// var OTEL_TRACES_SAMPLE_RATE lets ops tune (0.0–1.0). Wrapping in
+// ParentBasedSampler honors upstream sampling decisions — if Alloy or another
+// caller propagates a sampled trace, we inherit that decision instead of
+// re-rolling and potentially breaking a trace mid-flight.
+const sampleRateEnv = process.env['OTEL_TRACES_SAMPLE_RATE'];
+const parsed = sampleRateEnv !== undefined ? parseFloat(sampleRateEnv) : NaN;
+const sampleRate = Number.isFinite(parsed) ? Math.min(1, Math.max(0, parsed)) : 0.1;
+const sampler = new ParentBasedSampler({
+  root: new TraceIdRatioBasedSampler(sampleRate),
+});
+const provider = new NodeTracerProvider({ resource, sampler });
 
 // OTLPTraceExporter silently drops spans when the collector is absent — no process crash.
 // Use BatchSpanProcessor in prod (non-blocking buffer flush) and SimpleSpanProcessor in dev.

--- a/apps/server/src/routes/__tests__/voice.test.ts
+++ b/apps/server/src/routes/__tests__/voice.test.ts
@@ -27,7 +27,29 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
  *     voiceRoute and injects a fake user.
  */
 
-const execFileSyncSpy = vi.fn((_bin: string, _args: string[]) => "hello world\n");
+// The shipping code switched from `execFileSync` (blocking, no timeout) to
+// promisified `execFile` so the audio.transcribe span always ends (see
+// phase-4 orch swarm M4). `util.promisify` without a custom symbol converts
+// a node-style callback (err, value) into a Promise resolving to `value`.
+// Our stub resolves with an `{stdout, stderr}` object so the awaiting code
+// destructures `{ stdout }` correctly.
+//
+// The mock module replaces `execFile` entirely (no promisify.custom), which
+// forces `promisify` down its default path — our spy's callback delivers
+// `{stdout, stderr}` as the single value arg.
+const execFileSpy = vi.fn((
+  _bin: string,
+  _args: string[],
+  optsOrCb: unknown,
+  maybeCb?: (err: Error | null, value: { stdout: string; stderr: string }) => void,
+) => {
+  const cb =
+    typeof optsOrCb === "function"
+      ? (optsOrCb as (err: Error | null, value: { stdout: string; stderr: string }) => void)
+      : maybeCb;
+  cb?.(null, { stdout: "hello world\n", stderr: "" });
+  return { kill: vi.fn() } as unknown as import("node:child_process").ChildProcess;
+});
 const writeFileSpy = vi.fn((_path: string, _data: any) => {});
 const unlinkSpy = vi.fn((_path: string) => {});
 
@@ -35,7 +57,7 @@ vi.mock("node:child_process", async () => {
   const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
   return {
     ...actual,
-    execFileSync: execFileSyncSpy,
+    execFile: execFileSpy,
   };
 });
 
@@ -80,7 +102,7 @@ app.use("*", async (c, next) => {
 app.route("/api/voice", voiceRoute);
 
 beforeEach(() => {
-  execFileSyncSpy.mockClear();
+  execFileSpy.mockClear();
   writeFileSpy.mockClear();
   unlinkSpy.mockClear();
 });
@@ -108,35 +130,35 @@ describe("/transcribe extension allowlist (M-4)", () => {
     // The rejection must happen BEFORE writeFileSync (no tmp file created)
     // and BEFORE execFileSync (no transcribe invocation).
     expect(writeFileSpy).not.toHaveBeenCalled();
-    expect(execFileSyncSpy).not.toHaveBeenCalled();
+    expect(execFileSpy).not.toHaveBeenCalled();
   });
 
   it("rejects a filename whose extension contains command substitution", async () => {
     const { status, body } = await postTranscribe("audio.$(whoami)");
     expect(status).toBe(400);
     expect(body.error).toMatch(/unsupported audio extension/);
-    expect(execFileSyncSpy).not.toHaveBeenCalled();
+    expect(execFileSpy).not.toHaveBeenCalled();
   });
 
   it("rejects a completely unknown extension like .exe", async () => {
     const { status, body } = await postTranscribe("malware.exe");
     expect(status).toBe(400);
     expect(body.error).toMatch(/unsupported audio extension/);
-    expect(execFileSyncSpy).not.toHaveBeenCalled();
+    expect(execFileSpy).not.toHaveBeenCalled();
   });
 
   it("rejects a filename whose extension is a pipe to another command", async () => {
     const { status } = await postTranscribe("audio.mp3|nc evil 1234");
     expect(status).toBe(400);
-    expect(execFileSyncSpy).not.toHaveBeenCalled();
+    expect(execFileSpy).not.toHaveBeenCalled();
   });
 
-  it("accepts a .mp3 upload and calls execFileSync with an argv array", async () => {
+  it("accepts a .mp3 upload and calls execFile with an argv array", async () => {
     const { status, body } = await postTranscribe("song.mp3");
     expect(status).toBe(200);
     expect(body.text).toBe("hello world");
-    expect(execFileSyncSpy).toHaveBeenCalledTimes(1);
-    const [bin, args] = execFileSyncSpy.mock.calls[0];
+    expect(execFileSpy).toHaveBeenCalledTimes(1);
+    const [bin, args] = execFileSpy.mock.calls[0];
     expect(bin).toMatch(/bin\/transcribe$/);
     // Second arg is the argv array — a single element (the tmp path).
     expect(Array.isArray(args)).toBe(true);
@@ -148,10 +170,10 @@ describe("/transcribe extension allowlist (M-4)", () => {
     // Pared-down coverage of the allowlist — one per token.
     const exts = ["wav", "ogg", "webm", "m4a", "flac", "opus", "oga", "mp4", "aac"];
     for (const ext of exts) {
-      execFileSyncSpy.mockClear();
+      execFileSpy.mockClear();
       const { status } = await postTranscribe(`clip.${ext}`);
       expect(status, `ext=${ext}`).toBe(200);
-      expect(execFileSyncSpy, `ext=${ext}`).toHaveBeenCalledTimes(1);
+      expect(execFileSpy, `ext=${ext}`).toHaveBeenCalledTimes(1);
     }
   });
 

--- a/apps/server/src/routes/terminal/slash-commands.ts
+++ b/apps/server/src/routes/terminal/slash-commands.ts
@@ -81,10 +81,14 @@ app.post("/send-keys", async (c) => {
         execFileAsync("tmux", ["send-keys", "-t", TMUX_SESSION, ...tokens])
       );
     } else {
-      // Literal text — use -l to avoid special char issues, then Enter
+      // Literal text — use execFile (no shell) with `-l` and `--` so user
+      // input cannot inject via $(...) or backticks. The previous execAsync
+      // path spawned /bin/sh -c on an interpolated string; JSON.stringify
+      // only quotes for JS, NOT for shells, so `$(...)` and backticks in the
+      // keys survived the quote and were executed by sh BEFORE tmux saw them.
       await tracedTmux('tmux.send-keys', TMUX_SESSION, 'literal', async () => {
-        await execAsync(`tmux send-keys -t ${TMUX_SESSION} -l ${JSON.stringify(keys)}`);
-        await execAsync(`tmux send-keys -t ${TMUX_SESSION} Enter`);
+        await execFileAsync("tmux", ["send-keys", "-t", TMUX_SESSION, "-l", "--", keys]);
+        await execFileAsync("tmux", ["send-keys", "-t", TMUX_SESSION, "Enter"]);
       });
     }
     return c.json({ ok: true, action: "send-keys" });
@@ -99,10 +103,11 @@ app.post("/compact", async (c) => {
     const message = body.message as string;
     if (!message) return c.json({ ok: false, error: "message required" }, 400);
 
-    // Send via tmux send-keys
+    // Send via tmux send-keys — execFile (no shell) with -l + -- so the
+    // user-provided message cannot inject via $(...) or backticks.
     await tracedTmux('tmux.compact', TMUX_SESSION, 'compact', async () => {
-      await execAsync(`tmux send-keys -t ${TMUX_SESSION} -l ${JSON.stringify(message)}`);
-      await execAsync(`tmux send-keys -t ${TMUX_SESSION} Enter`);
+      await execFileAsync("tmux", ["send-keys", "-t", TMUX_SESSION, "-l", "--", message]);
+      await execFileAsync("tmux", ["send-keys", "-t", TMUX_SESSION, "Enter"]);
     });
     return c.json({ ok: true, action: "compact" });
   } catch (err: any) {

--- a/apps/server/src/routes/voice.ts
+++ b/apps/server/src/routes/voice.ts
@@ -109,33 +109,38 @@ app.post("/transcribe", async (c) => {
     });
     let text: string;
     try {
-      // execFile (async) with a timeout so the event loop isn't blocked and
-      // the span always ends even if the child hangs. encoding: "utf-8"
-      // returns stdout as a string. maxBuffer bumped to 10 MiB to cover
-      // long transcripts (default 1 MiB would truncate noisy multi-minute
-      // recordings).
-      const { stdout } = await execFileAsync(transcribeBin, [tmpPath], {
-        encoding: "utf-8",
-        env: { ...process.env },
-        timeout: TRANSCRIBE_TIMEOUT_MS,
-        maxBuffer: 10 * 1024 * 1024,
-      });
-      text = stdout.trim();
-    } catch (err) {
-      // Node surfaces a SIGTERM with `code === null` and `signal === 'SIGTERM'`
-      // (or `killed: true`) when the timeout fires. Tag those distinctly so
-      // operators can filter transcribe-timeouts vs real transcribe errors.
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const e = err as any;
-      if (e && (e.killed === true || e.signal === 'SIGTERM')) {
-        span.setAttribute('error.type', 'timeout');
+      try {
+        // execFile (async) with a timeout so the event loop isn't blocked and
+        // the span always ends even if the child hangs. encoding: "utf-8"
+        // returns stdout as a string. maxBuffer bumped to 10 MiB to cover
+        // long transcripts (default 1 MiB would truncate noisy multi-minute
+        // recordings).
+        const { stdout } = await execFileAsync(transcribeBin, [tmpPath], {
+          encoding: "utf-8",
+          env: { ...process.env },
+          timeout: TRANSCRIBE_TIMEOUT_MS,
+          maxBuffer: 10 * 1024 * 1024,
+        });
+        text = stdout.trim();
+      } catch (err) {
+        // Node surfaces a SIGTERM with `code === null` and `signal === 'SIGTERM'`
+        // (or `killed: true`) when the timeout fires. Tag those distinctly so
+        // operators can filter transcribe-timeouts vs real transcribe errors.
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const e = err as any;
+        if (e && (e.killed === true || e.signal === 'SIGTERM')) {
+          span.setAttribute('error.type', 'timeout');
+        }
+        span.recordException(err instanceof Error ? err : String(err));
+        span.setStatus({ code: SpanStatusCode.ERROR });
+        throw err;
       }
-      span.recordException(err instanceof Error ? err : String(err));
-      span.setStatus({ code: SpanStatusCode.ERROR });
+    } finally {
+      // Single end() path (finally) so a throw between startSpan and the
+      // inner try can never leak the span. Defence-in-depth vs the prior
+      // two-call shape.
       span.end();
-      throw err;
     }
-    span.end();
 
     return c.json({ text });
   } catch (err: any) {

--- a/apps/server/src/routes/voice.ts
+++ b/apps/server/src/routes/voice.ts
@@ -2,12 +2,24 @@ import { Hono } from "hono";
 import { writeFileSync, unlinkSync, readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { execFileSync } from "node:child_process";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
 import { nanoid } from "nanoid";
 import { db } from "../db.js";
 import { getUserId as getUserIdShared } from "../lib/get-user-id.js";
 import { getTracer } from "../lib/otel.js";
 import { SpanStatusCode } from "@opentelemetry/api";
+
+const execFileAsync = promisify(execFile);
+
+// Hard cap on the transcribe child process. Previously execFileSync had no
+// timeout, so a hung transcribe (network wedge, model hang, etc.) would
+// block the Node event loop indefinitely AND orphan the `audio.transcribe`
+// span — never ending means BatchSpanProcessor never exports it, eventually
+// overflowing the buffer. On timeout execFile SIGTERMs the child; we set
+// error status + `error.type=timeout` before span.end() so operators can
+// spot these in the trace backend.
+const TRANSCRIBE_TIMEOUT_MS = 60_000;
 
 /**
  * Allowlist for uploaded-audio file extensions. Anything outside this set is
@@ -97,12 +109,27 @@ app.post("/transcribe", async (c) => {
     });
     let text: string;
     try {
-      const result = execFileSync(transcribeBin, [tmpPath], {
+      // execFile (async) with a timeout so the event loop isn't blocked and
+      // the span always ends even if the child hangs. encoding: "utf-8"
+      // returns stdout as a string. maxBuffer bumped to 10 MiB to cover
+      // long transcripts (default 1 MiB would truncate noisy multi-minute
+      // recordings).
+      const { stdout } = await execFileAsync(transcribeBin, [tmpPath], {
         encoding: "utf-8",
         env: { ...process.env },
+        timeout: TRANSCRIBE_TIMEOUT_MS,
+        maxBuffer: 10 * 1024 * 1024,
       });
-      text = result.trim();
+      text = stdout.trim();
     } catch (err) {
+      // Node surfaces a SIGTERM with `code === null` and `signal === 'SIGTERM'`
+      // (or `killed: true`) when the timeout fires. Tag those distinctly so
+      // operators can filter transcribe-timeouts vs real transcribe errors.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const e = err as any;
+      if (e && (e.killed === true || e.signal === 'SIGTERM')) {
+        span.setAttribute('error.type', 'timeout');
+      }
       span.recordException(err instanceof Error ? err : String(err));
       span.setStatus({ code: SpanStatusCode.ERROR });
       span.end();


### PR DESCRIPTION
Post-merge orch-swarm review of PR #271 (phase-4 OTEL SDK instrumentation, merged as `e099b69`) surfaced 5 HIGH + 3 MEDIUM findings. This is the consolidated hotfix.

Full review: https://github.com/claudes-world/claude-pocket-console/pull/271#issuecomment-4300693802

## Fixes

### HIGH — Security (pre-existing, exposed by OTEL review)
- **S1** `apps/server/src/routes/terminal/slash-commands.ts` `/send-keys` literal branch — `execAsync` with JS-quoted shell string → `execFileAsync` with argv array + `--` separator. Shell injection via `$(...)` / backticks in authed-user `keys` no longer reaches `/bin/sh -c`.
- **S2** same file, `/compact` route — same fix for user-controlled `message`.

### HIGH — DB lifecycle / coverage
- **H3** `apps/server/src/db.ts` — `.iterate()` now returns a wrapper iterator (with `next` / `return` / `throw`) that ends the span on exhaustion, early return, or throw. Previously the surrounding `finally { span.end() }` fired immediately after `iterate()` returned the (unconsumed) iterator, recording ~0µs and missing any iteration-time error.
- **H4** same file — `.pluck()` / `.expand()` / `.raw()` / `.safeIntegers()` / `.bind()` now return the outer Proxy (not the raw Statement), so chained `.get()/.all()/.iterate()` stay traced. `columns()` is deliberately NOT wrapped — it returns `ColumnDefinition[]`, not `this` (caught by codex swarm r1).
- **H5** `apps/server/src/__tests__/otel.test.ts` — `tracedQuery` now EXPORTED from `db.ts`; the test imports the real helper and uses `InMemorySpanExporter` against the actual proxy, so future `db.ts` edits can actually fail the test. Added coverage for iterate-span lifecycle and pluck-chain tracing.

### MEDIUM
- **M1** `apps/server/src/index.ts` — `http.route` resolved AFTER `next()` via `c.req.matchedRoutes` (walks end-to-start, skips catch-all patterns, falls back to `routePath`). Previously reported the middleware's own `/api/*` mount pattern for every request. Span also renamed via `updateName` so traces show `GET /api/voice/transcribe`, not `GET /api/*`.
- **M2** `apps/server/src/lib/otel.ts` — `ParentBased(TraceIdRatioBased)` sampler at 10% default, tunable via `OTEL_TRACES_SAMPLE_RATE` (NaN / negative / >1 all clamped). Previously always-on sampling combined with per-call spans risked `BatchSpanProcessor` buffer overflow under load.
- **M4** `apps/server/src/routes/voice.ts` — `execFileSync` → async `execFile` with 60s timeout, 10 MiB `maxBuffer`, timeout-vs-error attribution (`error.type=timeout`), single `span.end()` in a `finally` block. Previously a hung transcribe blocked the event loop AND orphaned the span forever.

## Swarm review

Local 3-tier pre-push swarm (cloud-thrift mode — orch to run cloud swarm independently):

| Round | Codex | Gemini flash | Claude tier 1 (inline) |
|-------|-------|--------------|------------------------|
| r1 | 1 MED (columns() mis-included) | CLEAN | CLEAN |
| r2 | CLEAN | 2 HIGH false-positive + 1 MED (iterate throw()) + 1 LOW cosmetic | N/A |
| r3 | CLEAN | CLEAN | N/A |

**r1 MED fix**: dropped `columns` from `CONFIGURATOR_METHODS` (returns `ColumnDefinition[]`, not `this`).
**r2 MED fix**: added `Iterator.throw()` to the iterate wrapper for protocol completeness. Two r2 HIGHs were false positives (verified against TS types + actual code path) but took the voice-finally refactor anyway for defence-in-depth.

Swarm converged clean at r3.

## Tests

- `pnpm --filter @cpc/server test` → 277/277 pass
- `pnpm --filter @cpc/server tsc --noEmit` → clean
- Security smoke: `grep 'execAsync.*tmux.*JSON\.stringify' apps/server/src/routes/terminal/slash-commands.ts` → 0 matches

## Out of scope (deferred)
- LOW findings from the phase-4 swarm (isPathAllowed sampling, WAL size gauge cadence, etc.) — to be filed as separate GH issues by the orchestrator.
- Frontend (`apps/web/`) untouched.

## Release plan
After merge to `dev` + orch-swarm clean, Liam will tag a `main` release. Current prod = `v1.12.0` which has the shell injection live; this is the urgent fix for that.