### PR TITLE
fix(server): /cpc-branch reports the running deployment's version

### DIFF
--- a/apps/server/src/routes/__tests__/git.test.ts
+++ b/apps/server/src/routes/__tests__/git.test.ts
@@ -31,6 +31,7 @@ let sandbox: string;
 let repoDir: string;
 let evilSibling: string;
 let testAllowedRoots: string[] = [];
+const originalCwd = process.cwd();
 
 vi.mock("../../lib/path-allowed.js", async () => {
   const real = await vi.importActual<typeof import("../../lib/path-allowed.js")>(
@@ -75,6 +76,8 @@ beforeAll(() => {
     { encoding: "utf-8" },
   );
   if (commit.status !== 0) throw new Error(`git commit failed: ${commit.stderr}`);
+  const tag = spawnSync("git", ["-C", repoDir, "tag", "v-test.1"], { encoding: "utf-8" });
+  if (tag.status !== 0) throw new Error(`git tag failed: ${tag.stderr}`);
   // Sibling-prefix directory — shares the sandbox string prefix but is a
   // separate path segment. Must NOT be reachable even though startsWith() would
   // say yes.
@@ -84,15 +87,21 @@ beforeAll(() => {
 
   testAllowedRoots = [repoDir];
   __resetRealRootCacheForTests();
+  process.chdir(repoDir);
 });
 
 afterAll(() => {
+  process.chdir(originalCwd);
   rmSync(sandbox, { recursive: true, force: true });
   rmSync(evilSibling, { recursive: true, force: true });
   __resetRealRootCacheForTests();
 });
 
 beforeEach(() => {
+  const checkout = spawnSync("git", ["-C", repoDir, "checkout", "-q", "main"], {
+    encoding: "utf-8",
+  });
+  if (checkout.status !== 0) throw new Error(`git checkout main failed: ${checkout.stderr}`);
   __resetRealRootCacheForTests();
 });
 
@@ -108,6 +117,37 @@ async function getDirBranch(path: string | null) {
   };
   return { status: res.status, body };
 }
+
+async function getCpcBranch() {
+  const res = await gitRoute.request("/cpc-branch");
+  const body = (await res.json()) as {
+    ok: boolean;
+    error?: string;
+    branch?: string;
+  };
+  return { status: res.status, body };
+}
+
+describe("/cpc-branch deployment version", () => {
+  it("returns the running repo branch from process.cwd()", async () => {
+    const { status, body } = await getCpcBranch();
+    expect(status).toBe(200);
+    expect(body.ok).toBe(true);
+    expect(body.branch).toBe("main");
+  });
+
+  it("returns describe output when the running repo is detached at a tag", async () => {
+    const checkout = spawnSync("git", ["-C", repoDir, "checkout", "-q", "v-test.1"], {
+      encoding: "utf-8",
+    });
+    if (checkout.status !== 0) throw new Error(`git checkout tag failed: ${checkout.stderr}`);
+
+    const { status, body } = await getCpcBranch();
+    expect(status).toBe(200);
+    expect(body.ok).toBe(true);
+    expect(body.branch).toBe("v-test.1");
+  });
+});
 
 describe("/dir-branch path validation (M-3)", () => {
   it("rejects a path containing a double-quote shell break-out with 403", async () => {

--- a/apps/server/src/routes/terminal/git.ts
+++ b/apps/server/src/routes/terminal/git.ts
@@ -96,9 +96,33 @@ app.get("/git-branch", async (c) => {
 
 app.get("/cpc-branch", async (c) => {
   try {
-    const cpcDir = join(process.env.HOME || "/home/claude", "code/claude-pocket-console");
-    const { stdout: branch } = await execAsync(`git -C ${cpcDir} rev-parse --abbrev-ref HEAD`);
-    return c.json({ ok: true, branch: branch.trim() });
+    let cpcDir: string;
+    try {
+      cpcDir = process.cwd();
+    } catch {
+      cpcDir = join(process.env.HOME || "/home/claude", "code/claude-pocket-console");
+    }
+
+    const { stdout: branch } = await execFileAsync("git", [
+      "-C",
+      cpcDir,
+      "rev-parse",
+      "--abbrev-ref",
+      "HEAD",
+    ]);
+    const branchName = branch.trim();
+    if (branchName !== "HEAD") {
+      return c.json({ ok: true, branch: branchName });
+    }
+
+    const { stdout: version } = await execFileAsync("git", [
+      "-C",
+      cpcDir,
+      "describe",
+      "--tags",
+      "--always",
+    ]);
+    return c.json({ ok: true, branch: version.trim() });
   } catch (err: any) {
     return c.json({ ok: false, error: err.message }, 500);
   }


### PR DESCRIPTION
Closes #287 (badge half; the SPA-fallback follow-up stays open there).

The `/cpc-branch` endpoint hardcoded the **dev checkout** path and returned its current branch, so the UI badge showed "dev" (or any feature branch the orchestrator happened to be on) regardless of the running deployment. Liam hit this mid-UAT 2026-07-09.

Now it resolves the server's own repo (`process.cwd()` — systemd sets WorkingDirectory to the deployment root): branch name when on a branch (dev instance), `git describe --tags --always` when detached (prod release checkout → "v1.13.0"). Switched to execFile argv style consistent with the hardened `/dir-branch` route. Response shape unchanged.

Tests: two new cases (branch + detached-at-tag) in git.test.ts; `pnpm --filter @cpc/server typecheck` + git route suite pass (8/8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)