### PR TITLE
feat(server): SPA fallback for client-routed paths (#287)

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -205,10 +205,12 @@ app.use("/*", serveStatic({ root: webDistRoot }));
 // app shell and let the client router handle the path (e.g. the /console
 // mini-app URL, which 404'd until a host-side Caddy rewrite papered over it).
 // API/WS prefixes still 404 so callers get JSON errors, not HTML.
+// Cached for the process lifetime: every deploy restarts the server
+// (docs/guides/deploying.md), which is what invalidates this.
 let spaIndexHtml: string | null = null;
 app.get("*", (c) => {
   const path = c.req.path;
-  if (path.startsWith("/api/") || path.startsWith("/ws/")) return c.notFound();
+  if (/^\/(api|ws)(\/|$)/.test(path)) return c.notFound();
   if (spaIndexHtml === null) {
     try {
       spaIndexHtml = readFileSync(join(webDistRoot, "index.html"), "utf-8");

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -200,6 +200,26 @@ app.use("/*", async (c, next) => {
 
 app.use("/*", serveStatic({ root: webDistRoot }));
 
+// SPA fallback (#287): serveStatic calls next() on a miss, so any GET that
+// reached this point is neither an API/WS route nor a real asset. Serve the
+// app shell and let the client router handle the path (e.g. the /console
+// mini-app URL, which 404'd until a host-side Caddy rewrite papered over it).
+// API/WS prefixes still 404 so callers get JSON errors, not HTML.
+let spaIndexHtml: string | null = null;
+app.get("*", (c) => {
+  const path = c.req.path;
+  if (path.startsWith("/api/") || path.startsWith("/ws/")) return c.notFound();
+  if (spaIndexHtml === null) {
+    try {
+      spaIndexHtml = readFileSync(join(webDistRoot, "index.html"), "utf-8");
+    } catch {
+      // No frontend build present (bare dev server) — behave as before.
+      return c.notFound();
+    }
+  }
+  return c.html(spaIndexHtml);
+});
+
 const port = parseInt(process.env.PORT || "38830");
 const server = serve({ fetch: app.fetch, port }, (info) => {
   console.log(`CPC server running on http://localhost:${info.port}`);

--- a/apps/server/src/routes/__tests__/git.test.ts
+++ b/apps/server/src/routes/__tests__/git.test.ts
@@ -31,7 +31,6 @@ let sandbox: string;
 let repoDir: string;
 let evilSibling: string;
 let testAllowedRoots: string[] = [];
-const originalCwd = process.cwd();
 
 vi.mock("../../lib/path-allowed.js", async () => {
   const real = await vi.importActual<typeof import("../../lib/path-allowed.js")>(

--- a/apps/server/src/routes/__tests__/git.test.ts
+++ b/apps/server/src/routes/__tests__/git.test.ts
@@ -87,11 +87,14 @@ beforeAll(() => {
 
   testAllowedRoots = [repoDir];
   __resetRealRootCacheForTests();
-  process.chdir(repoDir);
+  // PR #288 review follow-up (#287): stub cwd instead of process.chdir() —
+  // chdir mutates global state for every test in the worker; the spy only
+  // affects code that reads process.cwd().
+  vi.spyOn(process, "cwd").mockReturnValue(repoDir);
 });
 
 afterAll(() => {
-  process.chdir(originalCwd);
+  vi.restoreAllMocks();
   rmSync(sandbox, { recursive: true, force: true });
   rmSync(evilSibling, { recursive: true, force: true });
   __resetRealRootCacheForTests();


### PR DESCRIPTION
Closes the SPA-fallback half of #287 (the badge half shipped in #288).

## What
- `GET` requests that miss every API/WS route **and** `serveStatic` now get `index.html` (cached after first read) instead of 404 — fixes the `/console` 404 class without the host-side Caddy rewrite.
- `/api/*` and `/ws/*` keep 404ing as JSON so API callers never receive HTML.
- No web build present (bare dev server) → unchanged 404 behavior.
- Follow-up from PR #288's review: `git.test.ts` now stubs `process.cwd()` with `vi.spyOn` instead of `process.chdir()` (no global worker-state mutation).

## Verification (live, scratch instance on port 38912/38913)
- `/console` and `/some/deep/route` → **200 text/html** (app shell)
- `/api/nonexistent` → **401 application/json** (auth middleware, not HTML)
- `/api/public/health` → `{"status":"ok"}`
- `/assets/wardley-….js` → **200 text/javascript** (fallback doesn't shadow real assets)
- `pnpm --filter @cpc/server test` → 302/302; typecheck clean

Note for deploy: once this ships to prod, the host-side Caddy `/console` rewrite becomes redundant (leave-in is harmless, but can be retired).

🤖 Generated with [Claude Code](https://claude.com/claude-code)