### PR TITLE
fix(web): guard Telegram fullscreen behind isVersionAtLeast + try/catch

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -217,8 +217,12 @@ export function App() {
       tg.ready();
       tg.expand();
       // Request true full screen (hides Telegram header chrome) — Bot API 8.0+
-      if (typeof (tg as any).requestFullscreen === 'function') {
-        (tg as any).requestFullscreen();
+      if (typeof (tg as any).isVersionAtLeast === "function" && (tg as any).isVersionAtLeast("8.0")) {
+        try {
+          (tg as any).requestFullscreen();
+        } catch (err) {
+          console.debug("Telegram fullscreen request failed:", err);
+        }
       }
     }
   }, []);


### PR DESCRIPTION
## Live incident (2026-07-09, Liam UAT)

Opening the mini app on iOS threw `Error: WebAppMethodUnsupported` from telegram-web-app.js and broke app startup.

## Root cause
The v1.13.0 fullscreen-launch guard checked `typeof (tg as any).requestFullscreen === 'function'` — but telegram-web-app.js **always defines** the method and throws `WebAppMethodUnsupported` at runtime on clients/contexts that don't support it. The throw happened inside the mount `useEffect`, killing startup.

## Fix
Gate on `isVersionAtLeast('8.0')` AND wrap the call in try/catch (fullscreen is a nice-to-have; startup must never depend on it).

## Verification
- `pnpm --filter @cpc/web typecheck` + `build` pass.
- **Already hot-deployed** to prod (cherry-pick + rebuild + restart, 11:54 ET) and live-verified in the served bundle; Liam retesting. This PR is the clean-flow merge of the same commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)