### PR TITLE
release: clean dev — keep OTEL/systemd/file-browser/deps, strip Navigation Redesign v2

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,11 +44,11 @@ plugin. Do not try to set or change keyboard buttons from CPC.
 - Call `Telegram.WebApp.enableVerticalSwipes()` on close (cleanup in useEffect).
 - If you skip this, Telegram will minimize the app when users swipe down.
 
-### Git Safety
+### Git Safety + Branching
 
 - **Never `git checkout`/`restore` uncommitted work.** Always commit first.
-- **Always check `git branch` before making changes.** Never commit to `main`.
-- Work on `dev` or `feat/*` branches. Use `/deploy` skill to ship to prod.
+- **Branching:** 4-level hierarchy `feat/###-issue-PR → dev-<group> → dev → main`. Only orch merges to dev. Only Liam merges to main. Full rules: `docs/conventions/gitflow.md` (local) + `~/claudes-world/knowledge/adr/0018-gitflow-light-pr-branching.md` (canonical) + `~/claudes-world/knowledge/sop/feature-group-branching.md` (worked example).
+- Work on `dev` or `feat/*` branches (or `dev-<group>` for grouped features). Use `/deploy` skill to ship to prod.
 
 ### Camera / Media
 

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -16,7 +16,7 @@
     "@hono/node-server": "^1",
     "@hono/node-ws": "^1",
     "better-sqlite3": "^12.8.0",
-    "hono": "^4",
+    "hono": "^4.12.14",
     "nanoid": "^5.1.7"
   },
   "devDependencies": {

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -15,6 +15,14 @@
   "dependencies": {
     "@hono/node-server": "^1",
     "@hono/node-ws": "^1",
+    "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/exporter-metrics-otlp-http": "0.57.2",
+    "@opentelemetry/exporter-trace-otlp-http": "0.57.2",
+    "@opentelemetry/resources": "^1.30.0",
+    "@opentelemetry/sdk-metrics": "^1.30.1",
+    "@opentelemetry/sdk-trace-base": "^1.30.0",
+    "@opentelemetry/sdk-trace-node": "^1.30.0",
+    "@opentelemetry/semantic-conventions": "^1.28.0",
     "better-sqlite3": "^12.8.0",
     "hono": "^4.12.14",
     "nanoid": "^5.1.7"

--- a/apps/server/src/__tests__/otel.test.ts
+++ b/apps/server/src/__tests__/otel.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+/**
+ * Smoke tests for the OTEL module.
+ *
+ * Test 1: Module imports without throwing (side-effect initialisation is safe).
+ * Test 2: tracedQuery-style helper returns correct value and emits a span —
+ *         validated by mocking @opentelemetry/api's trace.getTracer().
+ */
+
+describe("otel module", () => {
+  it("imports without throwing", async () => {
+    // Dynamic import — if module-level OTLP setup throws we'd see it here.
+    await expect(import("../lib/otel.js")).resolves.not.toThrow();
+  });
+
+  it("getTracer returns a tracer object", async () => {
+    const { getTracer } = await import("../lib/otel.js");
+    const tracer = getTracer("test-tracer");
+    expect(tracer).toBeDefined();
+    expect(typeof tracer.startSpan).toBe("function");
+  });
+});
+
+describe("tracedQuery pattern", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns the correct value and calls span.end()", () => {
+    // Build a minimal mock span
+    const spanEnd = vi.fn();
+    const spanSetStatus = vi.fn();
+    const spanRecordException = vi.fn();
+    const mockSpan = {
+      end: spanEnd,
+      setStatus: spanSetStatus,
+      recordException: spanRecordException,
+    };
+
+    // Mock getTracer to return a tracer that produces our mock span
+    const startSpan = vi.fn().mockReturnValue(mockSpan);
+    const mockTracer = { startSpan };
+
+    // Replicate the tracedQuery logic to test the pattern
+    function tracedQuery<T>(
+      tracer: typeof mockTracer,
+      op: string,
+      table: string,
+      fn: () => T,
+    ): T {
+      const span = tracer.startSpan(`db.${op.toLowerCase()}`, {
+        attributes: { "db.system": "sqlite", "db.operation": op, "db.sql.table": table },
+      });
+      try {
+        return fn();
+      } catch (err) {
+        span.recordException(err instanceof Error ? err : String(err));
+        span.setStatus({ code: 2 }); // SpanStatusCode.ERROR = 2
+        throw err;
+      } finally {
+        span.end();
+      }
+    }
+
+    const result = tracedQuery(mockTracer, "SELECT", "transcripts", () => 42);
+
+    expect(result).toBe(42);
+    expect(startSpan).toHaveBeenCalledWith("db.select", {
+      attributes: {
+        "db.system": "sqlite",
+        "db.operation": "SELECT",
+        "db.sql.table": "transcripts",
+      },
+    });
+    expect(spanEnd).toHaveBeenCalledOnce();
+    expect(spanSetStatus).not.toHaveBeenCalled();
+  });
+
+  it("records exception and sets ERROR status when fn throws", () => {
+    const spanEnd = vi.fn();
+    const spanSetStatus = vi.fn();
+    const spanRecordException = vi.fn();
+    const mockSpan = {
+      end: spanEnd,
+      setStatus: spanSetStatus,
+      recordException: spanRecordException,
+    };
+    const startSpan = vi.fn().mockReturnValue(mockSpan);
+    const mockTracer = { startSpan };
+
+    function tracedQuery<T>(
+      tracer: typeof mockTracer,
+      op: string,
+      table: string,
+      fn: () => T,
+    ): T {
+      const span = tracer.startSpan(`db.${op.toLowerCase()}`, {
+        attributes: { "db.system": "sqlite", "db.operation": op, "db.sql.table": table },
+      });
+      try {
+        return fn();
+      } catch (err) {
+        span.recordException(err instanceof Error ? err : String(err));
+        span.setStatus({ code: 2 });
+        throw err;
+      } finally {
+        span.end();
+      }
+    }
+
+    const boom = new Error("db exploded");
+    expect(() => tracedQuery(mockTracer, "INSERT", "transcripts", () => { throw boom; })).toThrow("db exploded");
+    expect(spanRecordException).toHaveBeenCalledWith(boom);
+    expect(spanSetStatus).toHaveBeenCalledWith({ code: 2 });
+    expect(spanEnd).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/server/src/__tests__/otel.test.ts
+++ b/apps/server/src/__tests__/otel.test.ts
@@ -1,16 +1,40 @@
-import { describe, expect, it, vi, beforeEach } from "vitest";
+import { describe, expect, it, beforeAll, afterAll } from "vitest";
+import { SpanStatusCode, trace } from "@opentelemetry/api";
+import {
+  InMemorySpanExporter,
+  SimpleSpanProcessor,
+  BasicTracerProvider,
+  type ReadableSpan,
+} from "@opentelemetry/sdk-trace-base";
 
 /**
- * Smoke tests for the OTEL module.
+ * Smoke + integration tests for the OTEL module.
  *
- * Test 1: Module imports without throwing (side-effect initialisation is safe).
- * Test 2: tracedQuery-style helper returns correct value and emits a span —
- *         validated by mocking @opentelemetry/api's trace.getTracer().
+ *  - otel module smoke: import side-effects + getTracer shape.
+ *  - tracedQuery: the REAL exported helper (formerly the test duplicated the
+ *    function body inline, which meant future db.ts edits couldn't fail the
+ *    test). We now import from db.ts directly so the test tracks reality.
+ *  - DB proxy iterate / configurator coverage: exercises the fixes for
+ *    phase-4 orch swarm HIGH findings H3 (iterate span lifecycle) and H4
+ *    (pluck/raw return the raw Statement, bypassing tracing).
+ *
+ * We install an InMemorySpanExporter via a throwaway BasicTracerProvider
+ * registered as the GLOBAL tracer provider BEFORE importing ../db.js or
+ * ../lib/otel.js. That way the shipping code's `trace.getTracer(...)` calls
+ * resolve to our in-memory provider, and we can inspect the spans that
+ * actually flow through the real code paths.
  */
+
+const memoryExporter = new InMemorySpanExporter();
+const testProvider = new BasicTracerProvider();
+testProvider.addSpanProcessor(new SimpleSpanProcessor(memoryExporter));
+// Register as the global provider BEFORE any code under test imports and
+// calls getTracer. Once a tracer is vended from the global provider, it
+// stays bound to it for the lifetime of that Tracer instance.
+trace.setGlobalTracerProvider(testProvider);
 
 describe("otel module", () => {
   it("imports without throwing", async () => {
-    // Dynamic import — if module-level OTLP setup throws we'd see it here.
     await expect(import("../lib/otel.js")).resolves.not.toThrow();
   });
 
@@ -22,97 +46,139 @@ describe("otel module", () => {
   });
 });
 
-describe("tracedQuery pattern", () => {
-  beforeEach(() => {
-    vi.restoreAllMocks();
+describe("tracedQuery (real export from db.ts)", () => {
+  beforeAll(() => {
+    memoryExporter.reset();
   });
 
-  it("returns the correct value and calls span.end()", () => {
-    // Build a minimal mock span
-    const spanEnd = vi.fn();
-    const spanSetStatus = vi.fn();
-    const spanRecordException = vi.fn();
-    const mockSpan = {
-      end: spanEnd,
-      setStatus: spanSetStatus,
-      recordException: spanRecordException,
-    };
+  it("emits a db.<op> span and returns the callback result", async () => {
+    memoryExporter.reset();
+    const { tracedQuery } = await import("../db.js");
 
-    // Mock getTracer to return a tracer that produces our mock span
-    const startSpan = vi.fn().mockReturnValue(mockSpan);
-    const mockTracer = { startSpan };
-
-    // Replicate the tracedQuery logic to test the pattern
-    function tracedQuery<T>(
-      tracer: typeof mockTracer,
-      op: string,
-      table: string,
-      fn: () => T,
-    ): T {
-      const span = tracer.startSpan(`db.${op.toLowerCase()}`, {
-        attributes: { "db.system": "sqlite", "db.operation": op, "db.sql.table": table },
-      });
-      try {
-        return fn();
-      } catch (err) {
-        span.recordException(err instanceof Error ? err : String(err));
-        span.setStatus({ code: 2 }); // SpanStatusCode.ERROR = 2
-        throw err;
-      } finally {
-        span.end();
-      }
-    }
-
-    const result = tracedQuery(mockTracer, "SELECT", "transcripts", () => 42);
-
+    const result = tracedQuery("SELECT", "transcripts", () => 42);
     expect(result).toBe(42);
-    expect(startSpan).toHaveBeenCalledWith("db.select", {
-      attributes: {
-        "db.system": "sqlite",
-        "db.operation": "SELECT",
-        "db.sql.table": "transcripts",
-      },
-    });
-    expect(spanEnd).toHaveBeenCalledOnce();
-    expect(spanSetStatus).not.toHaveBeenCalled();
+
+    const spans = memoryExporter.getFinishedSpans();
+    const match = spans.find((s: ReadableSpan) => s.name === "db.select");
+    expect(match).toBeDefined();
+    expect(match!.attributes["db.system"]).toBe("sqlite");
+    expect(match!.attributes["db.operation"]).toBe("SELECT");
+    expect(match!.attributes["db.sql.table"]).toBe("transcripts");
+    // Non-error default status is UNSET (code 0), not ERROR (2).
+    expect(match!.status.code).not.toBe(SpanStatusCode.ERROR);
   });
 
-  it("records exception and sets ERROR status when fn throws", () => {
-    const spanEnd = vi.fn();
-    const spanSetStatus = vi.fn();
-    const spanRecordException = vi.fn();
-    const mockSpan = {
-      end: spanEnd,
-      setStatus: spanSetStatus,
-      recordException: spanRecordException,
-    };
-    const startSpan = vi.fn().mockReturnValue(mockSpan);
-    const mockTracer = { startSpan };
-
-    function tracedQuery<T>(
-      tracer: typeof mockTracer,
-      op: string,
-      table: string,
-      fn: () => T,
-    ): T {
-      const span = tracer.startSpan(`db.${op.toLowerCase()}`, {
-        attributes: { "db.system": "sqlite", "db.operation": op, "db.sql.table": table },
-      });
-      try {
-        return fn();
-      } catch (err) {
-        span.recordException(err instanceof Error ? err : String(err));
-        span.setStatus({ code: 2 });
-        throw err;
-      } finally {
-        span.end();
-      }
-    }
+  it("records exception and sets ERROR status when fn throws", async () => {
+    memoryExporter.reset();
+    const { tracedQuery } = await import("../db.js");
 
     const boom = new Error("db exploded");
-    expect(() => tracedQuery(mockTracer, "INSERT", "transcripts", () => { throw boom; })).toThrow("db exploded");
-    expect(spanRecordException).toHaveBeenCalledWith(boom);
-    expect(spanSetStatus).toHaveBeenCalledWith({ code: 2 });
-    expect(spanEnd).toHaveBeenCalledOnce();
+    expect(() =>
+      tracedQuery("INSERT", "transcripts", () => {
+        throw boom;
+      })
+    ).toThrow("db exploded");
+
+    const spans = memoryExporter.getFinishedSpans();
+    const match = spans.find((s: ReadableSpan) => s.name === "db.insert");
+    expect(match).toBeDefined();
+    expect(match!.status.code).toBe(SpanStatusCode.ERROR);
+    // recordException writes an "exception" event onto the span.
+    expect(match!.events.some((e) => e.name === "exception")).toBe(true);
+  });
+});
+
+describe("db Proxy tracing coverage", () => {
+  let dbMod: typeof import("../db.js");
+
+  beforeAll(async () => {
+    dbMod = await import("../db.js");
+  });
+
+  afterAll(() => {
+    // Best-effort: remove any rows this suite inserted to keep the
+    // on-disk dev DB tidy. Harmless if rows already gone.
+    try {
+      dbMod.db
+        .prepare("DELETE FROM transcripts WHERE user_id IN (?, ?)")
+        .run("u-iter", "u-pluck");
+    } catch {
+      /* ignore */
+    }
+  });
+
+  /**
+   * H3: `.iterate()` must NOT end its span before the caller consumes the
+   * iterator. Verify the span's duration spans the full consumption, not
+   * just the synchronous iterate() setup.
+   */
+  it("iterate() span stays open across full consumption", () => {
+    memoryExporter.reset();
+
+    const id = `iter-${Date.now()}-${Math.random()}`;
+    dbMod.db
+      .prepare(
+        `INSERT INTO transcripts (id, user_id, title, body, word_count, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`
+      )
+      .run(id, "u-iter", "t", "b", 1, Date.now(), Date.now());
+
+    const stmt = dbMod.db.prepare("SELECT id FROM transcripts WHERE id = ?");
+    const iter = (
+      stmt as { iterate: (id: string) => IterableIterator<unknown> }
+    ).iterate(id);
+
+    // Before consumption, the iterate span is OPEN — no finished db.select
+    // span should have appeared from the iterate call itself. (There will
+    // be insert-related db.insert spans from setup; we filter for select.)
+    const spansBeforeConsume = memoryExporter
+      .getFinishedSpans()
+      .filter((s: ReadableSpan) => s.name === "db.select");
+    expect(spansBeforeConsume.length).toBe(0);
+
+    // Drain. Sleep briefly between consume and assertion to ensure the
+    // SimpleSpanProcessor has processed the end.
+    const rows = Array.from(iter);
+    expect(rows.length).toBeGreaterThanOrEqual(1);
+
+    const spansAfterConsume = memoryExporter
+      .getFinishedSpans()
+      .filter((s: ReadableSpan) => s.name === "db.select");
+    expect(spansAfterConsume.length).toBe(1);
+
+    // Cleanup
+    dbMod.db.prepare("DELETE FROM transcripts WHERE id = ?").run(id);
+  });
+
+  /**
+   * H4: `.pluck()` must return a traced proxy, not the raw Statement.
+   * Regression shape: if pluck returns the raw stmt, the chained .get() is
+   * unproxied and emits zero spans.
+   */
+  it("pluck() chain still emits a db.select span on .get()", () => {
+    const id = `pluck-${Date.now()}-${Math.random()}`;
+    dbMod.db
+      .prepare(
+        `INSERT INTO transcripts (id, user_id, title, body, word_count, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`
+      )
+      .run(id, "u-pluck", "t", "b", 1, Date.now(), Date.now());
+
+    memoryExporter.reset();
+
+    const stmt = dbMod.db.prepare(
+      "SELECT id FROM transcripts WHERE id = ?"
+    );
+    const plucked = (stmt as { pluck: () => typeof stmt }).pluck();
+    const result = plucked.get(id);
+    expect(result).toBe(id);
+
+    const selects = memoryExporter
+      .getFinishedSpans()
+      .filter((s: ReadableSpan) => s.name === "db.select");
+    expect(selects.length).toBe(1);
+
+    // Cleanup
+    dbMod.db.prepare("DELETE FROM transcripts WHERE id = ?").run(id);
   });
 });

--- a/apps/server/src/auth.ts
+++ b/apps/server/src/auth.ts
@@ -1,10 +1,14 @@
 import { createHash, createHmac, randomBytes } from "node:crypto";
+import { getTracer } from "./lib/otel.js";
+import { SpanStatusCode } from "@opentelemetry/api";
 
 // Allow up to 30 seconds of clock skew on the future-timestamp check.
 // Telegram servers and client devices can drift by a few seconds; a hard
 // equality check (authDate > nowSec) would reject legitimate requests that
 // arrive with a timestamp slightly ahead of the server clock.
 const CLOCK_SKEW_TOLERANCE_SEC = 30;
+
+const authTracer = getTracer('cpc-server-auth');
 
 /**
  * Validate an auth_date unix timestamp.
@@ -24,14 +28,19 @@ function validateAuthDate(rawAuthDate: string | undefined): boolean {
 /**
  * Validate Telegram Mini App initData.
  * https://core.telegram.org/bots/webapps#validating-data-received-via-the-mini-app
+ *
+ * Note: no span here — the span lives in validateTelegramInitDataWithTokens so
+ * that multi-token deploys emit ONE span per request (not N hmac_mismatch spans).
  */
 export function validateTelegramInitData(
   initData: string,
   botToken: string,
-): { valid: boolean; user?: TelegramUser } {
+): { valid: boolean; user?: TelegramUser; failureReason?: string } {
   const params = new URLSearchParams(initData);
   const hash = params.get("hash");
-  if (!hash) return { valid: false };
+  if (!hash) {
+    return { valid: false, failureReason: 'missing_hash' };
+  }
 
   // Remove hash from params and sort alphabetically
   params.delete("hash");
@@ -46,20 +55,32 @@ export function validateTelegramInitData(
     .update(dataCheckString)
     .digest("hex");
 
-  if (computedHash !== hash) return { valid: false };
+  if (computedHash !== hash) {
+    return { valid: false, failureReason: 'hmac_mismatch' };
+  }
 
   // Check auth_date is within 24 hours (guard against NaN, future timestamps)
-  if (!validateAuthDate(params.get("auth_date") ?? undefined)) return { valid: false };
+  const authDateStr = params.get("auth_date") ?? undefined;
+  if (!validateAuthDate(authDateStr)) {
+    const authDate = authDateStr ? parseInt(authDateStr, 10) : NaN;
+    const nowSec = Date.now() / 1000;
+    const reason = Number.isFinite(authDate) && authDate > nowSec + CLOCK_SKEW_TOLERANCE_SEC
+      ? 'future_date'
+      : 'expired';
+    return { valid: false, failureReason: reason };
+  }
 
   // Parse user data
   const userStr = params.get("user");
-  if (!userStr) return { valid: true };
+  if (!userStr) {
+    return { valid: true };
+  }
 
   try {
     const user = JSON.parse(userStr) as TelegramUser;
     return { valid: true, user };
   } catch {
-    return { valid: false };
+    return { valid: false, failureReason: 'parse_error' };
   }
 }
 
@@ -175,16 +196,37 @@ export function validateSession(token: string): { valid: boolean; user?: Telegra
 
 /**
  * Try initData against each token in order; return first success or { valid: false }.
+ * Emits ONE span per request regardless of how many tokens are configured,
+ * avoiding N hmac_mismatch spans per request in multi-token deploys.
  */
 export function validateTelegramInitDataWithTokens(
   initData: string,
   tokens: string[],
 ): { valid: boolean; user?: TelegramUser } {
-  for (const token of tokens) {
-    const result = validateTelegramInitData(initData, token);
-    if (result.valid) return result;
+  const span = authTracer.startSpan('auth.telegram_initdata');
+  try {
+    let lastReason: string | undefined;
+    for (const token of tokens) {
+      const result = validateTelegramInitData(initData, token);
+      if (result.valid) {
+        span.setAttributes({ 'auth.valid': true, 'auth.tokens_tried': tokens.length });
+        return { valid: true, user: result.user };
+      }
+      lastReason = result.failureReason;
+    }
+    span.setAttributes({
+      'auth.valid': false,
+      'auth.tokens_tried': tokens.length,
+      ...(lastReason ? { 'auth.failure_reason': lastReason } : {}),
+    });
+    return { valid: false };
+  } catch (err) {
+    span.recordException(err instanceof Error ? err : String(err));
+    span.setStatus({ code: SpanStatusCode.ERROR });
+    throw err;
+  } finally {
+    span.end();
   }
-  return { valid: false };
 }
 
 /**

--- a/apps/server/src/db.ts
+++ b/apps/server/src/db.ts
@@ -22,7 +22,7 @@ function extractOperation(sql: string): string {
 
 const dbTracer = getTracer('cpc-server-db');
 
-function tracedQuery<T>(op: string, table: string, fn: () => T): T {
+export function tracedQuery<T>(op: string, table: string, fn: () => T): T {
   const span = dbTracer.startSpan(`db.${op.toLowerCase()}`, {
     attributes: { 'db.system': 'sqlite', 'db.operation': op, 'db.sql.table': table },
   });
@@ -38,11 +38,39 @@ function tracedQuery<T>(op: string, table: string, fn: () => T): T {
 }
 
 // Proxy wrapping ALL .prepare() usage.
-// Only trace actual execution methods — pluck/expand/raw are configurators that
-// return `this` for chaining (e.g. stmt.pluck().get(params)). Intercepting them
-// with tracedQuery would return the unproxied statement, losing span coverage on
-// the subsequent .get()/.all()/.run() call.
-const TRACED_STMT_METHODS = ['get', 'all', 'run', 'iterate'] as const;
+//
+// Three classes of method need distinct handling:
+//
+//  1. TRACED_SYNC_METHODS (`get`, `all`, `run`) — synchronous execute-and-return.
+//     Wrap the whole call in tracedQuery so the span captures elapsed time +
+//     any thrown error.
+//
+//  2. `iterate` — returns a lazy iterator SYNCHRONOUSLY; the actual row fetches
+//     happen later as the caller consumes the iterator. Wrapping it like a sync
+//     method ends the span before any row is pulled, recording ~0µs and missing
+//     any error raised during iteration. Instead we hand back an iterator that
+//     starts the span eagerly and ends it on exhaustion, early return, or throw.
+//
+//  3. CONFIGURATOR_METHODS (`pluck`, `expand`, `raw`, `safeIntegers`, `bind`) —
+//     mutate the statement and return `this` for chaining. Returning the raw
+//     `s` here would hand the caller an UNPROXIED statement, so the subsequent
+//     `.get()/.all()/.iterate()` would bypass all tracing. We re-route these
+//     to run the configurator on `s` and return the outer Proxy so tracing
+//     stays intact across the chain.
+//
+//     NOTE: `columns()` is deliberately EXCLUDED. Despite being a configurator-
+//     adjacent introspection API, it returns `ColumnDefinition[]`, not `this`
+//     — wrapping it here would replace that array with the statement proxy and
+//     break callers. It falls through to the default branch which returns the
+//     method bound to the real statement.
+const TRACED_SYNC_METHODS = new Set(['get', 'all', 'run']);
+const CONFIGURATOR_METHODS = new Set([
+  'pluck',
+  'expand',
+  'raw',
+  'safeIntegers',
+  'bind',
+]);
 
 export const db: DatabaseType = new Proxy(rawDb, {
   get(target, prop) {
@@ -51,17 +79,135 @@ export const db: DatabaseType = new Proxy(rawDb, {
         const stmt = target.prepare(sql);
         const table = extractTable(sql);
         const op = extractOperation(sql);
-        return new Proxy(stmt, {
+        const stmtProxy: typeof stmt = new Proxy(stmt, {
           get(s, method) {
-            if ((TRACED_STMT_METHODS as readonly string[]).includes(method as string)) {
+            const methodStr = method as string;
+
+            if (TRACED_SYNC_METHODS.has(methodStr)) {
               return (...args: unknown[]) =>
-                tracedQuery(op, table, () => Reflect.apply(s[method as keyof typeof s] as Function, s, args));
+                tracedQuery(op, table, () =>
+                  Reflect.apply(s[method as keyof typeof s] as Function, s, args)
+                );
             }
+
+            if (methodStr === 'iterate') {
+              return (...args: unknown[]) => {
+                // Start the span BEFORE invoking iterate so we capture
+                // any throw from the prepare/bind phase, and keep it
+                // open across the full consumer loop. We end it on
+                // StopIteration, caller-initiated .return(), or .throw().
+                const span = dbTracer.startSpan(`db.${op.toLowerCase()}`, {
+                  attributes: {
+                    'db.system': 'sqlite',
+                    'db.operation': op,
+                    'db.sql.table': table,
+                  },
+                });
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                let innerIter: IterableIterator<unknown> & { return?: (value?: any) => IteratorResult<unknown> };
+                try {
+                  innerIter = Reflect.apply(
+                    s.iterate as Function,
+                    s,
+                    args
+                  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                  ) as any;
+                } catch (err) {
+                  span.recordException(err instanceof Error ? err : String(err));
+                  span.setStatus({ code: SpanStatusCode.ERROR });
+                  span.end();
+                  throw err;
+                }
+                // Hand back a wrapper iterator that delegates to the inner
+                // better-sqlite3 iterator but ends the span exactly once,
+                // on whichever exit path fires first. Using an explicit
+                // iterator object (not a generator) avoids double-calling
+                // `.return()` on the underlying cursor, which previously
+                // left the DB connection in a "busy" state.
+                let ended = false;
+                const endOnce = () => {
+                  if (ended) return;
+                  ended = true;
+                  span.end();
+                };
+                const wrapper: IterableIterator<unknown> = {
+                  [Symbol.iterator]() { return this; },
+                  next() {
+                    try {
+                      const result = innerIter.next();
+                      if (result.done) endOnce();
+                      return result;
+                    } catch (err) {
+                      span.recordException(err instanceof Error ? err : String(err));
+                      span.setStatus({ code: SpanStatusCode.ERROR });
+                      endOnce();
+                      throw err;
+                    }
+                  },
+                  return(value?: unknown): IteratorResult<unknown> {
+                    try {
+                      const r = innerIter.return?.(value) ?? { value: undefined, done: true };
+                      endOnce();
+                      return r;
+                    } catch (err) {
+                      span.recordException(err instanceof Error ? err : String(err));
+                      span.setStatus({ code: SpanStatusCode.ERROR });
+                      endOnce();
+                      throw err;
+                    }
+                  },
+                  // `throw()` is rarely used but part of the Iterator protocol;
+                  // forward to the inner iterator if it supports throw, otherwise
+                  // record the error, end the span, and re-throw so the caller
+                  // still sees the exception.
+                  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                  throw(err?: any): IteratorResult<unknown> {
+                    try {
+                      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                      const innerThrow = (innerIter as any).throw as
+                        | ((e?: unknown) => IteratorResult<unknown>)
+                        | undefined;
+                      if (typeof innerThrow === 'function') {
+                        const r = innerThrow.call(innerIter, err);
+                        endOnce();
+                        return r;
+                      }
+                      // No inner throw — simulate protocol by recording +
+                      // rethrowing. Caller gets the error they handed us.
+                      span.recordException(err instanceof Error ? err : String(err));
+                      span.setStatus({ code: SpanStatusCode.ERROR });
+                      endOnce();
+                      throw err;
+                    } catch (thrownErr) {
+                      span.recordException(thrownErr instanceof Error ? thrownErr : String(thrownErr));
+                      span.setStatus({ code: SpanStatusCode.ERROR });
+                      endOnce();
+                      throw thrownErr;
+                    }
+                  },
+                };
+                return wrapper;
+              };
+            }
+
+            if (CONFIGURATOR_METHODS.has(methodStr)) {
+              const orig = s[method as keyof typeof s] as Function | undefined;
+              if (typeof orig !== 'function') return orig;
+              return (...args: unknown[]) => {
+                // Run the configurator on the underlying statement, then
+                // return the outer proxy so subsequent chained calls
+                // (.get / .all / .iterate) remain traced.
+                Reflect.apply(orig, s, args);
+                return stmtProxy;
+              };
+            }
+
             const val = s[method as keyof typeof s];
             if (typeof val === 'function') return (val as Function).bind(s);
             return val;
           },
         });
+        return stmtProxy;
       };
     }
     const val = target[prop as keyof typeof target];

--- a/apps/server/src/db.ts
+++ b/apps/server/src/db.ts
@@ -1,11 +1,74 @@
 import Database, { type Database as DatabaseType } from "better-sqlite3";
 import { join } from "node:path";
 import { mkdirSync } from "node:fs";
+import { SpanStatusCode } from "@opentelemetry/api";
+import { getTracer } from "./lib/otel.js";
 
 const DATA_DIR = join(process.env.HOME || "/home/claude", "data");
 mkdirSync(DATA_DIR, { recursive: true });
 
-const db: DatabaseType = new Database(join(DATA_DIR, "cpc-voice.db"));
+const DB_PATH = join(DATA_DIR, "cpc-voice.db");
+const rawDb: DatabaseType = new Database(DB_PATH);
+
+// ── OTEL helpers ──────────────────────────────────────────────────────────────
+
+function extractTable(sql: string): string {
+  return sql.match(/\b(?:FROM|INTO|UPDATE|JOIN)\s+(\w+)/i)?.[1] ?? 'unknown';
+}
+
+function extractOperation(sql: string): string {
+  return sql.trim().split(/\s+/)[0]?.toUpperCase() ?? 'QUERY';
+}
+
+const dbTracer = getTracer('cpc-server-db');
+
+function tracedQuery<T>(op: string, table: string, fn: () => T): T {
+  const span = dbTracer.startSpan(`db.${op.toLowerCase()}`, {
+    attributes: { 'db.system': 'sqlite', 'db.operation': op, 'db.sql.table': table },
+  });
+  try {
+    return fn();
+  } catch (err) {
+    span.recordException(err instanceof Error ? err : String(err));
+    span.setStatus({ code: SpanStatusCode.ERROR });
+    throw err;
+  } finally {
+    span.end();
+  }
+}
+
+// Proxy wrapping ALL .prepare() usage.
+// Only trace actual execution methods — pluck/expand/raw are configurators that
+// return `this` for chaining (e.g. stmt.pluck().get(params)). Intercepting them
+// with tracedQuery would return the unproxied statement, losing span coverage on
+// the subsequent .get()/.all()/.run() call.
+const TRACED_STMT_METHODS = ['get', 'all', 'run', 'iterate'] as const;
+
+export const db: DatabaseType = new Proxy(rawDb, {
+  get(target, prop) {
+    if (prop === 'prepare') {
+      return (sql: string) => {
+        const stmt = target.prepare(sql);
+        const table = extractTable(sql);
+        const op = extractOperation(sql);
+        return new Proxy(stmt, {
+          get(s, method) {
+            if ((TRACED_STMT_METHODS as readonly string[]).includes(method as string)) {
+              return (...args: unknown[]) =>
+                tracedQuery(op, table, () => Reflect.apply(s[method as keyof typeof s] as Function, s, args));
+            }
+            const val = s[method as keyof typeof s];
+            if (typeof val === 'function') return (val as Function).bind(s);
+            return val;
+          },
+        });
+      };
+    }
+    const val = target[prop as keyof typeof target];
+    if (typeof val === 'function') return (val as Function).bind(target);
+    return val;
+  },
+});
 
 // WAL mode for better concurrent reads
 db.pragma("journal_mode = WAL");
@@ -123,5 +186,5 @@ db.exec(
   }
 }
 
-export { db };
+export { DB_PATH };
 export type { DatabaseType };

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -68,13 +68,48 @@ app.use('/api/*', async (c, next) => {
   c.req.raw.headers.forEach((v, k) => { headers[k] = v; });
   const parentCtx = propagation.extract(otelContext.active(), headers);
 
+  // Start with the middleware mount path as the route; we refine it after
+  // next() runs, once Hono has resolved the matched handler. `c.req.routePath`
+  // inside middleware returns the MIDDLEWARE's own pattern (`/api/*`), not the
+  // matched handler's path — so we must wait until after next() and read the
+  // matched-route metadata instead. See Hono docs on `matchedRoutes`.
   const span = httpTracer.startSpan(`${c.req.method} /api/*`, {
     attributes: { 'http.method': c.req.method },
   }, parentCtx);
   await otelContext.with(trace.setSpan(parentCtx, span), async () => {
     try {
       await next();
-      span.setAttribute('http.route', c.req.routePath);
+      // Resolve the matched handler's route after next() has returned.
+      // Prefer the last entry in `matchedRoutes` that isn't this middleware's
+      // own mount pattern; fall back to `routePath`, then `/api/*`.
+      let matchedPath = '/api/*';
+      try {
+        // hono exposes `matchedRoutes` as an array of `{ path, method, handler }`.
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const matched = (c.req as any).matchedRoutes as
+          | Array<{ path: string; method?: string }>
+          | undefined;
+        if (Array.isArray(matched) && matched.length > 0) {
+          // Walk from the end looking for a specific route (not a catch-all
+          // middleware mount like `/api/*`). This covers the common case
+          // where the matched application handler is the last entry.
+          for (let i = matched.length - 1; i >= 0; i--) {
+            const p = matched[i]?.path;
+            if (p && !p.endsWith('/*')) { matchedPath = p; break; }
+          }
+          if (matchedPath === '/api/*') {
+            // Fall back to the last matched path even if it's a wildcard.
+            matchedPath = matched[matched.length - 1]?.path ?? matchedPath;
+          }
+        } else {
+          matchedPath = c.req.routePath ?? matchedPath;
+        }
+      } catch {
+        // Hono getter threw — keep the /api/* default rather than 500 the
+        // request (defence-in-depth around a telemetry-only attribute).
+      }
+      span.setAttribute('http.route', matchedPath);
+      span.updateName(`${c.req.method} ${matchedPath}`);
       span.setAttribute('http.status_code', c.res.status);
       if (c.res.status >= 500) span.setStatus({ code: SpanStatusCode.ERROR });
     } catch (err) {

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -1,3 +1,4 @@
+import './lib/otel.js';
 import { readFileSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -11,6 +12,9 @@ import { telegramAuth } from "./middleware.js";
 import { validateTelegramLoginWidget, createSession } from "./auth.js";
 import { isAllowedUser } from "./lib/allowed-users.js";
 import { ALLOWED_ORIGINS } from "./lib/allowed-origins.js";
+import { registerDbSizeGauge, getTracer } from "./lib/otel.js";
+import { propagation, context as otelContext, trace, SpanStatusCode } from "@opentelemetry/api";
+import { DB_PATH } from "./db.js";
 import { terminalRoute } from "./routes/terminal/index.js";
 import { sessionRoute } from "./routes/session.js";
 import { todoRoute } from "./routes/todo.js";
@@ -45,12 +49,43 @@ function loadEnv(path: string) {
 
 loadEnv(`${process.env.HOME}/.secrets/cpc.env`);
 
+// Register DB size gauge after env is loaded so DB_PATH is stable
+registerDbSizeGauge(DB_PATH);
+
 const app = new Hono<{ Bindings: HttpBindings }>();
 const { injectWebSocket, upgradeWebSocket } = createNodeWebSocket({ app });
 
 app.use("*", cors({
   origin: [...ALLOWED_ORIGINS],
 }));
+
+// ── HTTP span middleware ───────────────────────────────────────────────────────
+// Extract W3C traceparent from incoming headers, create a span per /api/* request.
+// Must run before auth middleware so auth failures are still traced.
+const httpTracer = getTracer('cpc-server-http');
+app.use('/api/*', async (c, next) => {
+  const headers: Record<string, string> = {};
+  c.req.raw.headers.forEach((v, k) => { headers[k] = v; });
+  const parentCtx = propagation.extract(otelContext.active(), headers);
+
+  const span = httpTracer.startSpan(`${c.req.method} /api/*`, {
+    attributes: { 'http.method': c.req.method },
+  }, parentCtx);
+  await otelContext.with(trace.setSpan(parentCtx, span), async () => {
+    try {
+      await next();
+      span.setAttribute('http.route', c.req.routePath);
+      span.setAttribute('http.status_code', c.res.status);
+      if (c.res.status >= 500) span.setStatus({ code: SpanStatusCode.ERROR });
+    } catch (err) {
+      span.recordException(err instanceof Error ? err : String(err));
+      span.setStatus({ code: SpanStatusCode.ERROR });
+      throw err;
+    } finally {
+      span.end();
+    }
+  });
+});
 
 // Public routes (no auth)
 app.get("/api/public/health", (c) => c.json({ status: "ok" }));

--- a/apps/server/src/lib/otel.ts
+++ b/apps/server/src/lib/otel.ts
@@ -1,0 +1,115 @@
+import fs from 'node:fs/promises';
+import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
+import { BatchSpanProcessor, SimpleSpanProcessor, ConsoleSpanExporter } from '@opentelemetry/sdk-trace-base';
+import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
+import { MeterProvider, PeriodicExportingMetricReader } from '@opentelemetry/sdk-metrics';
+import { OTLPMetricExporter } from '@opentelemetry/exporter-metrics-otlp-http';
+import { Resource } from '@opentelemetry/resources';
+import { ATTR_SERVICE_NAME, ATTR_SERVICE_VERSION } from '@opentelemetry/semantic-conventions';
+import { ATTR_DEPLOYMENT_ENVIRONMENT_NAME } from '@opentelemetry/semantic-conventions/incubating';
+import { context, trace, metrics, type Tracer, type Span, SpanStatusCode, type Meter, type ObservableResult } from '@opentelemetry/api';
+
+const resource = new Resource({
+  [ATTR_SERVICE_NAME]: 'cpc-server',
+  [ATTR_SERVICE_VERSION]: process.env['npm_package_version'] ?? '0.0.0',
+  [ATTR_DEPLOYMENT_ENVIRONMENT_NAME]: process.env['NODE_ENV'] ?? 'production',
+});
+
+// ── Traces ────────────────────────────────────────────────────────────────────
+const provider = new NodeTracerProvider({ resource });
+
+// OTLPTraceExporter silently drops spans when the collector is absent — no process crash.
+// Use BatchSpanProcessor in prod (non-blocking buffer flush) and SimpleSpanProcessor in dev.
+const otlpExporter = new OTLPTraceExporter({ url: 'http://localhost:4318/v1/traces' });
+provider.addSpanProcessor(
+  process.env['NODE_ENV'] === 'development'
+    ? new SimpleSpanProcessor(otlpExporter)
+    : new BatchSpanProcessor(otlpExporter)
+);
+
+if (process.env['NODE_ENV'] === 'development') {
+  provider.addSpanProcessor(new SimpleSpanProcessor(new ConsoleSpanExporter()));
+}
+
+provider.register();
+
+// ── Metrics ───────────────────────────────────────────────────────────────────
+// OTLPMetricExporter silently drops metrics when the collector is absent — no process crash.
+const meterProvider = new MeterProvider({
+  resource,
+  readers: [
+    new PeriodicExportingMetricReader({
+      exporter: new OTLPMetricExporter({ url: 'http://localhost:4318/v1/metrics' }),
+      exportIntervalMillis: 60_000,
+    }),
+  ],
+});
+
+metrics.setGlobalMeterProvider(meterProvider);
+
+// ── Graceful shutdown ─────────────────────────────────────────────────────────
+// Flush buffered spans/metrics on process termination, then exit so the process
+// doesn't hang on live handles (HTTP server socket, keep-alive connections).
+// process.exit(0) is in `finally` so it runs even if a provider rejects (e.g.
+// collector unavailable), preventing unhandled-rejection hangs on SIGTERM.
+const shutdown = async (signal: string) => {
+  // Hard-kill backstop: if flush stalls (e.g. collector network hang),
+  // force-exit after 10s. unref() so it doesn't prevent normal exit itself.
+  const hardKill = setTimeout(() => process.exit(1), 10_000);
+  hardKill.unref();
+  try {
+    await Promise.allSettled([provider.shutdown(), meterProvider.shutdown()]);
+  } finally {
+    process.exit(0);
+  }
+};
+process.on('SIGTERM', () => { void shutdown('SIGTERM'); });
+process.on('SIGINT', () => { void shutdown('SIGINT'); });
+
+export function getTracer(name: string): Tracer {
+  return trace.getTracer(name);
+}
+
+export function getMeter(name: string): Meter {
+  return metrics.getMeter(name);
+}
+
+/**
+ * Register an ObservableGauge that reports the SQLite DB file size in bytes.
+ * Called once from index.ts after the db path is resolved.
+ * Silent no-op if stat fails (file not yet created or permission error).
+ */
+export function registerDbSizeGauge(dbPath: string): void {
+  const m = getMeter('db');
+  const gauge = m.createObservableGauge('db_size_bytes', {
+    description: 'SQLite database file size in bytes',
+    unit: 'bytes',
+  });
+  gauge.addCallback(async (result: ObservableResult) => {
+    try {
+      const stat = await fs.stat(dbPath);
+      result.observe(stat.size);
+    } catch {
+      // File absent or unreadable — skip observation (no-op is safe)
+    }
+  });
+}
+
+// Convenience wrapper — every span must be paired with span.end()
+export async function withSpan<T>(
+  tracer: Tracer,
+  name: string,
+  attrs: Record<string, string | number | boolean>,
+  fn: (span: Span) => Promise<T>
+): Promise<T> {
+  const span = tracer.startSpan(name, { attributes: attrs });
+  try {
+    return await context.with(trace.setSpan(context.active(), span), () => fn(span));
+  } catch (err) {
+    span.recordException(err instanceof Error ? err : String(err));
+    span.setStatus({ code: SpanStatusCode.ERROR });
+    throw err;
+  } finally {
+    span.end();
+  }
+}

--- a/apps/server/src/lib/otel.ts
+++ b/apps/server/src/lib/otel.ts
@@ -1,6 +1,12 @@
 import fs from 'node:fs/promises';
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
-import { BatchSpanProcessor, SimpleSpanProcessor, ConsoleSpanExporter } from '@opentelemetry/sdk-trace-base';
+import {
+  BatchSpanProcessor,
+  SimpleSpanProcessor,
+  ConsoleSpanExporter,
+  ParentBasedSampler,
+  TraceIdRatioBasedSampler,
+} from '@opentelemetry/sdk-trace-base';
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
 import { MeterProvider, PeriodicExportingMetricReader } from '@opentelemetry/sdk-metrics';
 import { OTLPMetricExporter } from '@opentelemetry/exporter-metrics-otlp-http';
@@ -16,7 +22,20 @@ const resource = new Resource({
 });
 
 // ── Traces ────────────────────────────────────────────────────────────────────
-const provider = new NodeTracerProvider({ resource });
+// Sampling: default to 10% of root traces — the previous always-on default
+// combined with per-call spans (isPathAllowed, db statements) could overflow
+// BatchSpanProcessor's buffer under load, silently dropping spans. The env
+// var OTEL_TRACES_SAMPLE_RATE lets ops tune (0.0–1.0). Wrapping in
+// ParentBasedSampler honors upstream sampling decisions — if Alloy or another
+// caller propagates a sampled trace, we inherit that decision instead of
+// re-rolling and potentially breaking a trace mid-flight.
+const sampleRateEnv = process.env['OTEL_TRACES_SAMPLE_RATE'];
+const parsed = sampleRateEnv !== undefined ? parseFloat(sampleRateEnv) : NaN;
+const sampleRate = Number.isFinite(parsed) ? Math.min(1, Math.max(0, parsed)) : 0.1;
+const sampler = new ParentBasedSampler({
+  root: new TraceIdRatioBasedSampler(sampleRate),
+});
+const provider = new NodeTracerProvider({ resource, sampler });
 
 // OTLPTraceExporter silently drops spans when the collector is absent — no process crash.
 // Use BatchSpanProcessor in prod (non-blocking buffer flush) and SimpleSpanProcessor in dev.

--- a/apps/server/src/lib/path-allowed.ts
+++ b/apps/server/src/lib/path-allowed.ts
@@ -1,5 +1,7 @@
 import { realpath } from "node:fs/promises";
 import { resolve, sep } from "node:path";
+import { getTracer } from "./otel.js";
+import { SpanStatusCode } from "@opentelemetry/api";
 
 /**
  * Check whether an absolute path is contained within any of the allowed root
@@ -30,6 +32,8 @@ import { resolve, sep } from "node:path";
 // (e.g. if a root was temporarily missing). A guard prevents a delayed
 // rejection from evicting a newer entry added after a cache clear.
 const realRootCache = new Map<string, Promise<string>>();
+
+const pathTracer = getTracer('cpc-server-security');
 
 export const ALLOWED_FILE_ROOTS = [
   "/home/claude/claudes-world",
@@ -73,30 +77,44 @@ export async function isPathAllowed(
   absPath: string,
   allowedRoots: readonly string[],
 ): Promise<boolean> {
-  let realCandidate: string;
+  const span = pathTracer.startSpan('security.path_check', {
+    attributes: { 'path.root_count': allowedRoots.length },
+  });
   try {
-    realCandidate = await realpath(resolve(absPath));
-  } catch {
-    // Non-existent path, broken symlink, or permission denied — reject.
-    return false;
-  }
-
-  for (const root of allowedRoots) {
-    let realRoot: string;
+    let realCandidate: string;
     try {
-      realRoot = await getRealRoot(root);
+      realCandidate = await realpath(resolve(absPath));
     } catch {
-      // Allowed root is missing on disk — skip, don't let it match anything.
-      continue;
+      // Non-existent path, broken symlink, or permission denied — reject.
+      span.setAttribute('path.allowed', false);
+      return false;
     }
-    // When realRoot is the filesystem root (e.g. `/` on Unix, `C:\` on
-    // Windows), `realRoot + sep` yields `//` or `C:\\`, which no valid
-    // child path starts with. Only append a separator if the root doesn't
-    // already end with one.
-    const rootWithSep = realRoot.endsWith(sep) ? realRoot : realRoot + sep;
-    if (realCandidate === realRoot || realCandidate.startsWith(rootWithSep)) {
-      return true;
+
+    for (const root of allowedRoots) {
+      let realRoot: string;
+      try {
+        realRoot = await getRealRoot(root);
+      } catch {
+        // Allowed root is missing on disk — skip, don't let it match anything.
+        continue;
+      }
+      // When realRoot is the filesystem root (e.g. `/` on Unix, `C:\` on
+      // Windows), `realRoot + sep` yields `//` or `C:\\`, which no valid
+      // child path starts with. Only append a separator if the root doesn't
+      // already end with one.
+      const rootWithSep = realRoot.endsWith(sep) ? realRoot : realRoot + sep;
+      if (realCandidate === realRoot || realCandidate.startsWith(rootWithSep)) {
+        span.setAttribute('path.allowed', true);
+        return true;
+      }
     }
+    span.setAttribute('path.allowed', false);
+    return false;
+  } catch (err) {
+    span.recordException(err instanceof Error ? err : String(err));
+    span.setStatus({ code: SpanStatusCode.ERROR });
+    throw err;
+  } finally {
+    span.end();
   }
-  return false;
 }

--- a/apps/server/src/lib/path-allowed.ts
+++ b/apps/server/src/lib/path-allowed.ts
@@ -37,6 +37,7 @@ export const ALLOWED_FILE_ROOTS = [
   "/home/claude/bin",
   "/home/claude/.claude",
   "/home/claude/claudes-world/.claude",
+  "/home/claude/.world",
 ] as const;
 
 

--- a/apps/server/src/routes/__tests__/files.test.ts
+++ b/apps/server/src/routes/__tests__/files.test.ts
@@ -642,3 +642,53 @@ describe("POST /paste", () => {
     expect(JSON.stringify(body)).not.toContain(sandbox);
   });
 });
+
+// ---------------------------------------------------------------------------
+// GET /list — synthetic home view (/home/claude)
+// ---------------------------------------------------------------------------
+describe("GET /list — synthetic home view", () => {
+  it("returns only allowlisted subdirs of /home/claude, never disallowed siblings", async () => {
+    const res = await filesRoute.request(
+      `/list?path=${encodeURIComponent("/home/claude")}`,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      path: string;
+      parent: string | null;
+      items: Array<{ name: string; path: string; type: string }>;
+    };
+
+    expect(body.path).toBe("/home/claude");
+    expect(body.parent).toBeNull();
+    expect(Array.isArray(body.items)).toBe(true);
+
+    // Every returned item must be a directory whose path starts with /home/claude/
+    for (const item of body.items) {
+      expect(item.type).toBe("dir");
+      expect(item.path.startsWith("/home/claude/")).toBe(true);
+    }
+
+    const names = body.items.map((i) => i.name);
+
+    // Allowlisted direct children must be present
+    expect(names).toContain("claudes-world");
+    expect(names).toContain("code");
+    expect(names).toContain("bin");
+    expect(names).toContain(".claude");
+    expect(names).toContain(".world");
+
+    // Disallowed siblings must never appear
+    expect(names).not.toContain(".ssh");
+    expect(names).not.toContain(".secrets");
+    expect(names).not.toContain("claudes-world/.claude"); // nested root, not a direct child
+  });
+
+  it("returns 403 for direct file-read on /home/claude", async () => {
+    const res = await filesRoute.request(
+      `/read?path=${encodeURIComponent("/home/claude")}`,
+    );
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("Access denied");
+  });
+});

--- a/apps/server/src/routes/__tests__/path-allowed.test.ts
+++ b/apps/server/src/routes/__tests__/path-allowed.test.ts
@@ -149,6 +149,24 @@ describe("isPathAllowed", () => {
     expect(await isPathAllowed(allowedRoot, [platformRoot])).toBe(true);
   });
 
+  it("allows a path under /home/claude/.world when that root is in the allowlist", async () => {
+    // Verify that ALLOWED_FILE_ROOTS includes /home/claude/.world by importing it
+    // and checking membership, then confirm the helper resolves the path as allowed
+    // against a synthetic tmp-based root (we can't use the live .world path in CI
+    // because it may not exist on the test host).
+    const { ALLOWED_FILE_ROOTS } = await import("../../lib/path-allowed.js");
+    expect(ALLOWED_FILE_ROOTS).toContain("/home/claude/.world");
+
+    // Functional check: a nested path under an allowed root that mimics the
+    // .world layout is accepted. Uses the existing allowedRoot fixture.
+    const snapshotsDir = join(allowedRoot, "pulse", "snapshots");
+    mkdirSync(snapshotsDir, { recursive: true });
+    writeFileSync(join(snapshotsDir, "current.json"), "{}");
+    expect(
+      await isPathAllowed(join(snapshotsDir, "current.json"), [allowedRoot]),
+    ).toBe(true);
+  });
+
   it("memoizes realpath(root) via an on-disk swap of the root target", async () => {
     // Spying on `realpath` in ESM is blocked by vitest (module namespace
     // is not configurable), so we verify memoization by observing a behavior

--- a/apps/server/src/routes/__tests__/voice.test.ts
+++ b/apps/server/src/routes/__tests__/voice.test.ts
@@ -27,7 +27,29 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
  *     voiceRoute and injects a fake user.
  */
 
-const execFileSyncSpy = vi.fn((_bin: string, _args: string[]) => "hello world\n");
+// The shipping code switched from `execFileSync` (blocking, no timeout) to
+// promisified `execFile` so the audio.transcribe span always ends (see
+// phase-4 orch swarm M4). `util.promisify` without a custom symbol converts
+// a node-style callback (err, value) into a Promise resolving to `value`.
+// Our stub resolves with an `{stdout, stderr}` object so the awaiting code
+// destructures `{ stdout }` correctly.
+//
+// The mock module replaces `execFile` entirely (no promisify.custom), which
+// forces `promisify` down its default path — our spy's callback delivers
+// `{stdout, stderr}` as the single value arg.
+const execFileSpy = vi.fn((
+  _bin: string,
+  _args: string[],
+  optsOrCb: unknown,
+  maybeCb?: (err: Error | null, value: { stdout: string; stderr: string }) => void,
+) => {
+  const cb =
+    typeof optsOrCb === "function"
+      ? (optsOrCb as (err: Error | null, value: { stdout: string; stderr: string }) => void)
+      : maybeCb;
+  cb?.(null, { stdout: "hello world\n", stderr: "" });
+  return { kill: vi.fn() } as unknown as import("node:child_process").ChildProcess;
+});
 const writeFileSpy = vi.fn((_path: string, _data: any) => {});
 const unlinkSpy = vi.fn((_path: string) => {});
 
@@ -35,7 +57,7 @@ vi.mock("node:child_process", async () => {
   const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
   return {
     ...actual,
-    execFileSync: execFileSyncSpy,
+    execFile: execFileSpy,
   };
 });
 
@@ -80,7 +102,7 @@ app.use("*", async (c, next) => {
 app.route("/api/voice", voiceRoute);
 
 beforeEach(() => {
-  execFileSyncSpy.mockClear();
+  execFileSpy.mockClear();
   writeFileSpy.mockClear();
   unlinkSpy.mockClear();
 });
@@ -108,35 +130,35 @@ describe("/transcribe extension allowlist (M-4)", () => {
     // The rejection must happen BEFORE writeFileSync (no tmp file created)
     // and BEFORE execFileSync (no transcribe invocation).
     expect(writeFileSpy).not.toHaveBeenCalled();
-    expect(execFileSyncSpy).not.toHaveBeenCalled();
+    expect(execFileSpy).not.toHaveBeenCalled();
   });
 
   it("rejects a filename whose extension contains command substitution", async () => {
     const { status, body } = await postTranscribe("audio.$(whoami)");
     expect(status).toBe(400);
     expect(body.error).toMatch(/unsupported audio extension/);
-    expect(execFileSyncSpy).not.toHaveBeenCalled();
+    expect(execFileSpy).not.toHaveBeenCalled();
   });
 
   it("rejects a completely unknown extension like .exe", async () => {
     const { status, body } = await postTranscribe("malware.exe");
     expect(status).toBe(400);
     expect(body.error).toMatch(/unsupported audio extension/);
-    expect(execFileSyncSpy).not.toHaveBeenCalled();
+    expect(execFileSpy).not.toHaveBeenCalled();
   });
 
   it("rejects a filename whose extension is a pipe to another command", async () => {
     const { status } = await postTranscribe("audio.mp3|nc evil 1234");
     expect(status).toBe(400);
-    expect(execFileSyncSpy).not.toHaveBeenCalled();
+    expect(execFileSpy).not.toHaveBeenCalled();
   });
 
-  it("accepts a .mp3 upload and calls execFileSync with an argv array", async () => {
+  it("accepts a .mp3 upload and calls execFile with an argv array", async () => {
     const { status, body } = await postTranscribe("song.mp3");
     expect(status).toBe(200);
     expect(body.text).toBe("hello world");
-    expect(execFileSyncSpy).toHaveBeenCalledTimes(1);
-    const [bin, args] = execFileSyncSpy.mock.calls[0];
+    expect(execFileSpy).toHaveBeenCalledTimes(1);
+    const [bin, args] = execFileSpy.mock.calls[0];
     expect(bin).toMatch(/bin\/transcribe$/);
     // Second arg is the argv array — a single element (the tmp path).
     expect(Array.isArray(args)).toBe(true);
@@ -148,10 +170,10 @@ describe("/transcribe extension allowlist (M-4)", () => {
     // Pared-down coverage of the allowlist — one per token.
     const exts = ["wav", "ogg", "webm", "m4a", "flac", "opus", "oga", "mp4", "aac"];
     for (const ext of exts) {
-      execFileSyncSpy.mockClear();
+      execFileSpy.mockClear();
       const { status } = await postTranscribe(`clip.${ext}`);
       expect(status, `ext=${ext}`).toBe(200);
-      expect(execFileSyncSpy, `ext=${ext}`).toHaveBeenCalledTimes(1);
+      expect(execFileSpy, `ext=${ext}`).toHaveBeenCalledTimes(1);
     }
   });
 

--- a/apps/server/src/routes/audio.ts
+++ b/apps/server/src/routes/audio.ts
@@ -8,6 +8,8 @@ import {
   ALLOWED_FILE_ROOTS,
   isPathAllowed as isPathAllowedShared,
 } from "../lib/path-allowed.js";
+import { getTracer } from "../lib/otel.js";
+import { SpanStatusCode } from "@opentelemetry/api";
 
 const execFileAsync = promisify(execFile);
 
@@ -17,6 +19,8 @@ loadOpenAIEnv();
 function isPathAllowed(absPath: string): Promise<boolean> {
   return isPathAllowedShared(absPath, ALLOWED_FILE_ROOTS);
 }
+
+const audioTracer = getTracer('cpc-server-audio');
 
 const app = new Hono();
 
@@ -92,26 +96,57 @@ app.post("/generate", async (c) => {
     const apiKey = process.env.OPENAI_API_KEY;
     if (!apiKey) return c.json({ ok: false, error: "OPENAI_API_KEY not set" }, 500);
 
-    const res = await fetch("https://api.openai.com/v1/audio/speech", {
-      method: "POST",
-      headers: {
-        "Authorization": `Bearer ${apiKey}`,
-        "Content-Type": "application/json",
+    const ttsInput = content.slice(0, 4096);
+    const ttsVoice = "nova";
+    const ttsSpan = audioTracer.startSpan('audio.tts', {
+      attributes: {
+        'ai.model': 'tts-1',
+        'audio.voice': ttsVoice,
+        'audio.input_length': ttsInput.length,
       },
-      body: JSON.stringify({
-        model: "tts-1",
-        input: content.slice(0, 4096), // API limit
-        voice: "nova",
-        response_format: "mp3",
-      }),
     });
 
-    if (!res.ok) {
-      const err = await res.text();
-      return c.json({ ok: false, error: `TTS API error: ${err}` }, 500);
+    let buffer: Buffer;
+    try {
+      let res: Response;
+      try {
+        res = await fetch("https://api.openai.com/v1/audio/speech", {
+          method: "POST",
+          headers: {
+            "Authorization": `Bearer ${apiKey}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            model: "tts-1",
+            input: ttsInput,
+            voice: ttsVoice,
+            response_format: "mp3",
+          }),
+        });
+      } catch (err) {
+        ttsSpan.recordException(err instanceof Error ? err : String(err));
+        ttsSpan.setStatus({ code: SpanStatusCode.ERROR });
+        throw err;
+      }
+
+      if (!res.ok) {
+        const err = await res.text();
+        ttsSpan.setAttribute('http.status_code', res.status);
+        ttsSpan.setStatus({ code: SpanStatusCode.ERROR });
+        // Return inside the try block so finally still runs to call ttsSpan.end()
+        return c.json({ ok: false, error: `TTS API error: ${err}` }, 500);
+      }
+
+      ttsSpan.setAttribute('http.status_code', res.status);
+      buffer = Buffer.from(await res.arrayBuffer());
+    } catch (err) {
+      ttsSpan.recordException(err instanceof Error ? err : String(err));
+      ttsSpan.setStatus({ code: SpanStatusCode.ERROR });
+      throw err;
+    } finally {
+      ttsSpan.end();
     }
 
-    const buffer = Buffer.from(await res.arrayBuffer());
     writeFileSync(audioPath, buffer);
 
     return c.json({ ok: true, path: audioPath });

--- a/apps/server/src/routes/files.ts
+++ b/apps/server/src/routes/files.ts
@@ -130,10 +130,37 @@ app.get("/roots", (c) => {
   });
 });
 
+// Synthetic home view — parent of all allowed roots. Constructed purely from
+// ALLOWED_ROOTS (no readdir on /home/claude) so disallowed siblings like .ssh
+// can never appear in the listing.
+const HOME_CLAUDE = "/home/claude";
+
 // List directory contents
 app.get("/list", async (c) => {
   const dir = c.req.query("path") || BASE_DIR;
   const resolved = resolve(dir);
+
+  // Synthetic home view: construct listing from allowlist, never readdir /home/claude.
+  if (resolved === HOME_CLAUDE) {
+    const items = ALLOWED_ROOTS
+      .map((r) => resolve(r))
+      .filter((r) => {
+        // Only include roots whose immediate parent is /home/claude
+        const parentDir = resolve(r, "..");
+        return parentDir === HOME_CLAUDE;
+      })
+      .map((r) => ({
+        name: basename(r),
+        path: r,
+        type: "dir" as const,
+      }));
+
+    return c.json({
+      path: HOME_CLAUDE,
+      parent: null,
+      items,
+    });
+  }
 
   if (!await isPathAllowed(resolved)) {
     return c.json({ error: "Access denied" }, 403);
@@ -205,6 +232,10 @@ app.get("/read", async (c) => {
   }
 
   const resolved = resolve(filePath);
+  // /home/claude itself is a synthetic virtual directory — never a real file.
+  if (resolved === HOME_CLAUDE) {
+    return c.json({ error: "Access denied" }, 403);
+  }
   if (!await isPathAllowed(resolved)) {
     return c.json({ error: "Access denied" }, 403);
   }

--- a/apps/server/src/routes/terminal/slash-commands.ts
+++ b/apps/server/src/routes/terminal/slash-commands.ts
@@ -81,10 +81,14 @@ app.post("/send-keys", async (c) => {
         execFileAsync("tmux", ["send-keys", "-t", TMUX_SESSION, ...tokens])
       );
     } else {
-      // Literal text — use -l to avoid special char issues, then Enter
+      // Literal text — use execFile (no shell) with `-l` and `--` so user
+      // input cannot inject via $(...) or backticks. The previous execAsync
+      // path spawned /bin/sh -c on an interpolated string; JSON.stringify
+      // only quotes for JS, NOT for shells, so `$(...)` and backticks in the
+      // keys survived the quote and were executed by sh BEFORE tmux saw them.
       await tracedTmux('tmux.send-keys', TMUX_SESSION, 'literal', async () => {
-        await execAsync(`tmux send-keys -t ${TMUX_SESSION} -l ${JSON.stringify(keys)}`);
-        await execAsync(`tmux send-keys -t ${TMUX_SESSION} Enter`);
+        await execFileAsync("tmux", ["send-keys", "-t", TMUX_SESSION, "-l", "--", keys]);
+        await execFileAsync("tmux", ["send-keys", "-t", TMUX_SESSION, "Enter"]);
       });
     }
     return c.json({ ok: true, action: "send-keys" });
@@ -99,10 +103,11 @@ app.post("/compact", async (c) => {
     const message = body.message as string;
     if (!message) return c.json({ ok: false, error: "message required" }, 400);
 
-    // Send via tmux send-keys
+    // Send via tmux send-keys — execFile (no shell) with -l + -- so the
+    // user-provided message cannot inject via $(...) or backticks.
     await tracedTmux('tmux.compact', TMUX_SESSION, 'compact', async () => {
-      await execAsync(`tmux send-keys -t ${TMUX_SESSION} -l ${JSON.stringify(message)}`);
-      await execAsync(`tmux send-keys -t ${TMUX_SESSION} Enter`);
+      await execFileAsync("tmux", ["send-keys", "-t", TMUX_SESSION, "-l", "--", message]);
+      await execFileAsync("tmux", ["send-keys", "-t", TMUX_SESSION, "Enter"]);
     });
     return c.json({ ok: true, action: "compact" });
   } catch (err: any) {

--- a/apps/server/src/routes/terminal/slash-commands.ts
+++ b/apps/server/src/routes/terminal/slash-commands.ts
@@ -2,8 +2,32 @@ import { Hono } from "hono";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { execAsync, sendToTmux, TMUX_SESSION } from "../utils.js";
+import { getTracer } from "../../lib/otel.js";
+import { SpanStatusCode } from "@opentelemetry/api";
 
 const execFileAsync = promisify(execFile);
+
+const tmuxTracer = getTracer('cpc-server-tmux');
+
+async function tracedTmux<T>(
+  spanName: string,
+  session: string,
+  commandType: string,
+  fn: () => Promise<T>
+): Promise<T> {
+  const span = tmuxTracer.startSpan(spanName, {
+    attributes: { 'tmux.session': session, 'tmux.command_type': commandType },
+  });
+  try {
+    return await fn();
+  } catch (err) {
+    span.recordException(err instanceof Error ? err : String(err));
+    span.setStatus({ code: SpanStatusCode.ERROR });
+    throw err;
+  } finally {
+    span.end();
+  }
+}
 
 const app = new Hono();
 
@@ -53,11 +77,15 @@ app.post("/send-keys", async (c) => {
         }
       }
       // execFile with argv — no shell, no interpolation.
-      await execFileAsync("tmux", ["send-keys", "-t", TMUX_SESSION, ...tokens]);
+      await tracedTmux('tmux.send-keys', TMUX_SESSION, 'raw', () =>
+        execFileAsync("tmux", ["send-keys", "-t", TMUX_SESSION, ...tokens])
+      );
     } else {
       // Literal text — use -l to avoid special char issues, then Enter
-      await execAsync(`tmux send-keys -t ${TMUX_SESSION} -l ${JSON.stringify(keys)}`);
-      await execAsync(`tmux send-keys -t ${TMUX_SESSION} Enter`);
+      await tracedTmux('tmux.send-keys', TMUX_SESSION, 'literal', async () => {
+        await execAsync(`tmux send-keys -t ${TMUX_SESSION} -l ${JSON.stringify(keys)}`);
+        await execAsync(`tmux send-keys -t ${TMUX_SESSION} Enter`);
+      });
     }
     return c.json({ ok: true, action: "send-keys" });
   } catch (err: any) {
@@ -72,8 +100,10 @@ app.post("/compact", async (c) => {
     if (!message) return c.json({ ok: false, error: "message required" }, 400);
 
     // Send via tmux send-keys
-    await execAsync(`tmux send-keys -t ${TMUX_SESSION} -l ${JSON.stringify(message)}`);
-    await execAsync(`tmux send-keys -t ${TMUX_SESSION} Enter`);
+    await tracedTmux('tmux.compact', TMUX_SESSION, 'compact', async () => {
+      await execAsync(`tmux send-keys -t ${TMUX_SESSION} -l ${JSON.stringify(message)}`);
+      await execAsync(`tmux send-keys -t ${TMUX_SESSION} Enter`);
+    });
     return c.json({ ok: true, action: "compact" });
   } catch (err: any) {
     return c.json({ ok: false, error: err.message }, 500);
@@ -82,7 +112,9 @@ app.post("/compact", async (c) => {
 
 app.post("/reload-plugins", async (c) => {
   try {
-    await sendToTmux("/reload-plugins");
+    await tracedTmux('tmux.send-keys', TMUX_SESSION, 'reload-plugins', () =>
+      sendToTmux("/reload-plugins")
+    );
     return c.json({ ok: true, action: "reload-plugins" });
   } catch (err: any) {
     return c.json({ ok: false, error: err.message }, 500);
@@ -91,14 +123,16 @@ app.post("/reload-plugins", async (c) => {
 
 app.post("/restart-session", async (c) => {
   try {
-    // Kill existing tmux session, then recreate using the same command as the cw alias
-    await execAsync(`tmux kill-session -t ${TMUX_SESSION} 2>/dev/null || true`, { shell: "/bin/bash" });
-    // Match the cw alias exactly: tmux new-session with the full claude command
-    const cmd = [
-      `tmux new-session -d -s ${TMUX_SESSION}`,
-      `"cd ~/claudes-world && TZ=America/New_York claude --dangerously-skip-permissions --continue --channels plugin:telegram@claude-plugins-official"`,
-    ].join(" ");
-    await execAsync(cmd, { shell: "/bin/bash" });
+    await tracedTmux('tmux.restart-session', TMUX_SESSION, 'restart-session', async () => {
+      // Kill existing tmux session, then recreate using the same command as the cw alias
+      await execAsync(`tmux kill-session -t ${TMUX_SESSION} 2>/dev/null || true`, { shell: "/bin/bash" });
+      // Match the cw alias exactly: tmux new-session with the full claude command
+      const cmd = [
+        `tmux new-session -d -s ${TMUX_SESSION}`,
+        `"cd ~/claudes-world && TZ=America/New_York claude --dangerously-skip-permissions --continue --channels plugin:telegram@claude-plugins-official"`,
+      ].join(" ");
+      await execAsync(cmd, { shell: "/bin/bash" });
+    });
     return c.json({ ok: true, action: "restart-session" });
   } catch (err: any) {
     return c.json({ ok: false, error: err.message }, 500);
@@ -107,7 +141,9 @@ app.post("/restart-session", async (c) => {
 
 app.post("/resize-terminal", async (c) => {
   try {
-    await execAsync(`tmux resize-window -t ${TMUX_SESSION} -A`);
+    await tracedTmux('tmux.resize-terminal', TMUX_SESSION, 'resize-terminal', () =>
+      execAsync(`tmux resize-window -t ${TMUX_SESSION} -A`)
+    );
     return c.json({ ok: true, action: "resize-terminal" });
   } catch (err: any) {
     return c.json({ ok: false, error: err.message }, 500);

--- a/apps/server/src/routes/voice.ts
+++ b/apps/server/src/routes/voice.ts
@@ -2,12 +2,24 @@ import { Hono } from "hono";
 import { writeFileSync, unlinkSync, readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { execFileSync } from "node:child_process";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
 import { nanoid } from "nanoid";
 import { db } from "../db.js";
 import { getUserId as getUserIdShared } from "../lib/get-user-id.js";
 import { getTracer } from "../lib/otel.js";
 import { SpanStatusCode } from "@opentelemetry/api";
+
+const execFileAsync = promisify(execFile);
+
+// Hard cap on the transcribe child process. Previously execFileSync had no
+// timeout, so a hung transcribe (network wedge, model hang, etc.) would
+// block the Node event loop indefinitely AND orphan the `audio.transcribe`
+// span — never ending means BatchSpanProcessor never exports it, eventually
+// overflowing the buffer. On timeout execFile SIGTERMs the child; we set
+// error status + `error.type=timeout` before span.end() so operators can
+// spot these in the trace backend.
+const TRANSCRIBE_TIMEOUT_MS = 60_000;
 
 /**
  * Allowlist for uploaded-audio file extensions. Anything outside this set is
@@ -97,18 +109,38 @@ app.post("/transcribe", async (c) => {
     });
     let text: string;
     try {
-      const result = execFileSync(transcribeBin, [tmpPath], {
-        encoding: "utf-8",
-        env: { ...process.env },
-      });
-      text = result.trim();
-    } catch (err) {
-      span.recordException(err instanceof Error ? err : String(err));
-      span.setStatus({ code: SpanStatusCode.ERROR });
+      try {
+        // execFile (async) with a timeout so the event loop isn't blocked and
+        // the span always ends even if the child hangs. encoding: "utf-8"
+        // returns stdout as a string. maxBuffer bumped to 10 MiB to cover
+        // long transcripts (default 1 MiB would truncate noisy multi-minute
+        // recordings).
+        const { stdout } = await execFileAsync(transcribeBin, [tmpPath], {
+          encoding: "utf-8",
+          env: { ...process.env },
+          timeout: TRANSCRIBE_TIMEOUT_MS,
+          maxBuffer: 10 * 1024 * 1024,
+        });
+        text = stdout.trim();
+      } catch (err) {
+        // Node surfaces a SIGTERM with `code === null` and `signal === 'SIGTERM'`
+        // (or `killed: true`) when the timeout fires. Tag those distinctly so
+        // operators can filter transcribe-timeouts vs real transcribe errors.
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const e = err as any;
+        if (e && (e.killed === true || e.signal === 'SIGTERM')) {
+          span.setAttribute('error.type', 'timeout');
+        }
+        span.recordException(err instanceof Error ? err : String(err));
+        span.setStatus({ code: SpanStatusCode.ERROR });
+        throw err;
+      }
+    } finally {
+      // Single end() path (finally) so a throw between startSpan and the
+      // inner try can never leak the span. Defence-in-depth vs the prior
+      // two-call shape.
       span.end();
-      throw err;
     }
-    span.end();
 
     return c.json({ text });
   } catch (err: any) {

--- a/apps/server/src/routes/voice.ts
+++ b/apps/server/src/routes/voice.ts
@@ -1,11 +1,13 @@
 import { Hono } from "hono";
-import { writeFileSync, unlinkSync, readFileSync } from "node:fs";
+import { writeFileSync, unlinkSync, readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { execFileSync } from "node:child_process";
 import { nanoid } from "nanoid";
 import { db } from "../db.js";
 import { getUserId as getUserIdShared } from "../lib/get-user-id.js";
+import { getTracer } from "../lib/otel.js";
+import { SpanStatusCode } from "@opentelemetry/api";
 
 /**
  * Allowlist for uploaded-audio file extensions. Anything outside this set is
@@ -40,6 +42,8 @@ function loadOpenAIEnv() {
 }
 
 loadOpenAIEnv();
+
+const voiceTracer = getTracer('cpc-server-audio');
 
 const app = new Hono();
 
@@ -82,11 +86,29 @@ app.post("/transcribe", async (c) => {
     // the ext (and therefore the tmp path) shell-safe, but routing through
     // execFile is the stronger guarantee: defense-in-depth against any
     // future regression that might weaken the allowlist.
-    const result = execFileSync(transcribeBin, [tmpPath], {
-      encoding: "utf-8",
-      env: { ...process.env },
+    let audioSizeBytes = 0;
+    try { audioSizeBytes = statSync(tmpPath).size; } catch { /* best-effort */ }
+
+    const span = voiceTracer.startSpan('audio.transcribe', {
+      attributes: {
+        'audio.format': rawExt,
+        'audio.size_bytes': audioSizeBytes,
+      },
     });
-    const text = result.trim();
+    let text: string;
+    try {
+      const result = execFileSync(transcribeBin, [tmpPath], {
+        encoding: "utf-8",
+        env: { ...process.env },
+      });
+      text = result.trim();
+    } catch (err) {
+      span.recordException(err instanceof Error ? err : String(err));
+      span.setStatus({ code: SpanStatusCode.ERROR });
+      span.end();
+      throw err;
+    }
+    span.end();
 
     return c.json({ text });
   } catch (err: any) {

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -197,6 +197,10 @@ export function App() {
     if (tg) {
       tg.ready();
       tg.expand();
+      // Request true full screen (hides Telegram header chrome) — Bot API 8.0+
+      if (typeof (tg as any).requestFullscreen === 'function') {
+        (tg as any).requestFullscreen();
+      }
     }
   }, []);
 

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -567,11 +567,11 @@ export function FileViewer({ onClose, initialFile, showHidden = false, sortMode 
           }}
         >
           {[
+            { label: "\ud83c\udfe0 home", path: "/home/claude" },
             { label: "claudes-world", path: "/home/claude/claudes-world" },
             { label: "code", path: "/home/claude/code" },
             { label: "bin", path: "/home/claude/bin" },
             { label: "\ud83c\udf10 .claude", path: "/home/claude/claudes-world/.claude" },
-            { label: "\ud83c\udfe0 .claude", path: "/home/claude/.claude" },
           ].map((root) => (
             <button
               key={root.path}

--- a/package.json
+++ b/package.json
@@ -17,5 +17,10 @@
     "@playwright/test": "^1.58.2",
     "turbo": "^2"
   },
-  "packageManager": "pnpm@10.28.1"
+  "packageManager": "pnpm@10.28.1",
+  "pnpm": {
+    "overrides": {
+      "dompurify": "^3.4.0"
+    }
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  dompurify: ^3.4.0
+
 importers:
 
   .:
@@ -19,16 +22,16 @@ importers:
     dependencies:
       '@hono/node-server':
         specifier: ^1
-        version: 1.19.13(hono@4.12.12)
+        version: 1.19.13(hono@4.12.14)
       '@hono/node-ws':
         specifier: ^1
-        version: 1.3.0(@hono/node-server@1.19.13(hono@4.12.12))(hono@4.12.12)
+        version: 1.3.0(@hono/node-server@1.19.13(hono@4.12.14))(hono@4.12.14)
       better-sqlite3:
         specifier: ^12.8.0
         version: 12.8.0
       hono:
-        specifier: ^4
-        version: 4.12.12
+        specifier: ^4.12.14
+        version: 4.12.14
       nanoid:
         specifier: ^5.1.7
         version: 5.1.7
@@ -1525,8 +1528,8 @@ packages:
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
-  dompurify@3.3.3:
-    resolution: {integrity: sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==}
+  dompurify@3.4.0:
+    resolution: {integrity: sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==}
 
   electron-to-chromium@1.5.332:
     resolution: {integrity: sha512-7OOtytmh/rINMLwaFTbcMVvYXO3AUm029X0LcyfYk0B557RlPkdpTpnH9+htMlfu5dKwOmT0+Zs2Aw+lnn6TeQ==}
@@ -1663,8 +1666,8 @@ packages:
     resolution: {integrity: sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==}
     engines: {node: '>=12.0.0'}
 
-  hono@4.12.12:
-    resolution: {integrity: sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==}
+  hono@4.12.14:
+    resolution: {integrity: sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==}
     engines: {node: '>=16.9.0'}
 
   html-encoding-sniffer@6.0.0:
@@ -2968,14 +2971,14 @@ snapshots:
 
   '@exodus/bytes@1.15.0': {}
 
-  '@hono/node-server@1.19.13(hono@4.12.12)':
+  '@hono/node-server@1.19.13(hono@4.12.14)':
     dependencies:
-      hono: 4.12.12
+      hono: 4.12.14
 
-  '@hono/node-ws@1.3.0(@hono/node-server@1.19.13(hono@4.12.12))(hono@4.12.12)':
+  '@hono/node-ws@1.3.0(@hono/node-server@1.19.13(hono@4.12.14))(hono@4.12.14)':
     dependencies:
-      '@hono/node-server': 1.19.13(hono@4.12.12)
-      hono: 4.12.12
+      '@hono/node-server': 1.19.13(hono@4.12.14)
+      hono: 4.12.14
       ws: 8.20.0
     transitivePeerDependencies:
       - bufferutil
@@ -3846,7 +3849,7 @@ snapshots:
 
   dom-accessibility-api@0.6.3: {}
 
-  dompurify@3.3.3:
+  dompurify@3.4.0:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -4022,7 +4025,7 @@ snapshots:
 
   highlight.js@11.11.1: {}
 
-  hono@4.12.12: {}
+  hono@4.12.14: {}
 
   html-encoding-sniffer@6.0.0:
     dependencies:
@@ -4379,7 +4382,7 @@ snapshots:
       d3-sankey: 0.12.3
       dagre-d3-es: 7.0.14
       dayjs: 1.11.20
-      dompurify: 3.3.3
+      dompurify: 3.4.0
       katex: 0.16.45
       khroma: 2.1.0
       lodash-es: 4.18.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,30 @@ importers:
       '@hono/node-ws':
         specifier: ^1
         version: 1.3.0(@hono/node-server@1.19.13(hono@4.12.14))(hono@4.12.14)
+      '@opentelemetry/api':
+        specifier: ^1.9.0
+        version: 1.9.1
+      '@opentelemetry/exporter-metrics-otlp-http':
+        specifier: 0.57.2
+        version: 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-trace-otlp-http':
+        specifier: 0.57.2
+        version: 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources':
+        specifier: ^1.30.0
+        version: 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics':
+        specifier: ^1.30.1
+        version: 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base':
+        specifier: ^1.30.0
+        version: 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-node':
+        specifier: ^1.30.0
+        version: 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions':
+        specifier: ^1.28.0
+        version: 1.40.0
       better-sqlite3:
         specifier: ^12.8.0
         version: 12.8.0
@@ -50,7 +74,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.3
-        version: 4.1.3(@types/node@22.19.17)(@vitest/ui@4.1.3)(jsdom@29.0.2)(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))
+        version: 4.1.3(@opentelemetry/api@1.9.1)(@types/node@22.19.17)(@vitest/ui@4.1.3)(jsdom@29.0.2)(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))
 
   apps/web:
     dependencies:
@@ -141,7 +165,7 @@ importers:
         version: 6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)
       vitest:
         specifier: ^4.1.3
-        version: 4.1.3(@types/node@22.19.17)(@vitest/ui@4.1.3)(jsdom@29.0.2)(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))
+        version: 4.1.3(@opentelemetry/api@1.9.1)(@types/node@22.19.17)(@vitest/ui@4.1.3)(jsdom@29.0.2)(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))
 
 packages:
 
@@ -666,6 +690,100 @@ packages:
   '@mermaid-js/parser@1.1.0':
     resolution: {integrity: sha512-gxK9ZX2+Fex5zu8LhRQoMeMPEHbc73UKZ0FQ54YrQtUxE1VVhMwzeNtKRPAu5aXks4FasbMe4xB4bWrmq6Jlxw==}
 
+  '@opentelemetry/api-logs@0.57.2':
+    resolution: {integrity: sha512-uIX52NnTM0iBh84MShlpouI7UKqkZ7MrUszTmaypHBu4r7NofznSnQRfJ+uUeDtQDj6w8eFGg5KBLDAwAPz1+A==}
+    engines: {node: '>=14'}
+
+  '@opentelemetry/api@1.9.1':
+    resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/context-async-hooks@1.30.1':
+    resolution: {integrity: sha512-s5vvxXPVdjqS3kTLKMeBMvop9hbWkwzBpu+mUO2M7sZtlkyDJGwFe33wRKnbaYDo8ExRVBIIdwIGrqpxHuKttA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/core@1.30.1':
+    resolution: {integrity: sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/exporter-metrics-otlp-http@0.57.2':
+    resolution: {integrity: sha512-ttb9+4iKw04IMubjm3t0EZsYRNWr3kg44uUuzfo9CaccYlOh8cDooe4QObDUkvx9d5qQUrbEckhrWKfJnKhemA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-trace-otlp-http@0.57.2':
+    resolution: {integrity: sha512-sB/gkSYFu+0w2dVQ0PWY9fAMl172PKMZ/JrHkkW8dmjCL0CYkmXeE+ssqIL/yBUTPOvpLIpenX5T9RwXRBW/3g==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-exporter-base@0.57.2':
+    resolution: {integrity: sha512-XdxEzL23Urhidyebg5E6jZoaiW5ygP/mRjxLHixogbqwDy2Faduzb5N0o/Oi+XTIJu+iyxXdVORjXax+Qgfxag==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-transformer@0.57.2':
+    resolution: {integrity: sha512-48IIRj49gbQVK52jYsw70+Jv+JbahT8BqT2Th7C4H7RCM9d0gZ5sgNPoMpWldmfjvIsSgiGJtjfk9MeZvjhoig==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/propagator-b3@1.30.1':
+    resolution: {integrity: sha512-oATwWWDIJzybAZ4pO76ATN5N6FFbOA1otibAVlS8v90B4S1wClnhRUk7K+2CHAwN1JKYuj4jh/lpCEG5BAqFuQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/propagator-jaeger@1.30.1':
+    resolution: {integrity: sha512-Pj/BfnYEKIOImirH76M4hDaBSx6HyZ2CXUqk+Kj02m6BB80c/yo4BdWkn/1gDFfU+YPY+bPR2U0DKBfdxCKwmg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/resources@1.30.1':
+    resolution: {integrity: sha512-5UxZqiAgLYGFjS4s9qm5mBVo433u+dSPUFWVWXmLAD4wB65oMCoXaJP1KJa9DIYYMeHu3z4BZcStG3LC593cWA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/sdk-logs@0.57.2':
+    resolution: {integrity: sha512-TXFHJ5c+BKggWbdEQ/inpgIzEmS2BGQowLE9UhsMd7YYlUfBQJ4uax0VF/B5NYigdM/75OoJGhAV3upEhK+3gg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.4.0 <1.10.0'
+
+  '@opentelemetry/sdk-metrics@1.30.1':
+    resolution: {integrity: sha512-q9zcZ0Okl8jRgmy7eNW3Ku1XSgg3sDLa5evHZpCwjspw7E8Is4K/haRPDJrBcX3YSn/Y7gUvFnByNYEKQNbNog==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-base@1.30.1':
+    resolution: {integrity: sha512-jVPgBbH1gCy2Lb7X0AVQ8XAfgg0pJ4nvl8/IiQA6nxOsPvS+0zMJaFSs2ltXe0J6C8dqjcnpyqINDJmU30+uOg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-node@1.30.1':
+    resolution: {integrity: sha512-cBjYOINt1JxXdpw1e5MlHmFRc5fgj4GW/86vsKFxJCJ8AL4PdVtYH41gWwl4qd4uQjqEL1oJVrXkSy5cnduAnQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/semantic-conventions@1.28.0':
+    resolution: {integrity: sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==}
+    engines: {node: '>=14'}
+
+  '@opentelemetry/semantic-conventions@1.40.0':
+    resolution: {integrity: sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==}
+    engines: {node: '>=14'}
+
   '@playwright/test@1.59.1':
     resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
     engines: {node: '>=18'}
@@ -673,6 +791,36 @@ packages:
 
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
+
+  '@protobufjs/aspromise@1.1.2':
+    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
+
+  '@protobufjs/base64@1.1.2':
+    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
+
+  '@protobufjs/codegen@2.0.4':
+    resolution: {integrity: sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==}
+
+  '@protobufjs/eventemitter@1.1.0':
+    resolution: {integrity: sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==}
+
+  '@protobufjs/fetch@1.1.0':
+    resolution: {integrity: sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==}
+
+  '@protobufjs/float@1.0.2':
+    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
+
+  '@protobufjs/inquire@1.1.0':
+    resolution: {integrity: sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==}
+
+  '@protobufjs/path@1.1.2':
+    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
+
+  '@protobufjs/pool@1.1.0':
+    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
+
+  '@protobufjs/utf8@1.1.0':
+    resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
 
   '@rolldown/pluginutils@1.0.0-beta.27':
     resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
@@ -1857,6 +2005,9 @@ packages:
   lodash-es@4.18.1:
     resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
 
+  long@5.3.2:
+    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
+
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
 
@@ -2138,6 +2289,10 @@ packages:
 
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
+
+  protobufjs@7.5.5:
+    resolution: {integrity: sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==}
+    engines: {node: '>=12.0.0'}
 
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
@@ -3015,11 +3170,134 @@ snapshots:
     dependencies:
       langium: 4.2.2
 
+  '@opentelemetry/api-logs@0.57.2':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+
+  '@opentelemetry/api@1.9.1': {}
+
+  '@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+
+  '@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/semantic-conventions': 1.28.0
+
+  '@opentelemetry/exporter-metrics-otlp-http@0.57.2(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 1.30.1(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/exporter-trace-otlp-http@0.57.2(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/otlp-exporter-base@0.57.2(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.57.2(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/otlp-transformer@0.57.2(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.57.2
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.1)
+      protobufjs: 7.5.5
+
+  '@opentelemetry/propagator-b3@1.30.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/propagator-jaeger@1.30.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/resources@1.30.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.28.0
+
+  '@opentelemetry/sdk-logs@0.57.2(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.57.2
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/sdk-metrics@1.30.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.28.0
+
+  '@opentelemetry/sdk-trace-node@1.30.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/context-async-hooks': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/propagator-b3': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/propagator-jaeger': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.1)
+      semver: 7.7.4
+
+  '@opentelemetry/semantic-conventions@1.28.0': {}
+
+  '@opentelemetry/semantic-conventions@1.40.0': {}
+
   '@playwright/test@1.59.1':
     dependencies:
       playwright: 1.59.1
 
   '@polka/url@1.0.0-next.29': {}
+
+  '@protobufjs/aspromise@1.1.2': {}
+
+  '@protobufjs/base64@1.1.2': {}
+
+  '@protobufjs/codegen@2.0.4': {}
+
+  '@protobufjs/eventemitter@1.1.0': {}
+
+  '@protobufjs/fetch@1.1.0':
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/inquire': 1.1.0
+
+  '@protobufjs/float@1.0.2': {}
+
+  '@protobufjs/inquire@1.1.0': {}
+
+  '@protobufjs/path@1.1.2': {}
+
+  '@protobufjs/pool@1.1.0': {}
+
+  '@protobufjs/utf8@1.1.0': {}
 
   '@rolldown/pluginutils@1.0.0-beta.27': {}
 
@@ -3475,7 +3753,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vitest: 4.1.3(@types/node@22.19.17)(@vitest/ui@4.1.3)(jsdom@29.0.2)(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))
+      vitest: 4.1.3(@opentelemetry/api@1.9.1)(@types/node@22.19.17)(@vitest/ui@4.1.3)(jsdom@29.0.2)(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))
 
   '@vitest/utils@4.1.3':
     dependencies:
@@ -4184,6 +4462,8 @@ snapshots:
 
   lodash-es@4.18.1: {}
 
+  long@5.3.2: {}
+
   longest-streak@3.1.0: {}
 
   lowlight@3.3.0:
@@ -4705,6 +4985,21 @@ snapshots:
 
   property-information@7.1.0: {}
 
+  protobufjs@7.5.5:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.4
+      '@protobufjs/eventemitter': 1.1.0
+      '@protobufjs/fetch': 1.1.0
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/inquire': 1.1.0
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.0
+      '@types/node': 22.19.17
+      long: 5.3.2
+
   pump@3.0.4:
     dependencies:
       end-of-stream: 1.4.5
@@ -5110,7 +5405,7 @@ snapshots:
       lightningcss: 1.32.0
       tsx: 4.21.0
 
-  vitest@4.1.3(@types/node@22.19.17)(@vitest/ui@4.1.3)(jsdom@29.0.2)(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)):
+  vitest@4.1.3(@opentelemetry/api@1.9.1)(@types/node@22.19.17)(@vitest/ui@4.1.3)(jsdom@29.0.2)(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)):
     dependencies:
       '@vitest/expect': 4.1.3
       '@vitest/mocker': 4.1.3(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))
@@ -5133,6 +5428,7 @@ snapshots:
       vite: 6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
+      '@opentelemetry/api': 1.9.1
       '@types/node': 22.19.17
       '@vitest/ui': 4.1.3(vitest@4.1.3)
       jsdom: 29.0.2

--- a/systemd/user/cpc-dev.service
+++ b/systemd/user/cpc-dev.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Claude Pocket Console — dev (Vite + tsx watch)
+After=network-online.target
+StartLimitIntervalSec=120
+StartLimitBurst=5
+
+[Service]
+Type=simple
+WorkingDirectory=/home/claude/code/claude-pocket-console
+Environment=PORT=38831
+Environment=PATH=/home/claude/.local/share/fnm/aliases/default/bin:/home/claude/.local/bin:/home/claude/bin:/usr/local/bin:/usr/bin:/bin
+ExecStart=/home/claude/.local/bin/pnpm dev
+ExecStartPost=/home/claude/code/toolbox/lib/systemd-wait-port.sh 38831
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=default.target

--- a/systemd/user/cpc.service
+++ b/systemd/user/cpc.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Claude Pocket Console — prod (latest tagged release)
+After=network-online.target
+StartLimitIntervalSec=120
+StartLimitBurst=5
+
+[Service]
+Type=simple
+WorkingDirectory=/home/claude/code/claude-pocket-console-prod
+Environment=PORT=38830
+Environment=NODE_ENV=production
+Environment=PATH=/home/claude/.local/share/fnm/aliases/default/bin:/home/claude/.local/bin:/home/claude/bin:/usr/local/bin:/usr/bin:/bin
+ExecStart=/home/claude/.local/share/fnm/aliases/default/bin/node apps/server/dist/index.js
+ExecStartPost=/home/claude/code/toolbox/lib/systemd-wait-port.sh 38830
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
**Liam's merge gate.** Rebuilt `dev` per the 2026-07-02 audit (`agent-tasks/cpc-dev-audit-report.md`, Option B): fresh branch from `main` @63ec678 with only the nav-independent keepers cherry-picked, then `dev` was reset to it (old dev preserved at `archive/nav-redesign-v2-20260702`).

## Included (7 items)
- #263 dependabot/deps bumps
- #265 file-browser `.world` allowlist + synthetic home view
- #271 OTEL instrumentation
- #272 OTEL phase-4 hardening (server security/lifecycle + test coverage)
- #273 hardened systemd units (`cpc.service`/`cpc-dev.service` — relevant to Mac-mini migration)
- #278 docs: branching convention pointer
- 1fd0157 Telegram Mini-App full-screen launch (4 lines, re-applied by hand onto main's `App.tsx`)

## Deliberately stripped (preserved on the archive branch)
- Nav Redesign v2 Phases 1/2/3/4 (#259/#260/#261/#262) — the janky TabDock/swipe-drawer/ticker cluster
- #267 ActionBar restore (dependent revert of Phase 3 — moot without it)
- #269 Pulse Lab (+3,676 LOC, 4 experimental dashboards, welded to the stripped nav) — **separate keep/rebuild decision when wanted**

## Verification
- Build green for both packages; **523 tests pass** (277 server + 246 web).
- The 46 initial failures reproduced identically on a clean `origin/main` worktree — pre-existing `NODE_ENV=production` sandbox artifact, not introduced here (green with `NODE_ENV=test`).
- Full report: `~/claudes-world/tmp/cpc-dev-cleanup-report.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)