### PR TITLE
feat(links): Fleet Cockpit link that opens inside the Mini App

### DIFF
--- a/apps/web/src/components/Links.tsx
+++ b/apps/web/src/components/Links.tsx
@@ -28,17 +28,17 @@ interface LinkItem {
  *     current Mini App to switch context;
  *   - `target="_blank"` anchors (the default for every other link on this
  *     tab) are handed to the external browser by the WebView too.
- * SDK access is presence-checked and try/caught (same defensive pattern as
- * the PR #286 fullscreen guard); outside Telegram — plain browser tab —
- * fall back to a new tab so CPC itself stays open.
+ * Outside Telegram — plain browser tab — fall back to a new tab so CPC
+ * itself stays open.
+ *
+ * "Inside Telegram" is decided by `initData` truthiness, NOT by SDK-object
+ * presence: index.html loads telegram-web-app.js unconditionally, so
+ * `window.Telegram.WebApp` exists in every browser and only a genuine
+ * Mini App launch populates initData — the same discriminator `hasAuth()`
+ * uses in lib/telegram.ts. (PR #290 codex review, HIGH.)
  */
 function openInApp(url: string) {
-  let insideTelegram = false;
-  try {
-    insideTelegram = Boolean(getTelegramWebApp());
-  } catch {
-    insideTelegram = false;
-  }
+  const insideTelegram = Boolean(getTelegramWebApp()?.initData);
   if (insideTelegram) {
     window.location.assign(url);
   } else {
@@ -143,10 +143,20 @@ export function Links({ onClose }: LinksProps) {
             key={link.url}
             href={link.url}
             // In-app links navigate the webview itself (see openInApp);
-            // everything else keeps the external-tab behavior.
+            // everything else keeps the external-tab behavior. rel stays on
+            // both: middle-click/context-menu can still open the href
+            // without going through onClick (PR #290 gemini review, MED).
             target={link.inApp ? undefined : "_blank"}
-            rel={link.inApp ? undefined : "noopener noreferrer"}
-            onClick={link.inApp ? (e) => { e.preventDefault(); openInApp(link.url); } : undefined}
+            rel="noopener noreferrer"
+            onClick={link.inApp ? (e) => {
+              // Respect explicit new-tab intent (ctrl/cmd/shift-click,
+              // middle-click) — let the browser's default anchor behavior
+              // handle those instead of hijacking into a same-tab
+              // navigation. (PR #290 codex LOW / gemini MED.)
+              if (e.ctrlKey || e.metaKey || e.shiftKey || e.altKey || e.button !== 0) return;
+              e.preventDefault();
+              openInApp(link.url);
+            } : undefined}
             style={{
               display: "flex",
               alignItems: "center",

--- a/apps/web/src/components/Links.tsx
+++ b/apps/web/src/components/Links.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { getTelegramWebApp } from "../lib/telegram";
 import "./Links.css";
 
 interface LinkItem {
@@ -6,6 +7,43 @@ interface LinkItem {
   url: string;
   icon?: string;
   description?: string;
+  /**
+   * Open by navigating the current webview instead of target="_blank", so
+   * inside Telegram the destination stays INSIDE the Mini App window
+   * (Liam voice msg 1185). See openInApp for why the SDK link methods
+   * don't fit.
+   */
+  inApp?: boolean;
+}
+
+/**
+ * Navigate to `url` without leaving the Mini App.
+ *
+ * Inside the Telegram WebView the only mechanic that keeps a destination
+ * INSIDE the Mini App window is navigating the webview itself — the SDK's
+ * link methods were each checked and rejected:
+ *   - `WebApp.openLink(url)` always opens the EXTERNAL browser (Safari) —
+ *     the exact behavior this feature exists to avoid;
+ *   - `WebApp.openTelegramLink(url)` only takes t.me links and closes the
+ *     current Mini App to switch context;
+ *   - `target="_blank"` anchors (the default for every other link on this
+ *     tab) are handed to the external browser by the WebView too.
+ * SDK access is presence-checked and try/caught (same defensive pattern as
+ * the PR #286 fullscreen guard); outside Telegram — plain browser tab —
+ * fall back to a new tab so CPC itself stays open.
+ */
+function openInApp(url: string) {
+  let insideTelegram = false;
+  try {
+    insideTelegram = Boolean(getTelegramWebApp());
+  } catch {
+    insideTelegram = false;
+  }
+  if (insideTelegram) {
+    window.location.assign(url);
+  } else {
+    window.open(url, "_blank", "noopener,noreferrer");
+  }
 }
 
 interface AppItem {
@@ -18,6 +56,17 @@ interface AppItem {
 }
 
 const LINKS: LinkItem[] = [
+  {
+    title: "Fleet Cockpit",
+    url: "https://cockpit.claude.do",
+    icon: "🛩️",
+    description: "Fleet grid + live lane terminals",
+    // Stays inside the Mini App (Liam voice msg 1185). NOTE: cockpit.claude.do
+    // currently sits behind Cloudflare Access, which a Telegram WebView cannot
+    // pass — the link hits the Access wall until the cockpit auth lift lands
+    // (world-os#218 plan addendum). Shipped anyway per Liam.
+    inApp: true,
+  },
   {
     title: "Transcription Glossary",
     url: "https://github.com/claudes-world/toolbox/blob/main/transcribe/glossary.txt",
@@ -93,8 +142,11 @@ export function Links({ onClose }: LinksProps) {
           <a
             key={link.url}
             href={link.url}
-            target="_blank"
-            rel="noopener noreferrer"
+            // In-app links navigate the webview itself (see openInApp);
+            // everything else keeps the external-tab behavior.
+            target={link.inApp ? undefined : "_blank"}
+            rel={link.inApp ? undefined : "noopener noreferrer"}
+            onClick={link.inApp ? (e) => { e.preventDefault(); openInApp(link.url); } : undefined}
             style={{
               display: "flex",
               alignItems: "center",


### PR DESCRIPTION
## What

Adds a **Fleet Cockpit** entry (`https://cockpit.claude.do`) to the Links tab that opens **inside the Mini App** instead of bouncing to Safari/the external browser (Liam voice msg 1185).

## How

New `inApp` flag on `LinkItem` + an `openInApp()` helper that navigates the current webview (`window.location.assign`). The Telegram SDK's link methods were each checked and rejected:

- `WebApp.openLink(url)` — always opens the **external** browser (the exact behavior to avoid)
- `WebApp.openTelegramLink(url)` — t.me links only, and **closes** the current Mini App
- `target="_blank"` anchors (every other link on the tab) — handed to the external browser by the WebView

SDK access is presence-checked + try/caught (same defensive pattern as the PR #286 fullscreen guard). Outside Telegram (plain browser), falls back to a new tab so CPC stays open.

## Known reality (shipped anyway, per Liam)

`cockpit.claude.do` currently sits behind Cloudflare Access, which a Telegram WebView cannot pass — the link hits the Access wall until the cockpit auth lift lands (see the [world-os#218 plan addendum](https://github.com/claudes-world/world-os/issues/218#issuecomment-4929228894)).

## Verification

- `pnpm --filter @cpc/web build` clean, `tsc --noEmit` clean.
- Behavior change is Telegram-WebView-only; desktop browser keeps new-tab behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)