### PR TITLE
feat(cpc): manual "Fit screen" action — resize pty+tmux to mini-app viewport

### DIFF
--- a/apps/server/src/routes/__tests__/terminal-ws-fit.test.ts
+++ b/apps/server/src/routes/__tests__/terminal-ws-fit.test.ts
@@ -1,0 +1,243 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { createSession } from "../../auth.js";
+
+/**
+ * "Fit screen" WS message tests (manual resize action, issue: CPC tmux
+ * terminal sizing QoL fix).
+ *
+ * Covers:
+ *   1. `validateFitDimensions` — bounds/type checks in isolation (no tmux
+ *      involved), since this is the untrusted input surface (WebView).
+ *   2. `onMessage` wiring — a valid `{ type: "fit", cols, rows }` message
+ *      calls `tmux resize-window -t <session> -x <cols> -y <rows>` via
+ *      `execFile` (argv array, no shell) and acks over the socket; an
+ *      invalid message never reaches `execFile` and gets an error reply
+ *      instead; the legacy `resize` message type remains a no-op.
+ */
+
+const TEST_USER_ID = "999222";
+
+let savedBotToken: string | undefined;
+let savedAllowed: string | undefined;
+
+beforeAll(() => {
+  savedBotToken = process.env.TELEGRAM_BOT_TOKEN;
+  savedAllowed = process.env.ALLOWED_TELEGRAM_USERS;
+  process.env.TELEGRAM_BOT_TOKEN = "123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11";
+  process.env.ALLOWED_TELEGRAM_USERS = TEST_USER_ID;
+});
+
+afterAll(() => {
+  if (savedBotToken === undefined) {
+    delete process.env.TELEGRAM_BOT_TOKEN;
+  } else {
+    process.env.TELEGRAM_BOT_TOKEN = savedBotToken;
+  }
+  if (savedAllowed === undefined) {
+    delete process.env.ALLOWED_TELEGRAM_USERS;
+  } else {
+    process.env.ALLOWED_TELEGRAM_USERS = savedAllowed;
+  }
+});
+
+// Capture every execFile invocation so we can assert on the exact argv used
+// for the tmux resize-window call, without ever spawning a real process.
+const execFileCalls: { cmd: string; args: string[] }[] = [];
+const mockExecFile = vi.fn(
+  (cmd: string, args: string[], callback: (err: Error | null, stdout?: string, stderr?: string) => void) => {
+    execFileCalls.push({ cmd, args });
+    callback(null, "", "");
+  },
+);
+
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:child_process")>();
+  return {
+    ...actual,
+    spawn: vi.fn(() => ({
+      stdout: { on: vi.fn() },
+      on: vi.fn(),
+    })),
+    execSync: vi.fn(() => "80x24"),
+    execFile: mockExecFile,
+  };
+});
+
+// Mock utils to avoid tmux session validation at import time (same pattern
+// as terminal-ws-auth.test.ts).
+vi.mock("../utils.js", async () => {
+  const actual = await vi.importActual<typeof import("../utils.js")>("../utils.js");
+  return { ...actual, TMUX_SESSION: "test-session" };
+});
+
+const { terminalWsRoute, validateFitDimensions } = await import("../terminal-ws.js");
+
+function makeMockContext(query: Record<string, string>, headers: Record<string, string> = {}) {
+  return {
+    req: {
+      query: (key: string) => query[key] || "",
+      header: (key: string) => headers[key.toLowerCase()],
+    },
+  };
+}
+
+function makeMockWs() {
+  const sent: string[] = [];
+  return {
+    send: vi.fn((data: string) => sent.push(data)),
+    close: vi.fn(),
+    _sent: sent,
+  };
+}
+
+function connectAuthenticatedWs() {
+  const token = createSession({ id: Number(TEST_USER_ID), first_name: "Allowed" });
+  const c = makeMockContext({ token }, { origin: "https://cpc.claude.do" });
+  const handlers = terminalWsRoute(c);
+  const ws = makeMockWs();
+  handlers.onOpen(new Event("open"), ws as any);
+  return { handlers, ws };
+}
+
+// ---------------------------------------------------------------------------
+// validateFitDimensions — pure bounds/type validation
+// ---------------------------------------------------------------------------
+
+describe("validateFitDimensions", () => {
+  it("accepts a sane cols/rows pair", () => {
+    expect(validateFitDimensions({ cols: 92, rows: 40 })).toEqual({ ok: true, cols: 92, rows: 40 });
+  });
+
+  it("accepts the boundary values", () => {
+    expect(validateFitDimensions({ cols: 20, rows: 5 })).toEqual({ ok: true, cols: 20, rows: 5 });
+    expect(validateFitDimensions({ cols: 500, rows: 300 })).toEqual({ ok: true, cols: 500, rows: 300 });
+  });
+
+  it("rejects cols below the minimum", () => {
+    const result = validateFitDimensions({ cols: 19, rows: 24 });
+    expect(result.ok).toBe(false);
+  });
+
+  it("rejects cols above the maximum", () => {
+    const result = validateFitDimensions({ cols: 501, rows: 24 });
+    expect(result.ok).toBe(false);
+  });
+
+  it("rejects rows below the minimum", () => {
+    const result = validateFitDimensions({ cols: 80, rows: 4 });
+    expect(result.ok).toBe(false);
+  });
+
+  it("rejects rows above the maximum", () => {
+    const result = validateFitDimensions({ cols: 80, rows: 301 });
+    expect(result.ok).toBe(false);
+  });
+
+  it("rejects non-integer cols/rows (floats)", () => {
+    expect(validateFitDimensions({ cols: 80.5, rows: 24 }).ok).toBe(false);
+    expect(validateFitDimensions({ cols: 80, rows: 24.5 }).ok).toBe(false);
+  });
+
+  it("rejects string cols/rows (a WebView could send anything)", () => {
+    expect(validateFitDimensions({ cols: "80", rows: 24 }).ok).toBe(false);
+  });
+
+  it("rejects missing fields", () => {
+    expect(validateFitDimensions({ cols: 80 }).ok).toBe(false);
+    expect(validateFitDimensions({}).ok).toBe(false);
+  });
+
+  it("rejects non-object input", () => {
+    expect(validateFitDimensions(null).ok).toBe(false);
+    expect(validateFitDimensions("80x24").ok).toBe(false);
+    expect(validateFitDimensions(42).ok).toBe(false);
+  });
+
+  it("rejects NaN/Infinity smuggled in as numbers", () => {
+    expect(validateFitDimensions({ cols: NaN, rows: 24 }).ok).toBe(false);
+    expect(validateFitDimensions({ cols: 80, rows: Infinity }).ok).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// onMessage wiring — "fit" applies a bounded tmux resize-window call
+// ---------------------------------------------------------------------------
+
+describe("terminalWsRoute onMessage: fit", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    execFileCalls.length = 0;
+  });
+
+  it("calls tmux resize-window with the exact validated argv on a valid fit request", async () => {
+    const { handlers, ws } = connectAuthenticatedWs();
+
+    handlers.onMessage({ data: JSON.stringify({ type: "fit", cols: 92, rows: 40 }) } as any, ws as any);
+    // applyFitResize resolves via a microtask (promisified execFile) — flush it.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(execFileCalls).toHaveLength(1);
+    expect(execFileCalls[0].cmd).toBe("tmux");
+    expect(execFileCalls[0].args).toEqual([
+      "resize-window", "-t", "test-session", "-x", "92", "-y", "40",
+    ]);
+
+    (ws as any)._cleanup?.();
+  });
+
+  it("sends a fit-ack over the socket once tmux resize-window succeeds", async () => {
+    const { handlers, ws } = connectAuthenticatedWs();
+
+    handlers.onMessage({ data: JSON.stringify({ type: "fit", cols: 100, rows: 30 }) } as any, ws as any);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const acks = ws._sent.map((s) => JSON.parse(s)).filter((m) => m.type === "fit-ack");
+    expect(acks).toEqual([{ type: "fit-ack", cols: 100, rows: 30 }]);
+
+    (ws as any)._cleanup?.();
+  });
+
+  it("never calls tmux and replies with an error for an out-of-bounds fit request", async () => {
+    const { handlers, ws } = connectAuthenticatedWs();
+    ws._sent.length = 0; // drop the initial "dimensions"/"pane" sends from onOpen
+
+    handlers.onMessage({ data: JSON.stringify({ type: "fit", cols: 5000, rows: 40 }) } as any, ws as any);
+    await Promise.resolve();
+
+    expect(execFileCalls).toHaveLength(0);
+    const errors = ws._sent.map((s) => JSON.parse(s)).filter((m) => m.type === "error");
+    expect(errors).toHaveLength(1);
+
+    (ws as any)._cleanup?.();
+  });
+
+  it("never calls tmux for a malformed fit request (non-numeric rows)", async () => {
+    const { handlers, ws } = connectAuthenticatedWs();
+
+    handlers.onMessage({ data: JSON.stringify({ type: "fit", cols: 80, rows: "24" }) } as any, ws as any);
+    await Promise.resolve();
+
+    expect(execFileCalls).toHaveLength(0);
+
+    (ws as any)._cleanup?.();
+  });
+
+  it("legacy 'resize' message type remains a no-op (does not call tmux)", async () => {
+    const { handlers, ws } = connectAuthenticatedWs();
+
+    handlers.onMessage({ data: JSON.stringify({ type: "resize", cols: 92, rows: 40 }) } as any, ws as any);
+    await Promise.resolve();
+
+    expect(execFileCalls).toHaveLength(0);
+
+    (ws as any)._cleanup?.();
+  });
+
+  it("ignores non-JSON messages without throwing", () => {
+    const { handlers, ws } = connectAuthenticatedWs();
+    expect(() => handlers.onMessage({ data: "not-json{{{" } as any, ws as any)).not.toThrow();
+    (ws as any)._cleanup?.();
+  });
+});

--- a/apps/server/src/routes/__tests__/terminal-ws-fit.test.ts
+++ b/apps/server/src/routes/__tests__/terminal-ws-fit.test.ts
@@ -11,11 +11,18 @@ import { createSession } from "../../auth.js";
  *   2. `onMessage` wiring — a valid `{ type: "fit", cols, rows }` message
  *      calls `tmux resize-window -t <session> -x <cols> -y <rows>` via
  *      `execFile` (argv array, no shell) and acks over the socket; an
- *      invalid message never reaches `execFile` and gets an error reply
- *      instead; the legacy `resize` message type remains a no-op.
+ *      invalid message never reaches `execFile` and gets a `fit-error`
+ *      reply instead; the legacy `resize` message type remains a no-op.
+ *   3. Auth guard — an unauthenticated (no token) or disallowed-user
+ *      socket must never reach `execFile` even if a well-formed `fit`
+ *      message arrives on it. This is the regression coverage a prior
+ *      review round found missing (PR #284 review, 2026-07-07): the
+ *      `if (!authResult.ok) return;` guard in `onMessage` was correct on
+ *      inspection but had zero test proof.
  */
 
 const TEST_USER_ID = "999222";
+const INTRUDER_ID = "888333";
 
 let savedBotToken: string | undefined;
 let savedAllowed: string | undefined;
@@ -96,6 +103,21 @@ function connectAuthenticatedWs() {
   const handlers = terminalWsRoute(c);
   const ws = makeMockWs();
   handlers.onOpen(new Event("open"), ws as any);
+  return { handlers, ws };
+}
+
+/**
+ * Build a `terminalWsRoute` for a socket that should NOT be authorized —
+ * either no token at all, or a token for a user outside the allowlist.
+ * Deliberately does NOT call `onOpen` (which would close the socket) so
+ * these tests can assert the `onMessage` guard independently catches the
+ * case where a message arrives before (or instead of) that close landing —
+ * exactly the race the guard's own comment describes.
+ */
+function connectUnauthenticatedWs(token = "") {
+  const c = makeMockContext(token ? { token } : {}, { origin: "https://cpc.claude.do" });
+  const handlers = terminalWsRoute(c);
+  const ws = makeMockWs();
   return { handlers, ws };
 }
 
@@ -199,7 +221,7 @@ describe("terminalWsRoute onMessage: fit", () => {
     (ws as any)._cleanup?.();
   });
 
-  it("never calls tmux and replies with an error for an out-of-bounds fit request", async () => {
+  it("never calls tmux and replies with fit-error for an out-of-bounds fit request", async () => {
     const { handlers, ws } = connectAuthenticatedWs();
     ws._sent.length = 0; // drop the initial "dimensions"/"pane" sends from onOpen
 
@@ -207,19 +229,24 @@ describe("terminalWsRoute onMessage: fit", () => {
     await Promise.resolve();
 
     expect(execFileCalls).toHaveLength(0);
-    const errors = ws._sent.map((s) => JSON.parse(s)).filter((m) => m.type === "error");
+    const errors = ws._sent.map((s) => JSON.parse(s)).filter((m) => m.type === "fit-error");
     expect(errors).toHaveLength(1);
 
     (ws as any)._cleanup?.();
   });
 
-  it("never calls tmux for a malformed fit request (non-numeric rows)", async () => {
+  it("never calls tmux and replies with fit-error for a malformed fit request (non-numeric rows)", async () => {
     const { handlers, ws } = connectAuthenticatedWs();
+    ws._sent.length = 0; // drop the initial "dimensions"/"pane" sends from onOpen
 
     handlers.onMessage({ data: JSON.stringify({ type: "fit", cols: 80, rows: "24" }) } as any, ws as any);
     await Promise.resolve();
 
     expect(execFileCalls).toHaveLength(0);
+    // Aligned with the out-of-bounds test above (previously only asserted
+    // the execFile-empty half of this, per review finding).
+    const errors = ws._sent.map((s) => JSON.parse(s)).filter((m) => m.type === "fit-error");
+    expect(errors).toHaveLength(1);
 
     (ws as any)._cleanup?.();
   });
@@ -238,6 +265,69 @@ describe("terminalWsRoute onMessage: fit", () => {
   it("ignores non-JSON messages without throwing", () => {
     const { handlers, ws } = connectAuthenticatedWs();
     expect(() => handlers.onMessage({ data: "not-json{{{" } as any, ws as any)).not.toThrow();
+    (ws as any)._cleanup?.();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Auth guard on "fit" — the regression coverage the review flagged as
+// missing. `onMessage` reads the same `authResult` closure variable that
+// `onOpen` uses to decide whether to close the socket (4001); these tests
+// prove that even without `onOpen` having run (or having already closed the
+// socket), a `fit` message on an unauthenticated/disallowed connection can
+// never reach `applyFitResize`/`execFile`.
+// ---------------------------------------------------------------------------
+
+describe("terminalWsRoute onMessage: fit auth guard", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    execFileCalls.length = 0;
+  });
+
+  it("drops a fit message with no token at all — never calls tmux", () => {
+    const { handlers, ws } = connectUnauthenticatedWs("");
+
+    handlers.onMessage({ data: JSON.stringify({ type: "fit", cols: 92, rows: 40 }) } as any, ws as any);
+
+    expect(execFileCalls).toHaveLength(0);
+    expect(mockExecFile).not.toHaveBeenCalled();
+  });
+
+  it("drops a fit message from a disallowed (non-allowlisted) user's session token — never calls tmux", () => {
+    const token = createSession({ id: Number(INTRUDER_ID), first_name: "Intruder" });
+    const { handlers, ws } = connectUnauthenticatedWs(token);
+
+    handlers.onMessage({ data: JSON.stringify({ type: "fit", cols: 92, rows: 40 }) } as any, ws as any);
+
+    expect(execFileCalls).toHaveLength(0);
+    expect(mockExecFile).not.toHaveBeenCalled();
+  });
+
+  it("still drops the fit message even after onOpen has already closed the unauthorized socket", () => {
+    const token = createSession({ id: Number(INTRUDER_ID), first_name: "Intruder" });
+    const { handlers, ws } = connectUnauthenticatedWs(token);
+
+    // Simulate onOpen having run first (the normal case) — it should close
+    // with 4001 and send the auth error, never touching tmux.
+    handlers.onOpen(new Event("open"), ws as any);
+    expect(ws.close).toHaveBeenCalledWith(4001, "Unauthorized");
+
+    // A message that still arrives afterward (the race the guard's comment
+    // describes) must be dropped too.
+    handlers.onMessage({ data: JSON.stringify({ type: "fit", cols: 92, rows: 40 }) } as any, ws as any);
+
+    expect(execFileCalls).toHaveLength(0);
+    expect(mockExecFile).not.toHaveBeenCalled();
+  });
+
+  it("control case: the same fit message DOES call tmux on an authenticated, allowlisted socket", async () => {
+    const { handlers, ws } = connectAuthenticatedWs();
+
+    handlers.onMessage({ data: JSON.stringify({ type: "fit", cols: 92, rows: 40 }) } as any, ws as any);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(execFileCalls).toHaveLength(1);
     (ws as any)._cleanup?.();
   });
 });

--- a/apps/server/src/routes/terminal-ws.ts
+++ b/apps/server/src/routes/terminal-ws.ts
@@ -1,4 +1,5 @@
-import { spawn, execSync } from "node:child_process";
+import { spawn, execSync, execFile } from "node:child_process";
+import { promisify } from "node:util";
 import type { WSContext } from "hono/ws";
 import { checkAuth, validateSession, validateJwtTokenWithTokens, getBotTokens } from "../auth.js";
 import { isAllowedUser } from "../lib/allowed-users.js";
@@ -9,6 +10,8 @@ import { isAllowedUser } from "../lib/allowed-users.js";
 // security-high by cloud Gemini Code Assist on round-2 review of PR #85.
 import { TMUX_SESSION } from "./utils.js";
 import { ALLOWED_ORIGINS } from "../lib/allowed-origins.js";
+
+const execFileAsync = promisify(execFile);
 
 function getPaneDimensions(): { cols: number; rows: number } {
   try {
@@ -23,10 +26,79 @@ function getPaneDimensions(): { cols: number; rows: number } {
   }
 }
 
-// NOTE: Do NOT resize tmux from the mini app. The mini app is a read-only
-// viewer using capture-pane. Resizing tmux to the mini app's viewport breaks
-// the user's SSH terminal which may have a different size.
-// The mini app adapts to whatever tmux size exists via -J (join wrapped lines).
+// NOTE (original design, still true for the *automatic* path): the mini app
+// is a read-only viewer using capture-pane, not a real attached tmux client.
+// tmux itself decides the window's size from its `window-size` option
+// (host default: "smallest" — the size of the smallest ATTACHED client,
+// e.g. a Termius SSH session) plus the `/resize-terminal` REST endpoint
+// (slash-commands.ts) which forces `resize-window -A` (largest attached
+// client) on every Reconnect tap. Neither of those has any notion of the
+// mini app's own xterm.js viewport, because the mini app was never an
+// "attached client" in tmux's eyes — it only polls `capture-pane`. That's
+// the root cause of the sizing bug: whichever SSH client happens to be
+// attached (or the stale size left over from one that detached) wins, and
+// the mini app just captures whatever that produced.
+//
+// We still do NOT auto-resize tmux to the mini app's viewport on every
+// frame/reconnect — that would fight a concurrently attached Termius
+// session and thrash the window size back and forth. Instead we support a
+// single EXPLICIT, user-initiated "fit" request (the "Fit screen" action in
+// the reconnect menu): the client measures its current xterm.js viewport
+// and sends one `{ type: "fit", cols, rows }` message; we validate the
+// dimensions and issue exactly one bounded `tmux resize-window -x -y` call.
+// Per `man tmux`, `resize-window -x/-y` "automatically sets window-size to
+// manual" for that window, so the size sticks until the user (or another
+// manual resize) changes it again — a deliberate, visible trade-off the
+// user accepts by tapping the button, not something we impose silently.
+const FIT_COLS_MIN = 20;
+const FIT_COLS_MAX = 500;
+const FIT_ROWS_MIN = 5;
+const FIT_ROWS_MAX = 300;
+
+export type FitValidationResult =
+  | { ok: true; cols: number; rows: number }
+  | { ok: false; error: string };
+
+/**
+ * Validate the cols/rows pair in a client "fit" WS message before it ever
+ * reaches `tmux resize-window`. This input comes from a Telegram WebView —
+ * untrusted by definition — so bounds are enforced defensively even though
+ * the values are also argv-escaped (no shell) below.
+ */
+export function validateFitDimensions(msg: unknown): FitValidationResult {
+  if (typeof msg !== "object" || msg === null) {
+    return { ok: false, error: "fit message must be an object" };
+  }
+  const { cols, rows } = msg as { cols?: unknown; rows?: unknown };
+  if (!Number.isInteger(cols) || !Number.isInteger(rows)) {
+    return { ok: false, error: "cols/rows must be integers" };
+  }
+  const c = cols as number;
+  const r = rows as number;
+  if (c < FIT_COLS_MIN || c > FIT_COLS_MAX) {
+    return { ok: false, error: `cols out of range (${FIT_COLS_MIN}-${FIT_COLS_MAX})` };
+  }
+  if (r < FIT_ROWS_MIN || r > FIT_ROWS_MAX) {
+    return { ok: false, error: `rows out of range (${FIT_ROWS_MIN}-${FIT_ROWS_MAX})` };
+  }
+  return { ok: true, cols: c, rows: r };
+}
+
+/**
+ * Apply a validated fit request: resize the tmux window to exactly
+ * cols x rows. `execFile` (no shell) with an argv array — same discipline
+ * as `sendToTmux` in routes/utils.ts — so the numeric strings can never be
+ * interpreted as shell metacharacters even though they're already
+ * integer-validated above.
+ */
+export async function applyFitResize(cols: number, rows: number): Promise<void> {
+  await execFileAsync("tmux", [
+    "resize-window",
+    "-t", TMUX_SESSION,
+    "-x", String(cols),
+    "-y", String(rows),
+  ]);
+}
 
 export function terminalWsRoute(c: any) {
   // Origin check: WebSocket upgrades bypass Hono's cors() middleware, so we
@@ -130,9 +202,40 @@ export function terminalWsRoute(c: any) {
     },
 
     onMessage(event: MessageEvent, ws: WSContext) {
+      // onMessage previously only logged on any branch (dead weight — the
+      // "resize" case was a documented no-op). Now that a message type can
+      // trigger a real `tmux resize-window` call, guard on the same
+      // authResult computed in onOpen; onOpen already closes unauthorized
+      // sockets, but this closes the gap if a message arrives before the
+      // close takes effect.
+      if (!authResult.ok) return;
       try {
         const msg = JSON.parse(event.data.toString());
-        if (msg.type === "resize") {
+        if (msg.type === "fit") {
+          // Explicit, user-initiated "Fit screen" action only — the client
+          // never sends this automatically (see NOTE above). Validate
+          // before touching tmux.
+          const result = validateFitDimensions(msg);
+          if (!result.ok) {
+            console.log(`[ws] fit rejected: ${result.error}`);
+            ws.send(JSON.stringify({ type: "error", message: result.error }));
+            return;
+          }
+          const { cols, rows } = result;
+          applyFitResize(cols, rows)
+            .then(() => {
+              console.log(`[ws] fit applied: ${cols}x${rows}`);
+              ws.send(JSON.stringify({ type: "fit-ack", cols, rows }));
+            })
+            .catch((err: Error) => {
+              console.error("[tmux] fit resize error:", err.message);
+              ws.send(JSON.stringify({ type: "error", message: "Failed to resize tmux window" }));
+            });
+        } else if (msg.type === "resize") {
+          // Legacy/automatic path — intentionally still a no-op. Kept so any
+          // stray client still sending continuous resize-on-viewport-change
+          // messages can't silently start fighting an attached Termius
+          // session. Only the explicit "fit" message (above) resizes tmux.
           console.log(`[ws] resize request ignored (read-only viewer): ${msg.cols}x${msg.rows}`);
         }
       } catch {

--- a/apps/server/src/routes/terminal-ws.ts
+++ b/apps/server/src/routes/terminal-ws.ts
@@ -218,7 +218,12 @@ export function terminalWsRoute(c: any) {
           const result = validateFitDimensions(msg);
           if (!result.ok) {
             console.log(`[ws] fit rejected: ${result.error}`);
-            ws.send(JSON.stringify({ type: "error", message: result.error }));
+            // Distinct "fit-error" type (not the generic "error" also used
+            // for auth failures) so the client can pair it unambiguously
+            // with "fit-ack" and surface a real failure instead of the
+            // optimistic "requested" status sticking around. (Review
+            // finding: client previously showed success regardless.)
+            ws.send(JSON.stringify({ type: "fit-error", message: result.error }));
             return;
           }
           const { cols, rows } = result;
@@ -229,7 +234,7 @@ export function terminalWsRoute(c: any) {
             })
             .catch((err: Error) => {
               console.error("[tmux] fit resize error:", err.message);
-              ws.send(JSON.stringify({ type: "error", message: "Failed to resize tmux window" }));
+              ws.send(JSON.stringify({ type: "fit-error", message: "Failed to resize tmux window" }));
             });
         } else if (msg.type === "resize") {
           // Legacy/automatic path — intentionally still a no-op. Kept so any

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -141,6 +141,15 @@ export function App() {
   const onFitScreen = useCallback(() => {
     fitScreenRef.current?.();
   }, []);
+  // The server's fit-ack/fit-error round-trip, forwarded to ActionBar so it
+  // can replace its optimistic "Fit screen requested" status with the real
+  // outcome. `ts` forces a new object identity on every result even if
+  // ok/message are identical to the previous one (e.g. two failed taps in a
+  // row), so ActionBar's effect fires each time rather than only on change.
+  const [fitResult, setFitResult] = useState<{ ok: boolean; message?: string; ts: number } | null>(null);
+  const onFitResult = useCallback((result: { ok: boolean; message?: string }) => {
+    setFitResult({ ...result, ts: Date.now() });
+  }, []);
 
   // Swipe gesture state
   const touchStartX = useRef(0);
@@ -440,7 +449,7 @@ export function App() {
           onTransitionEnd={() => setIsAnimating(false)}
         >
           <div style={{ width: `${100 / TABS.length}%`, height: "100%", flexShrink: 0 }}>
-            <Terminal key={reconnectKey} onConnectionChange={onConnectionChange} isActive={activeTab === "terminal"} fitScreenRef={fitScreenRef} />
+            <Terminal key={reconnectKey} onConnectionChange={onConnectionChange} isActive={activeTab === "terminal"} fitScreenRef={fitScreenRef} onFitResult={onFitResult} />
           </div>
           <div style={{ width: `${100 / TABS.length}%`, height: "100%", flexShrink: 0 }}>
             <FileViewer onClose={() => setActiveTab("terminal")} initialFile={initialFilePath} showHidden={fileShowHidden} sortMode={fileSortMode} onSortModeChange={setFileSortMode} onViewChange={setViewingFile} onPathChange={setCurrentFolder} />
@@ -462,6 +471,7 @@ export function App() {
         <ActionBar
           onReconnect={onReconnect}
           onFitScreen={onFitScreen}
+          fitResult={fitResult}
           connected={connected}
           activeTab={activeTab}
           fileShowHidden={fileShowHidden}

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -132,6 +132,16 @@ export function App() {
     setReconnectKey((k) => k + 1);
   }, []);
 
+  // "Fit screen" (reconnect menu) — Terminal registers its trigger function
+  // into this ref on mount; onFitScreen just forwards the tap to it. Kept
+  // as a plain ref (not state) since invoking it has no render-visible
+  // effect of its own — the resulting tmux resize shows up as new "pane"
+  // WS frames a moment later.
+  const fitScreenRef = useRef<(() => void) | null>(null);
+  const onFitScreen = useCallback(() => {
+    fitScreenRef.current?.();
+  }, []);
+
   // Swipe gesture state
   const touchStartX = useRef(0);
   const touchStartY = useRef(0);
@@ -430,7 +440,7 @@ export function App() {
           onTransitionEnd={() => setIsAnimating(false)}
         >
           <div style={{ width: `${100 / TABS.length}%`, height: "100%", flexShrink: 0 }}>
-            <Terminal key={reconnectKey} onConnectionChange={onConnectionChange} isActive={activeTab === "terminal"} />
+            <Terminal key={reconnectKey} onConnectionChange={onConnectionChange} isActive={activeTab === "terminal"} fitScreenRef={fitScreenRef} />
           </div>
           <div style={{ width: `${100 / TABS.length}%`, height: "100%", flexShrink: 0 }}>
             <FileViewer onClose={() => setActiveTab("terminal")} initialFile={initialFilePath} showHidden={fileShowHidden} sortMode={fileSortMode} onSortModeChange={setFileSortMode} onViewChange={setViewingFile} onPathChange={setCurrentFolder} />
@@ -451,6 +461,7 @@ export function App() {
       <div onTouchStart={(e) => e.stopPropagation()}>
         <ActionBar
           onReconnect={onReconnect}
+          onFitScreen={onFitScreen}
           connected={connected}
           activeTab={activeTab}
           fileShowHidden={fileShowHidden}

--- a/apps/web/src/__tests__/Terminal.test.tsx
+++ b/apps/web/src/__tests__/Terminal.test.tsx
@@ -8,7 +8,7 @@
 import React from "react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render } from "@testing-library/react";
-import { Terminal } from "../components/Terminal";
+import { Terminal, type FitResult } from "../components/Terminal";
 import type { MutableRefObject } from "react";
 
 // ---------------------------------------------------------------------------
@@ -71,6 +71,14 @@ const mockTermOpen = vi.fn();
 const mockTermLoadAddon = vi.fn();
 const mockFitFit = vi.fn();
 
+// Mutable so individual tests can simulate an unusually wide/narrow/short
+// viewport (e.g. a desktop browser tab resolving to >500 cols) and assert
+// on the clamped value Terminal.tsx sends. Getters read the current value
+// at access time, matching how the component reads `term.cols`/`term.rows`
+// fresh on every `sendFitRequest()` call.
+let mockTermCols = 80;
+let mockTermRows = 24;
+
 vi.mock("@xterm/xterm", () => {
   function MockXTerm() {
     return {
@@ -79,8 +87,8 @@ vi.mock("@xterm/xterm", () => {
       write: mockTermWrite,
       resize: mockTermResize,
       dispose: mockTermDispose,
-      cols: 80,
-      rows: 24,
+      get cols() { return mockTermCols; },
+      get rows() { return mockTermRows; },
     };
   }
   return { Terminal: MockXTerm };
@@ -131,6 +139,9 @@ beforeEach(() => {
   resizeObserverCallback = null;
   vi.useFakeTimers();
 
+  mockTermCols = 80;
+  mockTermRows = 24;
+
   mockTermWrite.mockClear();
   mockTermResize.mockClear();
   mockTermDispose.mockClear();
@@ -173,10 +184,10 @@ function renderTerminal(onConnectionChange = vi.fn()) {
   return render(<Terminal onConnectionChange={onConnectionChange} />);
 }
 
-function renderTerminalWithFitRef(onConnectionChange = vi.fn()) {
+function renderTerminalWithFitRef(onConnectionChange = vi.fn(), onFitResult?: (r: FitResult) => void) {
   const fitScreenRef: MutableRefObject<(() => void) | null> = { current: null };
   const utils = render(
-    <Terminal onConnectionChange={onConnectionChange} fitScreenRef={fitScreenRef} />,
+    <Terminal onConnectionChange={onConnectionChange} fitScreenRef={fitScreenRef} onFitResult={onFitResult} />,
   );
   return { ...utils, fitScreenRef };
 }
@@ -405,6 +416,68 @@ describe("fit screen action", () => {
     renderTerminalWithFitRef();
     const ws = getWs();
     expect(() => ws.simulateMessage({ type: "fit-ack", cols: 92, rows: 40 })).not.toThrow();
+  });
+
+  it("clamps an oversized viewport (e.g. a wide desktop browser tab) to the server's max cols before sending", () => {
+    mockTermCols = 800; // wider than the server's FIT_COLS_MAX (500)
+    mockTermRows = 24;
+    const { fitScreenRef } = renderTerminalWithFitRef();
+    const ws = getWs();
+    ws.simulateOpen();
+
+    fitScreenRef.current?.();
+
+    const fitSends = ws.send.mock.calls
+      .map((call: unknown[]) => JSON.parse(call[0] as string))
+      .filter((m: { type: string }) => m.type === "fit");
+    expect(fitSends).toEqual([{ type: "fit", cols: 500, rows: 24 }]);
+  });
+
+  it("clamps an undersized viewport to the server's minimum rows before sending", () => {
+    mockTermCols = 80;
+    mockTermRows = 2; // below the server's FIT_ROWS_MIN (5)
+    const { fitScreenRef } = renderTerminalWithFitRef();
+    const ws = getWs();
+    ws.simulateOpen();
+
+    fitScreenRef.current?.();
+
+    const fitSends = ws.send.mock.calls
+      .map((call: unknown[]) => JSON.parse(call[0] as string))
+      .filter((m: { type: string }) => m.type === "fit");
+    expect(fitSends).toEqual([{ type: "fit", cols: 80, rows: 5 }]);
+  });
+
+  it("calls onFitResult({ ok: true, ... }) when a fit-ack arrives", () => {
+    const onFitResult = vi.fn();
+    renderTerminalWithFitRef(vi.fn(), onFitResult);
+    const ws = getWs();
+
+    ws.simulateMessage({ type: "fit-ack", cols: 92, rows: 40 });
+
+    expect(onFitResult).toHaveBeenCalledWith({ ok: true, cols: 92, rows: 40 });
+  });
+
+  it("calls onFitResult({ ok: false, message }) when a fit-error arrives, distinct from fit-ack", () => {
+    const onFitResult = vi.fn();
+    renderTerminalWithFitRef(vi.fn(), onFitResult);
+    const ws = getWs();
+
+    ws.simulateMessage({ type: "fit-error", message: "cols out of range (20-500)" });
+
+    expect(onFitResult).toHaveBeenCalledWith({ ok: false, message: "cols out of range (20-500)" });
+    expect(onFitResult).not.toHaveBeenCalledWith(expect.objectContaining({ ok: true }));
+  });
+
+  it("does not call onFitResult for unrelated messages (dimensions/pane)", () => {
+    const onFitResult = vi.fn();
+    renderTerminalWithFitRef(vi.fn(), onFitResult);
+    const ws = getWs();
+
+    ws.simulateMessage({ type: "dimensions", cols: 80, rows: 24 });
+    ws.simulateMessage({ type: "pane", content: "hello" });
+
+    expect(onFitResult).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/web/src/__tests__/Terminal.test.tsx
+++ b/apps/web/src/__tests__/Terminal.test.tsx
@@ -9,6 +9,7 @@ import React from "react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render } from "@testing-library/react";
 import { Terminal } from "../components/Terminal";
+import type { MutableRefObject } from "react";
 
 // ---------------------------------------------------------------------------
 // WebSocket mock
@@ -16,6 +17,14 @@ import { Terminal } from "../components/Terminal";
 
 class MockWebSocket {
   static instances: MockWebSocket[] = [];
+  // Match the real WebSocket readyState constants — Terminal.tsx compares
+  // readyState against `WebSocket.OPEN` etc., and once the test swaps in
+  // this mock as the global WebSocket, those class statics must exist or
+  // every comparison silently resolves against `undefined`.
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSING = 2;
+  static readonly CLOSED = 3;
   url: string;
   onopen: (() => void) | null = null;
   onmessage: ((e: { data: string }) => void) | null = null;
@@ -25,6 +34,7 @@ class MockWebSocket {
   close = vi.fn(() => {
     this.readyState = 3;
   });
+  send = vi.fn();
 
   constructor(url: string) {
     this.url = url;
@@ -161,6 +171,14 @@ afterEach(() => {
 
 function renderTerminal(onConnectionChange = vi.fn()) {
   return render(<Terminal onConnectionChange={onConnectionChange} />);
+}
+
+function renderTerminalWithFitRef(onConnectionChange = vi.fn()) {
+  const fitScreenRef: MutableRefObject<(() => void) | null> = { current: null };
+  const utils = render(
+    <Terminal onConnectionChange={onConnectionChange} fitScreenRef={fitScreenRef} />,
+  );
+  return { ...utils, fitScreenRef };
 }
 
 function getWs(): MockWebSocket {
@@ -330,6 +348,63 @@ describe("message handling", () => {
     renderTerminal();
     getWs().simulateRawMessage("not-json{{{{");
     expect(mockTermWrite).toHaveBeenCalledWith("not-json{{{{");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fit screen action (manual, via fitScreenRef)
+// ---------------------------------------------------------------------------
+
+describe("fit screen action", () => {
+  it("registers a trigger function on fitScreenRef after mount", () => {
+    const { fitScreenRef } = renderTerminalWithFitRef();
+    expect(typeof fitScreenRef.current).toBe("function");
+  });
+
+  it("does nothing automatically — no 'fit' message is sent without invoking the ref", () => {
+    renderTerminalWithFitRef();
+    const ws = getWs();
+    ws.simulateOpen();
+    const fitSends = ws.send.mock.calls.filter((call: unknown[]) => {
+      try { return JSON.parse(call[0] as string).type === "fit"; } catch { return false; }
+    });
+    expect(fitSends).toHaveLength(0);
+  });
+
+  it("sends a 'fit' message with the current xterm cols/rows when the trigger fires", () => {
+    const { fitScreenRef } = renderTerminalWithFitRef();
+    const ws = getWs();
+    ws.simulateOpen();
+
+    fitScreenRef.current?.();
+
+    expect(mockFitFit).toHaveBeenCalled();
+    const fitSends = ws.send.mock.calls
+      .map((call: unknown[]) => JSON.parse(call[0] as string))
+      .filter((m: { type: string }) => m.type === "fit");
+    // Mock XTerm reports cols: 80, rows: 24 (see MockXTerm above)
+    expect(fitSends).toEqual([{ type: "fit", cols: 80, rows: 24 }]);
+  });
+
+  it("does not send when the socket isn't open yet", () => {
+    const { fitScreenRef } = renderTerminalWithFitRef();
+    const ws = getWs();
+    // readyState still CONNECTING (0) — never called simulateOpen()
+    fitScreenRef.current?.();
+    expect(ws.send).not.toHaveBeenCalled();
+  });
+
+  it("unregisters the trigger on unmount", () => {
+    const { fitScreenRef, unmount } = renderTerminalWithFitRef();
+    expect(fitScreenRef.current).not.toBeNull();
+    unmount();
+    expect(fitScreenRef.current).toBeNull();
+  });
+
+  it("handles a fit-ack message from the server without throwing", () => {
+    renderTerminalWithFitRef();
+    const ws = getWs();
+    expect(() => ws.simulateMessage({ type: "fit-ack", cols: 92, rows: 40 })).not.toThrow();
   });
 });
 

--- a/apps/web/src/components/Terminal.tsx
+++ b/apps/web/src/components/Terminal.tsx
@@ -4,6 +4,28 @@ import { FitAddon } from "@xterm/addon-fit";
 import { WebLinksAddon } from "@xterm/addon-web-links";
 import "@xterm/xterm/css/xterm.css";
 
+// Keep in sync with FIT_COLS_MIN/MAX, FIT_ROWS_MIN/MAX in
+// apps/server/src/routes/terminal-ws.ts. Clamping client-side is a UX
+// nicety (avoids a round-trip failure for the common case of a viewport
+// resolving wider/taller than the bound, e.g. a wide desktop browser tab)
+// — the server remains the source of truth and validates independently
+// regardless of what the client sends.
+const FIT_COLS_MIN = 20;
+const FIT_COLS_MAX = 500;
+const FIT_ROWS_MIN = 5;
+const FIT_ROWS_MAX = 300;
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.round(Math.max(min, Math.min(max, value)));
+}
+
+export interface FitResult {
+  ok: boolean;
+  cols?: number;
+  rows?: number;
+  message?: string;
+}
+
 interface TerminalProps {
   onConnectionChange: (connected: boolean) => void;
   isActive?: boolean;
@@ -17,6 +39,13 @@ interface TerminalProps {
    * internal; only the trigger function is exposed).
    */
   fitScreenRef?: MutableRefObject<(() => void) | null>;
+  /**
+   * Fired when the server acks (`fit-ack`) or rejects (`fit-error`) a fit
+   * request, so the caller (App.tsx -> ActionBar) can replace the optimistic
+   * "Fit screen requested" status with the real outcome instead of leaving
+   * it looking like unconditional success.
+   */
+  onFitResult?: (result: FitResult) => void;
 }
 
 /** Build the WebSocket URL with auth params. */
@@ -38,7 +67,7 @@ function buildWsUrl(): string {
   return `${protocol}//${window.location.host}/ws/terminal${authParam}`;
 }
 
-export function Terminal({ onConnectionChange, isActive, fitScreenRef }: TerminalProps) {
+export function Terminal({ onConnectionChange, isActive, fitScreenRef, onFitResult }: TerminalProps) {
   const wrapperRef = useRef<HTMLDivElement>(null);
   const mountRef = useRef<HTMLDivElement>(null);
   const termRef = useRef<XTerm | null>(null);
@@ -48,6 +77,11 @@ export function Terminal({ onConnectionChange, isActive, fitScreenRef }: Termina
   // Stable ref for onConnectionChange so connectWs doesn't need it as a dep
   const onConnectionChangeRef = useRef(onConnectionChange);
   onConnectionChangeRef.current = onConnectionChange;
+
+  // Same pattern for onFitResult — connectWs/ws.onmessage is only set up
+  // once per connection and shouldn't need to be a dependency of anything.
+  const onFitResultRef = useRef(onFitResult);
+  onFitResultRef.current = onFitResult;
 
   /** Open a WebSocket and wire it to the current xterm instance.
    *  Closes any existing connection first to prevent duplicates. */
@@ -99,11 +133,19 @@ export function Terminal({ onConnectionChange, isActive, fitScreenRef }: Termina
             term.write(lines[i].trimEnd());
             if (i < lines.length - 1) term.write("\r\n");
           }
-        } else if (msg.type === "fit-ack" || msg.type === "error") {
-          // Server-side confirmation/rejection of a "Fit screen" request.
-          // Nothing to render here — ActionBar shows its own optimistic
-          // status text when the button is tapped. Logged for debugging.
-          console.log(`[fit] ${msg.type}`, msg);
+        } else if (msg.type === "fit-ack") {
+          // Server applied the fit request. Distinct from the generic
+          // "error" type (also used for auth failures) so this can't be
+          // confused with an unrelated connection error.
+          console.log(`[fit] applied ${msg.cols}x${msg.rows}`);
+          onFitResultRef.current?.({ ok: true, cols: msg.cols, rows: msg.rows });
+        } else if (msg.type === "fit-error") {
+          // Server rejected or failed to apply the fit request (validation
+          // failure or a tmux resize-window error). Surfaced to the caller
+          // so the UI can replace the optimistic "requested" status with
+          // the real outcome instead of showing false success.
+          console.log(`[fit] rejected: ${msg.message}`);
+          onFitResultRef.current?.({ ok: false, message: msg.message });
         }
       } catch {
         term.write(event.data);
@@ -130,6 +172,11 @@ export function Terminal({ onConnectionChange, isActive, fitScreenRef }: Termina
    * issue a single bounded `tmux resize-window -x -y` call. No-ops quietly
    * if the terminal isn't mounted or the socket isn't open — there's no
    * meaningful fallback for a tap that arrives mid-reconnect.
+   *
+   * Dimensions are clamped to the server's own bounds before sending (a
+   * wide desktop browser tab can resolve to well over 500 cols). The
+   * server re-validates independently either way — this just avoids
+   * manufacturing an avoidable `fit-error` round-trip for the common case.
    */
   const sendFitRequest = useCallback(() => {
     const term = termRef.current;
@@ -137,7 +184,8 @@ export function Terminal({ onConnectionChange, isActive, fitScreenRef }: Termina
     const ws = wsRef.current;
     if (!term || !fit || !ws || ws.readyState !== WebSocket.OPEN) return;
     fit.fit();
-    const { cols, rows } = term;
+    const cols = clamp(term.cols, FIT_COLS_MIN, FIT_COLS_MAX);
+    const rows = clamp(term.rows, FIT_ROWS_MIN, FIT_ROWS_MAX);
     if (cols > 0 && rows > 0) {
       ws.send(JSON.stringify({ type: "fit", cols, rows }));
     }

--- a/apps/web/src/components/Terminal.tsx
+++ b/apps/web/src/components/Terminal.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef, type MutableRefObject } from "react";
 import { Terminal as XTerm } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { WebLinksAddon } from "@xterm/addon-web-links";
@@ -7,6 +7,16 @@ import "@xterm/xterm/css/xterm.css";
 interface TerminalProps {
   onConnectionChange: (connected: boolean) => void;
   isActive?: boolean;
+  /**
+   * Escape hatch for the "Fit screen" action (reconnect menu). The parent
+   * (App.tsx) owns this ref; Terminal populates it with a function that
+   * measures the current xterm.js viewport and sends a one-shot `fit`
+   * request over the live WebSocket. Terminal doesn't use forwardRef
+   * elsewhere in this codebase, so a plain ref-as-prop keeps this consistent
+   * with the rest of the component's imperative surface (wsRef/fitRef stay
+   * internal; only the trigger function is exposed).
+   */
+  fitScreenRef?: MutableRefObject<(() => void) | null>;
 }
 
 /** Build the WebSocket URL with auth params. */
@@ -28,7 +38,7 @@ function buildWsUrl(): string {
   return `${protocol}//${window.location.host}/ws/terminal${authParam}`;
 }
 
-export function Terminal({ onConnectionChange, isActive }: TerminalProps) {
+export function Terminal({ onConnectionChange, isActive, fitScreenRef }: TerminalProps) {
   const wrapperRef = useRef<HTMLDivElement>(null);
   const mountRef = useRef<HTMLDivElement>(null);
   const termRef = useRef<XTerm | null>(null);
@@ -89,6 +99,11 @@ export function Terminal({ onConnectionChange, isActive }: TerminalProps) {
             term.write(lines[i].trimEnd());
             if (i < lines.length - 1) term.write("\r\n");
           }
+        } else if (msg.type === "fit-ack" || msg.type === "error") {
+          // Server-side confirmation/rejection of a "Fit screen" request.
+          // Nothing to render here — ActionBar shows its own optimistic
+          // status text when the button is tapped. Logged for debugging.
+          console.log(`[fit] ${msg.type}`, msg);
         }
       } catch {
         term.write(event.data);
@@ -107,6 +122,36 @@ export function Terminal({ onConnectionChange, isActive }: TerminalProps) {
 
     wsRef.current = ws;
   }, []);
+
+  /**
+   * "Fit screen" action (reconnect menu, manual only — never auto-fired).
+   * Re-measures the actual xterm.js viewport with the fit addon, then sends
+   * exactly one `fit` request over the live WebSocket so the server can
+   * issue a single bounded `tmux resize-window -x -y` call. No-ops quietly
+   * if the terminal isn't mounted or the socket isn't open — there's no
+   * meaningful fallback for a tap that arrives mid-reconnect.
+   */
+  const sendFitRequest = useCallback(() => {
+    const term = termRef.current;
+    const fit = fitRef.current;
+    const ws = wsRef.current;
+    if (!term || !fit || !ws || ws.readyState !== WebSocket.OPEN) return;
+    fit.fit();
+    const { cols, rows } = term;
+    if (cols > 0 && rows > 0) {
+      ws.send(JSON.stringify({ type: "fit", cols, rows }));
+    }
+  }, []);
+
+  // Register/unregister the fit trigger on the parent-owned ref so
+  // ActionBar -> ReconnectMenu can reach it without forwardRef plumbing.
+  useEffect(() => {
+    if (!fitScreenRef) return;
+    fitScreenRef.current = sendFitRequest;
+    return () => {
+      fitScreenRef.current = null;
+    };
+  }, [fitScreenRef, sendFitRequest]);
 
   // Initialize xterm and open the first WS connection on mount
   useEffect(() => {

--- a/apps/web/src/components/__tests__/ActionBar.test.tsx
+++ b/apps/web/src/components/__tests__/ActionBar.test.tsx
@@ -418,6 +418,30 @@ describe("ActionBar", () => {
     expect(onReconnect).toHaveBeenCalledOnce();
   });
 
+  it("hides Fit Screen button when onFitScreen is not provided", async () => {
+    const onReconnect = vi.fn();
+    render(<ActionBar activeTab="terminal" onReconnect={onReconnect} />);
+    fireEvent.click(screen.getByLabelText("Open reconnect menu"));
+    await waitFor(() => expect(screen.getByText("Reconnect Terminal")).toBeInTheDocument());
+
+    expect(screen.queryByText("Fit Screen")).not.toBeInTheDocument();
+  });
+
+  it("shows Fit Screen button and calls onFitScreen when tapped, then closes the menu", async () => {
+    const onReconnect = vi.fn();
+    const onFitScreen = vi.fn();
+    render(<ActionBar activeTab="terminal" onReconnect={onReconnect} onFitScreen={onFitScreen} />);
+    fireEvent.click(screen.getByLabelText("Open reconnect menu"));
+    await waitFor(() => expect(screen.getByText("Fit Screen")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByText("Fit Screen"));
+
+    expect(onFitScreen).toHaveBeenCalledOnce();
+    // Menu closes and status reflects the action (manual, not automatic).
+    await waitFor(() => expect(screen.queryByTestId("bottom-sheet")).not.toBeInTheDocument());
+    expect(screen.getByText("Fit screen requested")).toBeInTheDocument();
+  });
+
   it("calls restartSession when restart button is clicked", async () => {
     const onReconnect = vi.fn();
     render(<ActionBar activeTab="terminal" onReconnect={onReconnect} />);

--- a/apps/web/src/components/__tests__/ActionBar.test.tsx
+++ b/apps/web/src/components/__tests__/ActionBar.test.tsx
@@ -442,6 +442,52 @@ describe("ActionBar", () => {
     expect(screen.getByText("Fit screen requested")).toBeInTheDocument();
   });
 
+  it("replaces the optimistic status with 'Fit screen applied' once fitResult resolves ok", async () => {
+    const onReconnect = vi.fn();
+    const onFitScreen = vi.fn();
+    const { rerender } = render(
+      <ActionBar activeTab="terminal" onReconnect={onReconnect} onFitScreen={onFitScreen} fitResult={null} />,
+    );
+    fireEvent.click(screen.getByLabelText("Open reconnect menu"));
+    await waitFor(() => expect(screen.getByText("Fit Screen")).toBeInTheDocument());
+    fireEvent.click(screen.getByText("Fit Screen"));
+    expect(screen.getByText("Fit screen requested")).toBeInTheDocument();
+
+    // Server round-trip resolves — App.tsx would pass a fresh fitResult object.
+    rerender(
+      <ActionBar activeTab="terminal" onReconnect={onReconnect} onFitScreen={onFitScreen} fitResult={{ ok: true, ts: Date.now() }} />,
+    );
+
+    await waitFor(() => expect(screen.getByText("Fit screen applied")).toBeInTheDocument());
+    expect(screen.queryByText("Fit screen requested")).not.toBeInTheDocument();
+  });
+
+  it("surfaces a distinct failure status (not the optimistic success text) when fitResult resolves not-ok", async () => {
+    const onReconnect = vi.fn();
+    const onFitScreen = vi.fn();
+    const { rerender } = render(
+      <ActionBar activeTab="terminal" onReconnect={onReconnect} onFitScreen={onFitScreen} fitResult={null} />,
+    );
+    fireEvent.click(screen.getByLabelText("Open reconnect menu"));
+    await waitFor(() => expect(screen.getByText("Fit Screen")).toBeInTheDocument());
+    fireEvent.click(screen.getByText("Fit Screen"));
+
+    rerender(
+      <ActionBar
+        activeTab="terminal"
+        onReconnect={onReconnect}
+        onFitScreen={onFitScreen}
+        fitResult={{ ok: false, message: "cols out of range (20-500)", ts: Date.now() }}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByText("Fit screen failed: cols out of range (20-500)")).toBeInTheDocument(),
+    );
+    expect(screen.queryByText("Fit screen requested")).not.toBeInTheDocument();
+    expect(screen.queryByText("Fit screen applied")).not.toBeInTheDocument();
+  });
+
   it("calls restartSession when restart button is clicked", async () => {
     const onReconnect = vi.fn();
     render(<ActionBar activeTab="terminal" onReconnect={onReconnect} />);

--- a/apps/web/src/components/action-bar/ActionBar.tsx
+++ b/apps/web/src/components/action-bar/ActionBar.tsx
@@ -32,7 +32,7 @@ import { usePreferences } from "../../hooks/usePreferences";
 // for a boolean with a sensible default of ON.
 const SEARCH_SCOPE_PREF = "searchCurrentFolderOnly";
 
-export function ActionBar({ onReconnect, onFitScreen, connected, activeTab, fileShowHidden, setFileShowHidden, fileSortMode, setFileSortMode, viewingFile, currentFolder }: ActionBarProps) {
+export function ActionBar({ onReconnect, onFitScreen, fitResult, connected, activeTab, fileShowHidden, setFileShowHidden, fileSortMode, setFileSortMode, viewingFile, currentFolder }: ActionBarProps) {
   const [status, setStatus] = useState<string | null>(null);
   const [modal, setModal] = useState<Modal>(null);
   const [compactFocus, setCompactFocus] = useState("");
@@ -104,6 +104,25 @@ export function ActionBar({ onReconnect, onFitScreen, connected, activeTab, file
     const timer = setTimeout(() => setStatus(null), 4000);
     return () => clearTimeout(timer);
   }, [status]);
+
+  // Replace the optimistic "Fit screen requested" status (set the instant
+  // the button is tapped, in the reconnect-menu case below) with the real
+  // server round-trip result once it arrives. Without this, an oversized
+  // viewport (wide desktop tab) or a tmux resize-window failure would leave
+  // the UI claiming success indefinitely. Depends only on `fitResult` (not
+  // `status`) so a later unrelated status update doesn't get clobbered by a
+  // stale ack arriving after the fact.
+  useEffect(() => {
+    if (!fitResult) return;
+    if (fitResult.ok) {
+      haptic.success();
+      setStatus("Fit screen applied");
+    } else {
+      haptic.error();
+      setStatus(`Fit screen failed: ${fitResult.message || "unknown error"}`);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [fitResult]);
 
   const handleAction = async (endpoint: string, label: string) => {
     setStatus(`Running ${label}...`);

--- a/apps/web/src/components/action-bar/ActionBar.tsx
+++ b/apps/web/src/components/action-bar/ActionBar.tsx
@@ -32,7 +32,7 @@ import { usePreferences } from "../../hooks/usePreferences";
 // for a boolean with a sensible default of ON.
 const SEARCH_SCOPE_PREF = "searchCurrentFolderOnly";
 
-export function ActionBar({ onReconnect, connected, activeTab, fileShowHidden, setFileShowHidden, fileSortMode, setFileSortMode, viewingFile, currentFolder }: ActionBarProps) {
+export function ActionBar({ onReconnect, onFitScreen, connected, activeTab, fileShowHidden, setFileShowHidden, fileSortMode, setFileSortMode, viewingFile, currentFolder }: ActionBarProps) {
   const [status, setStatus] = useState<string | null>(null);
   const [modal, setModal] = useState<Modal>(null);
   const [compactFocus, setCompactFocus] = useState("");
@@ -444,6 +444,12 @@ export function ActionBar({ onReconnect, connected, activeTab, fileShowHidden, s
           onClose={() => setModal(null)}
           onReconnect={() => { onReconnect(); setModal(null); }}
           onRestart={() => void handleRestartSession()}
+          onFitScreen={onFitScreen ? () => {
+            haptic.impact("light");
+            onFitScreen();
+            setModal(null);
+            setStatus("Fit screen requested");
+          } : undefined}
         />
       ) : null;
       break;

--- a/apps/web/src/components/action-bar/ReconnectMenu.tsx
+++ b/apps/web/src/components/action-bar/ReconnectMenu.tsx
@@ -19,7 +19,7 @@ export function ReconnectMenu({ onClose, onReconnect, onRestart, onFitScreen }: 
         {onFitScreen && (
           <button onClick={onFitScreen} style={{ ...btnStyle, padding: "10px 14px", textAlign: "left", background: "#1a2a3a", color: "var(--color-accent-blue)", border: "1px solid #2d4a5a" }}>
             Fit Screen
-            <div style={{ fontSize: 10, color: "#4a6a8a", marginTop: 2 }}>Resize the terminal to match this screen</div>
+            <div style={{ fontSize: 10, color: "#4a6a8a", marginTop: 2 }}>Resize the terminal to match this screen (also resizes it for anyone else attached, e.g. via SSH)</div>
           </button>
         )}
         <button onClick={onRestart} style={{ ...btnStyle, padding: "10px 14px", textAlign: "left", background: "#3a2020", color: "var(--color-accent-red)", border: "1px solid #5a3030" }}>

--- a/apps/web/src/components/action-bar/ReconnectMenu.tsx
+++ b/apps/web/src/components/action-bar/ReconnectMenu.tsx
@@ -5,9 +5,10 @@ interface ReconnectMenuProps {
   onClose: () => void;
   onReconnect: () => void;
   onRestart: () => void;
+  onFitScreen?: () => void;
 }
 
-export function ReconnectMenu({ onClose, onReconnect, onRestart }: ReconnectMenuProps) {
+export function ReconnectMenu({ onClose, onReconnect, onRestart, onFitScreen }: ReconnectMenuProps) {
   return (
     <BottomSheet onClose={onClose} title="Session Controls">
       <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
@@ -15,6 +16,12 @@ export function ReconnectMenu({ onClose, onReconnect, onRestart }: ReconnectMenu
           Reconnect Terminal
           <div style={{ fontSize: 10, color: "#4a7a5a", marginTop: 2 }}>Refresh the terminal WebSocket connection</div>
         </button>
+        {onFitScreen && (
+          <button onClick={onFitScreen} style={{ ...btnStyle, padding: "10px 14px", textAlign: "left", background: "#1a2a3a", color: "var(--color-accent-blue)", border: "1px solid #2d4a5a" }}>
+            Fit Screen
+            <div style={{ fontSize: 10, color: "#4a6a8a", marginTop: 2 }}>Resize the terminal to match this screen</div>
+          </button>
+        )}
         <button onClick={onRestart} style={{ ...btnStyle, padding: "10px 14px", textAlign: "left", background: "#3a2020", color: "var(--color-accent-red)", border: "1px solid #5a3030" }}>
           Restart Claude Session
           <div style={{ fontSize: 10, color: "#7a4a4a", marginTop: 2 }}>Kill tmux session and start fresh</div>

--- a/apps/web/src/components/action-bar/types.ts
+++ b/apps/web/src/components/action-bar/types.ts
@@ -3,6 +3,7 @@ import type { SortMode } from "../FileViewer";
 
 export interface ActionBarProps {
   onReconnect?: () => void;
+  onFitScreen?: () => void;
   connected?: boolean;
   activeTab?: string;
   fileShowHidden?: boolean;

--- a/apps/web/src/components/action-bar/types.ts
+++ b/apps/web/src/components/action-bar/types.ts
@@ -4,6 +4,13 @@ import type { SortMode } from "../FileViewer";
 export interface ActionBarProps {
   onReconnect?: () => void;
   onFitScreen?: () => void;
+  /**
+   * Result of the most recent "Fit screen" WS round-trip (fit-ack/fit-error
+   * from terminal-ws.ts), forwarded from Terminal.tsx via App.tsx. `ts` is a
+   * fresh timestamp per result so the same ok/message pair still re-triggers
+   * the status effect on repeated taps.
+   */
+  fitResult?: { ok: boolean; message?: string; ts: number } | null;
   connected?: boolean;
   activeTab?: string;
   fileShowHidden?: boolean;


### PR DESCRIPTION
## Root cause

CPC's mini app is **not an attached tmux client** — the server (`terminal-ws.ts`) never runs `tmux attach` and holds no pty; it just polls `tmux capture-pane` on a 500ms timer and streams the rendered text over WebSocket. Because of that, tmux's actual window size comes entirely from:

1. tmux's `window-size` option (host default: `smallest` — sized to whichever real attached client, e.g. a Termius SSH session, is smallest), and
2. the pre-existing `/api/terminal/resize-terminal` REST endpoint (`slash-commands.ts`), which runs `tmux resize-window -A` (fit to the **largest** attached client) on every "Reconnect" tap.

Neither of those has any notion of the mini app's own xterm.js viewport, because the mini app was never a tmux "client" in the first place. Whichever SSH client happens to be attached (or whatever size it left behind) wins, and the mini app just captures whatever that produced. This exactly matches the reported workaround — attaching via Termius and minimizing the keyboard changes Termius's own reported size, which (since it's the only/smallest attached client) reshapes the tmux window, which CPC then happens to capture correctly.

There is no stale-pty-winsize problem to fix here (the speculative root cause in the task brief) — there's no pty in this architecture at all.

## What the fix does

Adds a single **explicit, user-only-triggered** "Fit Screen" action to the reconnect menu (`ReconnectMenu.tsx`) — never auto-fires.

- **Client** (`Terminal.tsx`): on tap, re-measures the current xterm.js viewport via the fit addon, clamps it to the server's own bounds (20-500 cols / 5-300 rows — kept in sync via a comment cross-reference, purely a UX nicety since the server re-validates independently), and sends one `{ type: "fit", cols, rows }` WebSocket message. Exposed via a `fitScreenRef` ref-as-prop from `App.tsx` (this codebase doesn't use `forwardRef` elsewhere, so this matches the existing non-imperative-handle style).
- **Server** (`terminal-ws.ts`): validates the dimensions (`validateFitDimensions` — integers only, `20≤cols≤500`, `5≤rows≤300`; this is WebView-originated input) and, if valid, issues exactly one `tmux resize-window -t <session> -x <cols> -y <rows>` via `execFile` with an argv array (no shell) — the same exec discipline as `sendToTmux`/`slash-commands.ts`. Per `man tmux`, `resize-window -x/-y` "automatically sets window-size to manual" for that window, so the fit sticks until changed again — a visible, deliberate trade-off the user accepts by tapping the button, not something imposed silently or continuously. Success/failure are sent back as distinct `fit-ack`/`fit-error` message types (not the generic `error` also used for auth failures).
- `onMessage` is gated on the same `authResult` closure `onOpen` uses — it previously only logged on every branch, but now that a message can trigger a real `tmux` command it's authorization-checked the same way.
- The client forwards `fit-ack`/`fit-error` to ActionBar (via an `onFitResult` callback threaded through `App.tsx`), which replaces its optimistic "Fit screen requested" status with "Fit screen applied" or "Fit screen failed: `<reason>`" once the round-trip resolves.
- The reconnect-menu subtitle notes that fitting reshapes the tmux window for any other attached client too (e.g. a concurrent Termius SSH session) — the same side-effect class the pre-existing Reconnect (`-A`) flow already has.
- The old `resize` message type is left as a documented no-op for compatibility; the new behavior lives entirely under `fit`/`fit-ack`/`fit-error`.

### Fix-first review round (2026-07-07)

An adversarial review of the first version of this PR came back **FIX-FIRST** with 2 defects, both addressed in a follow-up commit:

1. **Medium — auth guard had zero regression coverage, and the original PR body incorrectly claimed a test for it existed.** The guard itself (`if (!authResult.ok) return;` in `onMessage`) was verified correct by the reviewer, but no test opened an unauthenticated/disallowed socket and asserted a `fit` message never reaches `execFile`. Fixed by adding 4 real tests: no-token, disallowed-user token, disallowed-user *after* `onOpen` already closed the socket (the exact race the guard's own comment describes), and a control case proving the same message *does* reach tmux on an authenticated/allowlisted socket.
2. **Low/medium — unclamped client dimensions + identical fit-ack/error handling produced a false "success" UI.** A viewport resolving past the server's bounds (e.g. a wide desktop browser tab) would silently no-op server-side while the UI still said "Fit screen requested" indefinitely. Fixed by clamping client-side before sending, giving the server response its own `fit-ack`/`fit-error` message types, and wiring both through to a distinct ActionBar status ("Fit screen applied" vs "Fit screen failed: `<reason>`").

Also folded in one suggestion from the same review (the ReconnectMenu copy note above) and aligned a minor test asymmetry the review flagged (the malformed-input test now asserts the `fit-error` reply, matching its out-of-bounds sibling).

## Test evidence

```
apps/server: vitest run          → 298/298 passed (12 new total: bounds/type
                                    validation, exact execFile argv assertion,
                                    fit-ack, legacy no-op preserved, and — added
                                    in the fix-first round — 4 auth-guard
                                    regression tests: no-token, disallowed-user,
                                    disallowed-user-after-close, control case)
apps/web:    vitest run          → 261/261 passed (13 new total: fit-screen
                                    trigger registration/send/no-auto-fire/
                                    socket-not-open/unmount/fit-ack, and — added
                                    in the fix-first round — client-side clamp
                                    (oversized/undersized viewport), distinct
                                    onFitResult(ok:true/false) wiring, and 4
                                    ActionBar tests: button visibility, tap
                                    wiring, "applied" status, "failed" status)
apps/server: tsc --noEmit        → clean
apps/web:    tsc -b              → clean
apps/web:    vite build          → succeeds
```

## Screenshots

Not possible — this changes WebSocket/tmux plumbing behind an existing button in a bottom sheet; there's no new visual surface beyond a text button styled to match its siblings (`Reconnect Terminal` / `Restart Claude Session`) in the same menu, plus a status-line text change on the round-trip result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
