### PR TITLE
fix(systemd): hardened service units — StartLimitBurst + ExecStartPost (#26, #27)

### DIFF
--- a/systemd/user/cpc-dev.service
+++ b/systemd/user/cpc-dev.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Claude Pocket Console — dev (Vite + tsx watch)
+After=network-online.target
+StartLimitIntervalSec=120
+StartLimitBurst=5
+
+[Service]
+Type=simple
+WorkingDirectory=/home/claude/code/claude-pocket-console
+Environment=PORT=38831
+Environment=PATH=/home/claude/.local/share/fnm/aliases/default/bin:/home/claude/.local/bin:/home/claude/bin:/usr/local/bin:/usr/bin:/bin
+ExecStart=/home/claude/.local/bin/pnpm dev
+ExecStartPost=/home/claude/code/toolbox/lib/systemd-wait-port.sh 38831
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=default.target

--- a/systemd/user/cpc.service
+++ b/systemd/user/cpc.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Claude Pocket Console — prod (latest tagged release)
+After=network-online.target
+StartLimitIntervalSec=120
+StartLimitBurst=5
+
+[Service]
+Type=simple
+WorkingDirectory=/home/claude/code/claude-pocket-console-prod
+Environment=PORT=38830
+Environment=NODE_ENV=production
+Environment=PATH=/home/claude/.local/share/fnm/aliases/default/bin:/home/claude/.local/bin:/home/claude/bin:/usr/local/bin:/usr/bin:/bin
+ExecStart=/home/claude/.local/share/fnm/aliases/default/bin/node apps/server/dist/index.js
+ExecStartPost=/home/claude/code/toolbox/lib/systemd-wait-port.sh 38830
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
## Summary
- Add tracked `systemd/user/` directory to CPC repo (first time)
- `cpc.service` (prod, port 38830) + `cpc-dev.service` (dev, port 38831): `StartLimitIntervalSec=120` + `StartLimitBurst=5` so crash-loops flip to `failed` state
- `ExecStartPost` port-bind verification via shared `toolbox/lib/systemd-wait-port.sh`
- `cpc-dev.service` port 38831 is the incident port — this is the direct prevention for the 5-day silent crash-loop

Part of claudes-world/do-box#26 + claudes-world/do-box#27 (umbrella).

## Test plan
- [ ] `bash -n systemd/user/cpc.service` — syntax clean (systemd file, not bash, but basic check)
- [ ] Confirm `WorkingDirectory` in `cpc.service` points to `-prod` clone (correct — different from dev)
- [ ] Port 38831 matches `cpc-dev.service` `Environment=PORT=38831` line