### PR TITLE
feat(terminal): multi-session terminal — session picker, deep links, per-session restricted palette (world-os#218 v1)

### DIFF
--- a/apps/server/src/routes/__tests__/slash-commands-session.test.ts
+++ b/apps/server/src/routes/__tests__/slash-commands-session.test.ts
@@ -1,0 +1,190 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Session-targeting tests for the restricted command palette endpoints
+ * (send-keys / compact / reload-plugins — world-os#218, Liam voice msg
+ * 1188: the palette targets the tmux session the terminal tab is viewing).
+ *
+ * Covers, per endpoint:
+ *   - a valid non-default `session` body field is existence-checked
+ *     (`tmux has-session -t =<name>`) and then targeted with the
+ *     exact-match `=` prefix;
+ *   - an invalid session name is rejected 400 BEFORE any tmux call;
+ *   - an unknown (charset-valid) session is rejected 404 after the probe,
+ *     and no keys are ever sent;
+ *   - the absent-session legacy path still targets the default session
+ *     with NO existence probe.
+ *
+ * Also: /restart-session and /resize-terminal remain default-session-only —
+ * they ignore a `session` field entirely (never probe, never retarget).
+ */
+
+const execFileCalls: { cmd: string; args: string[] }[] = [];
+const execCalls: string[] = [];
+/** Session names `tmux has-session` should report as existing. */
+let existingSessions = new Set<string>();
+
+const execFileMock = vi.fn((...fnArgs: any[]) => {
+  const cmd = fnArgs[0] as string;
+  const args = fnArgs[1] as string[];
+  const callback = fnArgs.find((a) => typeof a === "function");
+  execFileCalls.push({ cmd, args });
+  if (args[0] === "has-session") {
+    const target = (args[args.indexOf("-t") + 1] || "").replace(/^=/, "");
+    if (!existingSessions.has(target)) {
+      callback?.(new Error(`can't find session: ${target}`));
+      return { kill: () => {} } as any;
+    }
+  }
+  callback?.(null, { stdout: "", stderr: "" });
+  return { kill: () => {} } as any;
+});
+
+const execMock = vi.fn((...fnArgs: any[]) => {
+  execCalls.push(fnArgs[0] as string);
+  const callback = fnArgs.find((a) => typeof a === "function");
+  callback?.(null, { stdout: "", stderr: "" });
+  return { kill: () => {} } as any;
+});
+
+vi.mock("node:child_process", async () => {
+  const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
+  return { ...actual, execFile: execFileMock, exec: execMock };
+});
+
+vi.mock("../utils.js", async () => {
+  const actual = await vi.importActual<typeof import("../utils.js")>("../utils.js");
+  // Keep the real resolveTargetSession/tmuxSessionExists/sendToTmux — only
+  // pin the default session name. NOTE: utils' own helpers close over the
+  // real module-scope TMUX_SESSION ("claudes-world" by default env), so the
+  // pin must match what utils resolved to keep default-path assertions
+  // meaningful. The test env has no TMUX_SESSION set → "claudes-world".
+  return { ...actual, TMUX_SESSION: actual.TMUX_SESSION };
+});
+
+const { slashCommandsRoute } = await import("../terminal/slash-commands.js");
+const { TMUX_SESSION } = await import("../utils.js");
+
+beforeEach(() => {
+  execFileCalls.length = 0;
+  execCalls.length = 0;
+  existingSessions = new Set();
+  execFileMock.mockClear();
+  execMock.mockClear();
+});
+
+async function post(path: string, body?: unknown) {
+  const res = await slashCommandsRoute.request(path, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+  });
+  return { status: res.status, body: (await res.json()) as any };
+}
+
+const sendKeysCalls = () => execFileCalls.filter((c) => c.args[0] === "send-keys");
+const probeCalls = () => execFileCalls.filter((c) => c.args[0] === "has-session");
+
+describe("/send-keys session targeting", () => {
+  it("targets a valid existing session with the exact-match prefix, after probing it", async () => {
+    existingSessions.add("do-box--lane-a");
+    const { status, body } = await post("/send-keys", { keys: "Escape", raw: true, session: "do-box--lane-a" });
+    expect(status).toBe(200);
+    expect(body.ok).toBe(true);
+    expect(probeCalls()[0]?.args).toEqual(["has-session", "-t", "=do-box--lane-a"]);
+    expect(sendKeysCalls()[0]?.args).toEqual(["send-keys", "-t", "=do-box--lane-a:", "Escape"]);
+  });
+
+  it("targets the selected session on the literal path too", async () => {
+    existingSessions.add("do-box--lane-a");
+    const { status } = await post("/send-keys", { keys: "2", session: "do-box--lane-a" });
+    expect(status).toBe(200);
+    expect(sendKeysCalls().map((c) => c.args)).toEqual([
+      ["send-keys", "-t", "=do-box--lane-a:", "-l", "--", "2"],
+      ["send-keys", "-t", "=do-box--lane-a:", "Enter"],
+    ]);
+  });
+
+  it("rejects an invalid session name 400 before any tmux call", async () => {
+    const { status, body } = await post("/send-keys", { keys: "Escape", raw: true, session: "bad;name" });
+    expect(status).toBe(400);
+    expect(body.ok).toBe(false);
+    expect(execFileCalls).toHaveLength(0);
+  });
+
+  it("rejects an unknown session 404 and never sends keys", async () => {
+    const { status, body } = await post("/send-keys", { keys: "Escape", raw: true, session: "do-box--gone" });
+    expect(status).toBe(404);
+    expect(body.error).toMatch(/unknown session/);
+    expect(sendKeysCalls()).toHaveLength(0);
+  });
+
+  it("keeps the legacy default path: no session field → default target, no probe", async () => {
+    const { status } = await post("/send-keys", { keys: "Escape", raw: true });
+    expect(status).toBe(200);
+    expect(probeCalls()).toHaveLength(0);
+    expect(sendKeysCalls()[0]?.args).toEqual(["send-keys", "-t", `=${TMUX_SESSION}:`, "Escape"]);
+  });
+});
+
+describe("/compact session targeting", () => {
+  it("sends the compact message to the selected session", async () => {
+    existingSessions.add("do-box--lane-a");
+    const { status } = await post("/compact", { message: "/compact", session: "do-box--lane-a" });
+    expect(status).toBe(200);
+    expect(sendKeysCalls().map((c) => c.args)).toEqual([
+      ["send-keys", "-t", "=do-box--lane-a:", "-l", "--", "/compact"],
+      ["send-keys", "-t", "=do-box--lane-a:", "Enter"],
+    ]);
+  });
+
+  it("rejects unknown sessions 404 without sending", async () => {
+    const { status } = await post("/compact", { message: "/compact", session: "do-box--gone" });
+    expect(status).toBe(404);
+    expect(sendKeysCalls()).toHaveLength(0);
+  });
+});
+
+describe("/reload-plugins session targeting", () => {
+  it("tolerates a missing body (legacy clients) and targets the default session", async () => {
+    const { status, body } = await post("/reload-plugins");
+    expect(status).toBe(200);
+    expect(body.ok).toBe(true);
+    expect(probeCalls()).toHaveLength(0);
+    expect(sendKeysCalls()[0]?.args).toEqual([
+      "send-keys", "-t", `=${TMUX_SESSION}:`, "-l", "--", "/reload-plugins",
+    ]);
+  });
+
+  it("targets the selected session when given one", async () => {
+    existingSessions.add("do-box--lane-a");
+    const { status } = await post("/reload-plugins", { session: "do-box--lane-a" });
+    expect(status).toBe(200);
+    expect(sendKeysCalls()[0]?.args).toEqual([
+      "send-keys", "-t", "=do-box--lane-a:", "-l", "--", "/reload-plugins",
+    ]);
+  });
+
+  it("rejects invalid session names 400", async () => {
+    const { status } = await post("/reload-plugins", { session: "a b c" });
+    expect(status).toBe(400);
+    expect(execFileCalls).toHaveLength(0);
+  });
+});
+
+describe("default-session-only endpoints ignore session fields", () => {
+  it("/resize-terminal never probes or retargets", async () => {
+    const { status } = await post("/resize-terminal", { session: "do-box--lane-a" });
+    expect(status).toBe(200);
+    expect(probeCalls()).toHaveLength(0);
+    // Runs through execAsync (shell) against the default session, as before.
+    expect(execCalls.some((cmd) => cmd.includes(`resize-window -t ${TMUX_SESSION}`))).toBe(true);
+  });
+
+  it("/restart-session never probes or retargets", async () => {
+    const { status } = await post("/restart-session", { session: "do-box--lane-a" });
+    expect(status).toBe(200);
+    expect(probeCalls()).toHaveLength(0);
+    expect(execCalls.some((cmd) => cmd.includes(`kill-session -t ${TMUX_SESSION}`))).toBe(true);
+  });
+});

--- a/apps/server/src/routes/__tests__/terminal-sessions.test.ts
+++ b/apps/server/src/routes/__tests__/terminal-sessions.test.ts
@@ -1,0 +1,162 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Tests for `GET /api/terminal/sessions` (multi-session terminal,
+ * world-os#218). Covers:
+ *
+ *   1. `parseSessions` — the pure parser/sorter: infra-session filtering,
+ *      allowlist-regex filtering, first-pane command mapping, alive
+ *      detection, writable flag, and the "default first, then most recent
+ *      activity" sort.
+ *   2. Route behavior — happy path shape, and the tmux-server-down error
+ *      path (500 + ok:false so the client can fall back to the default
+ *      session instead of rendering an empty picker).
+ */
+
+const execFileCalls: { cmd: string; args: string[] }[] = [];
+let tmuxFails = false;
+
+const execFileMock = vi.fn((...fnArgs: any[]) => {
+  const cmd = fnArgs[0] as string;
+  const args = fnArgs[1] as string[];
+  const callback = fnArgs.find((a) => typeof a === "function");
+  execFileCalls.push({ cmd, args });
+  if (tmuxFails) {
+    callback?.(new Error("no server running on /tmp/tmux-1000/default"));
+    return { kill: () => {} } as any;
+  }
+  let stdout = "";
+  if (args[0] === "list-sessions") {
+    stdout = [
+      "_tmux-server-keepalive\t0\t1751900000",
+      "claudes-world\t1\t1751900100",
+      "do-box--lane-a\t0\t1751900300",
+      "do-box--lane-b\t0\t1751900200",
+      "bad;name\t0\t1751900400",
+    ].join("\n") + "\n";
+  } else if (args[0] === "list-panes") {
+    stdout = [
+      "_tmux-server-keepalive\tsh",
+      "claudes-world\tclaude",
+      // Two panes for lane-a — the FIRST row must win.
+      "do-box--lane-a\tclaude",
+      "do-box--lane-a\tbash",
+      "do-box--lane-b\tbash",
+    ].join("\n") + "\n";
+  }
+  callback?.(null, { stdout, stderr: "" });
+  return { kill: () => {} } as any;
+});
+
+vi.mock("node:child_process", async () => {
+  const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
+  return { ...actual, execFile: execFileMock };
+});
+
+// Pin the default session so assertions don't depend on host env.
+vi.mock("../utils.js", async () => {
+  const actual = await vi.importActual<typeof import("../utils.js")>("../utils.js");
+  return { ...actual, TMUX_SESSION: "claudes-world" };
+});
+
+const { parseSessions, sessionsRoute } = await import("../terminal/sessions.js");
+
+beforeEach(() => {
+  execFileCalls.length = 0;
+  execFileMock.mockClear();
+  tmuxFails = false;
+});
+
+describe("parseSessions", () => {
+  const LIST = [
+    "claudes-world\t1\t100",
+    "do-box--lane-a\t0\t300",
+    "do-box--lane-b\t0\t200",
+  ].join("\n");
+  const PANES = [
+    "claudes-world\tclaude",
+    "do-box--lane-a\tclaude",
+    "do-box--lane-b\tbash",
+  ].join("\n");
+
+  it("maps fields, marks the default writable, sorts default-first then activity desc", () => {
+    const sessions = parseSessions(LIST, PANES, "claudes-world");
+    expect(sessions.map((s) => s.name)).toEqual([
+      "claudes-world", // writable default pinned first despite lowest activity
+      "do-box--lane-a", // activity 300
+      "do-box--lane-b", // activity 200
+    ]);
+    expect(sessions[0]).toEqual({
+      name: "claudes-world",
+      attached: true,
+      activity: 100,
+      command: "claude",
+      alive: true,
+      writable: true,
+    });
+    expect(sessions[1].writable).toBe(false);
+  });
+
+  it("flags a bare-shell first pane as not alive", () => {
+    const sessions = parseSessions(LIST, PANES, "claudes-world");
+    const laneB = sessions.find((s) => s.name === "do-box--lane-b");
+    expect(laneB?.alive).toBe(false);
+    expect(laneB?.command).toBe("bash");
+  });
+
+  it("uses the FIRST pane row per session (lowest window/pane index)", () => {
+    const sessions = parseSessions(
+      "s1\t0\t1",
+      "s1\tclaude\ns1\tbash",
+      "claudes-world",
+    );
+    expect(sessions[0].command).toBe("claude");
+    expect(sessions[0].alive).toBe(true);
+  });
+
+  it("hides _-prefixed infra sessions", () => {
+    const sessions = parseSessions("_keepalive\t0\t1\nreal\t0\t2", "", "claudes-world");
+    expect(sessions.map((s) => s.name)).toEqual(["real"]);
+  });
+
+  it("drops names that fail the session-name allowlist", () => {
+    // A name we'd refuse to poll must never be offered to the client.
+    const sessions = parseSessions("bad;name\t0\t1\nok-name\t0\t2", "", "claudes-world");
+    expect(sessions.map((s) => s.name)).toEqual(["ok-name"]);
+  });
+
+  it("treats a session with no pane rows as not alive", () => {
+    const sessions = parseSessions("ghost\t0\t1", "", "claudes-world");
+    expect(sessions[0].alive).toBe(false);
+    expect(sessions[0].command).toBe("");
+  });
+});
+
+describe("GET /sessions", () => {
+  it("returns the parsed roster and the default session name", async () => {
+    const res = await sessionsRoute.request("/sessions");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as any;
+    expect(body.ok).toBe(true);
+    expect(body.default).toBe("claudes-world");
+    expect(body.sessions.map((s: any) => s.name)).toEqual([
+      "claudes-world",
+      "do-box--lane-a",
+      "do-box--lane-b",
+    ]);
+    // Charset-failing and _-prefixed names never reach the client.
+    expect(body.sessions.map((s: any) => s.name)).not.toContain("bad;name");
+    expect(body.sessions.map((s: any) => s.name)).not.toContain("_tmux-server-keepalive");
+    // argv discipline: both tmux calls go through execFile with arrays.
+    expect(execFileCalls.map((c) => c.args[0]).sort()).toEqual(["list-panes", "list-sessions"]);
+  });
+
+  it("returns 500 ok:false when tmux has no server running", async () => {
+    tmuxFails = true;
+    const res = await sessionsRoute.request("/sessions");
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as any;
+    expect(body.ok).toBe(false);
+    expect(typeof body.error).toBe("string");
+  });
+});

--- a/apps/server/src/routes/__tests__/terminal-ws-session.test.ts
+++ b/apps/server/src/routes/__tests__/terminal-ws-session.test.ts
@@ -1,0 +1,225 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { createSession } from "../../auth.js";
+
+/**
+ * Multi-session WS tests (world-os#218): the `?session=` query param on
+ * /ws/terminal. Covers:
+ *
+ *   1. `resolveRequestedSession` — charset fence on the client-controlled
+ *      param; absent = default session.
+ *   2. onOpen wiring — an invalid name closes 4004 without any tmux call;
+ *      a valid non-default name is existence-checked (`tmux has-session -t
+ *      =<name>`) BEFORE polling starts, and capture-pane targets the
+ *      exact-match `=<name>`; an unknown session closes 4004 after the
+ *      probe; the default session starts polling with no probe (legacy
+ *      restart-tolerance).
+ *   3. onMessage "fit" — a view-only (non-default) session gets fit-error
+ *      and `tmux resize-window` is NEVER reached; the default session
+ *      keeps its existing fit behavior.
+ */
+
+const TEST_USER_ID = "999222";
+
+let savedBotToken: string | undefined;
+let savedAllowed: string | undefined;
+
+beforeAll(() => {
+  savedBotToken = process.env.TELEGRAM_BOT_TOKEN;
+  savedAllowed = process.env.ALLOWED_TELEGRAM_USERS;
+  process.env.TELEGRAM_BOT_TOKEN = "123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11";
+  process.env.ALLOWED_TELEGRAM_USERS = TEST_USER_ID;
+});
+
+afterAll(() => {
+  if (savedBotToken === undefined) {
+    delete process.env.TELEGRAM_BOT_TOKEN;
+  } else {
+    process.env.TELEGRAM_BOT_TOKEN = savedBotToken;
+  }
+  if (savedAllowed === undefined) {
+    delete process.env.ALLOWED_TELEGRAM_USERS;
+  } else {
+    process.env.ALLOWED_TELEGRAM_USERS = savedAllowed;
+  }
+});
+
+const execFileCalls: { cmd: string; args: string[] }[] = [];
+const spawnCalls: { cmd: string; args: string[] }[] = [];
+/** Session names `tmux has-session` should report as existing. */
+let existingSessions = new Set<string>();
+
+const mockExecFile = vi.fn((...fnArgs: any[]) => {
+  const cmd = fnArgs[0] as string;
+  const args = fnArgs[1] as string[];
+  const callback = fnArgs.find((a) => typeof a === "function");
+  execFileCalls.push({ cmd, args });
+  if (args[0] === "has-session") {
+    const target = (args[args.indexOf("-t") + 1] || "").replace(/^=/, "");
+    if (!existingSessions.has(target)) {
+      callback?.(new Error(`can't find session: ${target}`));
+      return { kill: () => {} } as any;
+    }
+  }
+  callback?.(null, { stdout: "", stderr: "" });
+  return { kill: () => {} } as any;
+});
+
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:child_process")>();
+  return {
+    ...actual,
+    spawn: vi.fn((cmd: string, args: string[]) => {
+      spawnCalls.push({ cmd, args });
+      return {
+        stdout: { on: vi.fn() },
+        on: vi.fn(),
+      };
+    }),
+    execFileSync: vi.fn(() => "80x24"),
+    execFile: mockExecFile,
+  };
+});
+
+// Mock utils to pin the default session (same pattern as
+// terminal-ws-auth.test.ts / terminal-ws-fit.test.ts).
+vi.mock("../utils.js", async () => {
+  const actual = await vi.importActual<typeof import("../utils.js")>("../utils.js");
+  return { ...actual, TMUX_SESSION: "test-session" };
+});
+
+const { terminalWsRoute, resolveRequestedSession } = await import("../terminal-ws.js");
+
+function makeMockContext(query: Record<string, string>, headers: Record<string, string> = {}) {
+  return {
+    req: {
+      query: (key: string) => query[key] || "",
+      header: (key: string) => headers[key.toLowerCase()],
+    },
+  };
+}
+
+function makeMockWs() {
+  const sent: string[] = [];
+  return {
+    send: vi.fn((data: string) => sent.push(data)),
+    close: vi.fn(),
+    _sent: sent,
+  };
+}
+
+/** Open an authenticated socket, optionally viewing a specific session. */
+function connectWs(session?: string) {
+  const token = createSession({ id: Number(TEST_USER_ID), first_name: "Allowed" });
+  const query: Record<string, string> = { token };
+  if (session !== undefined) query.session = session;
+  const c = makeMockContext(query, { origin: "https://cpc.claude.do" });
+  const handlers = terminalWsRoute(c);
+  const ws = makeMockWs();
+  handlers.onOpen(new Event("open"), ws as any);
+  return { handlers, ws };
+}
+
+/** Let pending promises (the async has-session gate) settle. */
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+afterEach(() => {
+  execFileCalls.length = 0;
+  spawnCalls.length = 0;
+  existingSessions = new Set();
+  vi.clearAllMocks();
+});
+
+describe("resolveRequestedSession", () => {
+  it("falls back to the default session when the param is absent", () => {
+    expect(resolveRequestedSession("")).toEqual({ ok: true, session: "test-session" });
+  });
+
+  it("accepts a charset-valid session name", () => {
+    expect(resolveRequestedSession("do-box--lane_1.a")).toEqual({
+      ok: true,
+      session: "do-box--lane_1.a",
+    });
+  });
+
+  it("rejects shell/tmux metacharacters and over-long names", () => {
+    for (const bad of ["a;b", "a b", "a$(x)", "a|b", "../x", "a\nb", "a".repeat(65)]) {
+      expect(resolveRequestedSession(bad).ok).toBe(false);
+    }
+  });
+});
+
+describe("terminalWsRoute onOpen: session targeting", () => {
+  it("closes 4004 on an invalid session name without touching tmux", async () => {
+    const { ws } = connectWs("bad;name");
+    await flush();
+    expect(ws.close).toHaveBeenCalledWith(4004, "Invalid session");
+    expect(ws._sent.some((m) => JSON.parse(m).type === "error")).toBe(true);
+    expect(execFileCalls).toHaveLength(0);
+    expect(spawnCalls).toHaveLength(0);
+  });
+
+  it("existence-checks a non-default session before polling, then captures with exact-match target", async () => {
+    existingSessions.add("do-box--lane-a");
+    const { handlers, ws } = connectWs("do-box--lane-a");
+    await flush();
+    // has-session probe ran with the exact-match `=` prefix
+    const probe = execFileCalls.find((c) => c.args[0] === "has-session");
+    expect(probe?.args).toEqual(["has-session", "-t", "=do-box--lane-a"]);
+    // capture-pane targets the same exact-match session
+    expect(spawnCalls.length).toBeGreaterThan(0);
+    expect(spawnCalls[0].args).toEqual(["capture-pane", "-t", "=do-box--lane-a:", "-p", "-e", "-J"]);
+    expect(ws.close).not.toHaveBeenCalled();
+    handlers.onClose(new Event("close"), ws as any); // clear the poll interval
+  });
+
+  it("closes 4004 on an unknown (but charset-valid) session, and never polls it", async () => {
+    const { ws } = connectWs("do-box--gone");
+    await flush();
+    expect(ws.close).toHaveBeenCalledWith(4004, "Unknown session");
+    expect(ws._sent.some((m) => {
+      const msg = JSON.parse(m);
+      return msg.type === "error" && /unknown session/i.test(msg.message);
+    })).toBe(true);
+    expect(spawnCalls).toHaveLength(0);
+  });
+
+  it("starts the default session immediately with no existence probe (legacy restart tolerance)", async () => {
+    const { handlers, ws } = connectWs();
+    await flush();
+    expect(execFileCalls.find((c) => c.args[0] === "has-session")).toBeUndefined();
+    expect(spawnCalls[0].args).toEqual(["capture-pane", "-t", "=test-session:", "-p", "-e", "-J"]);
+    handlers.onClose(new Event("close"), ws as any);
+  });
+});
+
+describe("terminalWsRoute onMessage: fit is default-session-only", () => {
+  it("rejects fit on a non-default session with fit-error and never reaches resize-window", async () => {
+    existingSessions.add("do-box--lane-a");
+    const { handlers, ws } = connectWs("do-box--lane-a");
+    await flush();
+    handlers.onMessage(
+      { data: JSON.stringify({ type: "fit", cols: 100, rows: 40 }) } as unknown as MessageEvent,
+      ws as any,
+    );
+    await flush();
+    const fitError = ws._sent.map((m) => JSON.parse(m)).find((m) => m.type === "fit-error");
+    expect(fitError).toBeTruthy();
+    expect(fitError.message).toMatch(/view-only/i);
+    expect(execFileCalls.find((c) => c.args[0] === "resize-window")).toBeUndefined();
+    handlers.onClose(new Event("close"), ws as any);
+  });
+
+  it("still applies fit on the default session", async () => {
+    const { handlers, ws } = connectWs();
+    await flush();
+    handlers.onMessage(
+      { data: JSON.stringify({ type: "fit", cols: 100, rows: 40 }) } as unknown as MessageEvent,
+      ws as any,
+    );
+    await flush();
+    const resize = execFileCalls.find((c) => c.args[0] === "resize-window");
+    expect(resize?.args).toEqual(["resize-window", "-t", "test-session", "-x", "100", "-y", "40"]);
+    expect(ws._sent.map((m) => JSON.parse(m)).some((m) => m.type === "fit-ack")).toBe(true);
+    handlers.onClose(new Event("close"), ws as any);
+  });
+});

--- a/apps/server/src/routes/__tests__/utils.test.ts
+++ b/apps/server/src/routes/__tests__/utils.test.ts
@@ -229,13 +229,14 @@ describe("sendToTmux", () => {
     await sendToTmux("hello");
     expect(execFileSpy).toHaveBeenCalledTimes(2);
 
-    // First call: literal text
+    // First call: literal text. Target carries the `=` exact-match prefix
+    // (multi-session support, world-os#218 — no prefix-matching surprises).
     const [cmd1, args1] = execFileSpy.mock.calls[0];
     expect(cmd1).toBe("tmux");
     expect(args1).toContain("send-keys");
     expect(args1).toContain("-l");
     expect(args1).toContain("-t");
-    expect(args1).toContain(TMUX_SESSION);
+    expect(args1).toContain(`=${TMUX_SESSION}:`);
     expect(args1).toContain("--");
     expect(args1).toContain("hello");
 
@@ -245,7 +246,7 @@ describe("sendToTmux", () => {
     expect(args2).toContain("send-keys");
     expect(args2).toContain("Enter");
     expect(args2).toContain("-t");
-    expect(args2).toContain(TMUX_SESSION);
+    expect(args2).toContain(`=${TMUX_SESSION}:`);
   });
 
   it("passes timeout option to both execFile calls", async () => {

--- a/apps/server/src/routes/terminal-ws.ts
+++ b/apps/server/src/routes/terminal-ws.ts
@@ -1,4 +1,4 @@
-import { spawn, execSync, execFile } from "node:child_process";
+import { spawn, execFileSync, execFile } from "node:child_process";
 import { promisify } from "node:util";
 import type { WSContext } from "hono/ws";
 import { checkAuth, validateSession, validateJwtTokenWithTokens, getBotTokens } from "../auth.js";
@@ -8,22 +8,55 @@ import { isAllowedUser } from "../lib/allowed-users.js";
 // Keeping a local unvalidated copy would bypass that fence and leave the
 // execSync call below vulnerable to env-var shell injection. Flagged
 // security-high by cloud Gemini Code Assist on round-2 review of PR #85.
-import { TMUX_SESSION } from "./utils.js";
+import { SESSION_NAME_RE, TMUX_SESSION } from "./utils.js";
 import { ALLOWED_ORIGINS } from "../lib/allowed-origins.js";
 
 const execFileAsync = promisify(execFile);
 
-function getPaneDimensions(): { cols: number; rows: number } {
+// Same cap as the tmux helpers in routes/utils.ts — a wedged tmux server
+// must fail the call after 5s instead of wedging the connection setup.
+const TMUX_TIMEOUT_MS = 5_000;
+
+function getPaneDimensions(session: string): { cols: number; rows: number } {
   try {
-    const out = execSync(
-      `tmux display-message -t ${TMUX_SESSION} -p '#{pane_width}x#{pane_height}'`,
-      { encoding: "utf-8" },
+    // execFileSync argv (no shell) because `session` can come from the
+    // client's ?session= query param — regex-validated upstream, but a
+    // client-controlled string must never be interpolated into a shell
+    // line. Target form `=<name>:` — exact-match session lookup, and the
+    // trailing `:` is REQUIRED: tmux 3.5a rejects bare `=name` for
+    // pane-target commands (display-message/capture-pane/send-keys) with
+    // "can't find pane"; only session-target commands (has-session) take
+    // `=name` alone. Verified live on this host, 2026-07-09.
+    const out = execFileSync(
+      "tmux",
+      ["display-message", "-t", `=${session}:`, "-p", "#{pane_width}x#{pane_height}"],
+      { encoding: "utf-8", timeout: TMUX_TIMEOUT_MS },
     ).trim();
     const [cols, rows] = out.split("x").map(Number);
     return { cols: cols || 80, rows: rows || 24 };
   } catch {
     return { cols: 80, rows: 24 };
   }
+}
+
+export type SessionResolution =
+  | { ok: true; session: string }
+  | { ok: false; error: string };
+
+/**
+ * Resolve the tmux session a WS connection will view. The `?session=` query
+ * param is client-controlled (Telegram WebView — untrusted by definition):
+ * an absent/empty param keeps today's behavior (the configured
+ * TMUX_SESSION); anything else must pass the shared session-name allowlist
+ * before it can ever reach a tmux argv. Existence is checked separately in
+ * onOpen (`tmux has-session -t =<name>`) — this only fences the charset.
+ */
+export function resolveRequestedSession(raw: string): SessionResolution {
+  if (!raw) return { ok: true, session: TMUX_SESSION };
+  if (!SESSION_NAME_RE.test(raw)) {
+    return { ok: false, error: "Invalid session name" };
+  }
+  return { ok: true, session: raw };
 }
 
 // NOTE (original design, still true for the *automatic* path): the mini app
@@ -169,6 +202,11 @@ export function terminalWsRoute(c: any) {
     };
   }
 
+  // Which tmux session this connection views. Client-controlled query
+  // param — charset-fenced here, existence-checked in onOpen. Absent param
+  // = the configured TMUX_SESSION (today's single-session behavior).
+  const sessionResolution = resolveRequestedSession(c.req.query("session") || "");
+
   // Auth check: initData or session token passed as query param
   const initData = c.req.query("auth") || "";
   let authResult = checkAuth(initData);
@@ -206,25 +244,44 @@ export function terminalWsRoute(c: any) {
         ws.close(4001, "Unauthorized");
         return;
       }
-      console.log(`[ws] client connected (user: ${authResult.user?.username || "unknown"})`);
+      if (!sessionResolution.ok) {
+        console.log(`[ws] rejected: ${sessionResolution.error}`);
+        ws.send(JSON.stringify({ type: "error", message: sessionResolution.error }));
+        ws.close(4004, "Invalid session");
+        return;
+      }
+      const session = sessionResolution.session;
+      console.log(
+        `[ws] client connected (user: ${authResult.user?.username || "unknown"}, session: ${session})`,
+      );
 
       let lastContent = "";
       let lastDims = "";
-      let interval: ReturnType<typeof setInterval>;
+      let interval: ReturnType<typeof setInterval> | undefined;
+      // Set by onClose (via _cleanup). Guards the async has-session gate
+      // below: if the client disconnects before the check resolves, we must
+      // not start an interval nobody will ever clear.
+      let closed = false;
+      (ws as any)._cleanup = () => {
+        closed = true;
+        if (interval !== undefined) clearInterval(interval);
+      };
 
       const sendPaneContent = () => {
         // Send updated dimensions whenever they change
-        const dims = getPaneDimensions();
+        const dims = getPaneDimensions(session);
         const dimsKey = `${dims.cols}x${dims.rows}`;
         if (dimsKey !== lastDims) {
           lastDims = dimsKey;
           ws.send(JSON.stringify({ type: "dimensions", cols: dims.cols, rows: dims.rows }));
         }
         // -e preserves ANSI colors and -J joins wrapped lines so they reflow
-        // to the client width.
+        // to the client width. `=<name>:` target (exact-match + trailing
+        // colon required for pane-target commands on tmux 3.5a), since
+        // `session` may originate from the client's ?session= param.
         const capture = spawn("tmux", [
           "capture-pane",
-          "-t", TMUX_SESSION,
+          "-t", `=${session}:`,
           "-p",
           "-e",
           "-J",
@@ -235,7 +292,20 @@ export function terminalWsRoute(c: any) {
           output += data.toString();
         });
 
-        capture.on("close", () => {
+        capture.on("close", (code: number | null) => {
+          // A non-default session can disappear mid-view (lanes come and
+          // go). Close the connection honestly instead of leaving a frozen
+          // last frame that looks live. The DEFAULT session deliberately
+          // keeps the legacy tolerance: /restart-session kills and
+          // recreates it, and connections are expected to ride that out.
+          if (code !== 0 && session !== TMUX_SESSION) {
+            if (!closed) {
+              (ws as any)._cleanup?.();
+              ws.send(JSON.stringify({ type: "error", message: `Session "${session}" ended` }));
+              ws.close(4010, "Session ended");
+            }
+            return;
+          }
           if (output !== lastContent) {
             lastContent = output;
             ws.send(JSON.stringify({ type: "pane", content: output }));
@@ -247,12 +317,29 @@ export function terminalWsRoute(c: any) {
         });
       };
 
-      sendPaneContent();
-      interval = setInterval(sendPaneContent, 500);
-
-      (ws as any)._cleanup = () => {
-        clearInterval(interval);
+      const startPolling = () => {
+        if (closed) return;
+        sendPaneContent();
+        interval = setInterval(sendPaneContent, 500);
       };
+
+      if (session === TMUX_SESSION) {
+        // Default session: start immediately, tolerate absence (legacy
+        // behavior — see the capture close handler above).
+        startPolling();
+      } else {
+        // Client-picked session: prove it exists before polling it, so a
+        // bogus (but charset-valid) name gets a crisp error instead of a
+        // silently empty terminal. Exact-match `=` prefix, argv array.
+        execFileAsync("tmux", ["has-session", "-t", `=${session}`], { timeout: TMUX_TIMEOUT_MS })
+          .then(startPolling)
+          .catch(() => {
+            if (closed) return;
+            console.log(`[ws] rejected: unknown session "${session}"`);
+            ws.send(JSON.stringify({ type: "error", message: `Unknown session "${session}"` }));
+            ws.close(4004, "Unknown session");
+          });
+      }
     },
 
     onMessage(event: MessageEvent, ws: WSContext) {
@@ -263,9 +350,24 @@ export function terminalWsRoute(c: any) {
       // sockets, but this closes the gap if a message arrives before the
       // close takes effect.
       if (!authResult.ok) return;
+      if (!sessionResolution.ok) return;
       try {
         const msg = JSON.parse(event.data.toString());
         if (msg.type === "fit") {
+          // Fit resizes the REAL tmux window (a write). Only the default
+          // session — the one the REST write endpoints already target — may
+          // be resized; every client-picked session is view-only, so the
+          // multi-session feature adds zero new write surface. Checked
+          // before validation so applyFitResize (hardwired to TMUX_SESSION)
+          // can never be reached from a view-only connection.
+          if (sessionResolution.session !== TMUX_SESSION) {
+            console.log(`[ws] fit rejected: view-only session "${sessionResolution.session}"`);
+            ws.send(JSON.stringify({
+              type: "fit-error",
+              message: "This session is view-only — fit is only available on the default session",
+            }));
+            return;
+          }
           // Explicit, user-initiated "Fit screen" action only — the client
           // never sends this automatically (see NOTE above). Validate
           // before touching tmux.

--- a/apps/server/src/routes/terminal-ws.ts
+++ b/apps/server/src/routes/terminal-ws.ts
@@ -279,13 +279,16 @@ export function terminalWsRoute(c: any) {
         // to the client width. `=<name>:` target (exact-match + trailing
         // colon required for pane-target commands on tmux 3.5a), since
         // `session` may originate from the client's ?session= param.
+        // timeout: a wedged tmux server must not accumulate one unbounded
+        // child per 500ms poll tick — same cap as every other tmux call on
+        // these routes (spawn kills with SIGTERM on expiry).
         const capture = spawn("tmux", [
           "capture-pane",
           "-t", `=${session}:`,
           "-p",
           "-e",
           "-J",
-        ]);
+        ], { timeout: TMUX_TIMEOUT_MS });
 
         let output = "";
         capture.stdout.on("data", (data: Buffer) => {
@@ -293,17 +296,19 @@ export function terminalWsRoute(c: any) {
         });
 
         capture.on("close", (code: number | null) => {
+          // The capture child resolves asynchronously — the socket may have
+          // closed (and the interval been cleared) while it ran. Never send
+          // on a closed WSContext.
+          if (closed) return;
           // A non-default session can disappear mid-view (lanes come and
           // go). Close the connection honestly instead of leaving a frozen
           // last frame that looks live. The DEFAULT session deliberately
           // keeps the legacy tolerance: /restart-session kills and
           // recreates it, and connections are expected to ride that out.
           if (code !== 0 && session !== TMUX_SESSION) {
-            if (!closed) {
-              (ws as any)._cleanup?.();
-              ws.send(JSON.stringify({ type: "error", message: `Session "${session}" ended` }));
-              ws.close(4010, "Session ended");
-            }
+            (ws as any)._cleanup?.();
+            ws.send(JSON.stringify({ type: "error", message: `Session "${session}" ended` }));
+            ws.close(4010, "Session ended");
             return;
           }
           if (output !== lastContent) {

--- a/apps/server/src/routes/terminal/index.ts
+++ b/apps/server/src/routes/terminal/index.ts
@@ -1,10 +1,12 @@
 import { Hono } from "hono";
 import { slashCommandsRoute } from "./slash-commands.js";
 import { gitRoute } from "./git.js";
+import { sessionsRoute } from "./sessions.js";
 
 const app = new Hono();
 
 app.route("/", slashCommandsRoute);
 app.route("/", gitRoute);
+app.route("/", sessionsRoute);
 
 export { app as terminalRoute };

--- a/apps/server/src/routes/terminal/sessions.ts
+++ b/apps/server/src/routes/terminal/sessions.ts
@@ -1,0 +1,117 @@
+import { Hono } from "hono";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { SESSION_NAME_RE, TMUX_SESSION } from "../utils.js";
+
+const execFileAsync = promisify(execFile);
+
+// Same cap as the tmux helpers in routes/utils.ts — a wedged tmux server
+// must reject the request after 5s instead of hanging the HTTP handler.
+const TMUX_TIMEOUT_MS = 5_000;
+
+// Sessions whose name starts with "_" are infrastructure (e.g. the
+// _tmux-server-keepalive session that pins the tmux server alive) and are
+// never useful to view from the mini app.
+const HIDDEN_SESSION_PREFIX = "_";
+
+// A pane whose foreground process is a bare shell means the agent that was
+// running there has exited — same liveness heuristic as the fleet cockpit
+// collector (world-os apps/cpc/cockpit/lib/collector.mjs).
+const SHELL_COMMANDS = new Set(["bash", "zsh", "sh", "fish", "dash"]);
+
+export interface TmuxSessionInfo {
+  name: string;
+  attached: boolean;
+  /** epoch seconds of last activity in the session */
+  activity: number;
+  /** foreground command of the session's first pane, e.g. "claude" */
+  command: string;
+  /** false when the first pane has dropped to a bare shell */
+  alive: boolean;
+  /** true only for the server's configured TMUX_SESSION (the one session
+   *  the REST write endpoints target) — everything else is view-only */
+  writable: boolean;
+}
+
+/**
+ * Parse `tmux list-sessions` + `tmux list-panes -a` output into the session
+ * list served to the mini app. Pure function, exported for unit tests.
+ *
+ * - Skips `_`-prefixed infra sessions and (defensively) any name that fails
+ *   SESSION_NAME_RE — a name we would refuse to poll must not be offered to
+ *   the client in the first place.
+ * - `panesOut` rows are ordered by session/window/pane index, so the first
+ *   row seen for a session is its lowest window's first pane — good enough
+ *   for the alive/command signal.
+ * - Sort: the writable TMUX_SESSION first, then most recently active first.
+ */
+export function parseSessions(listOut: string, panesOut: string, defaultSession: string): TmuxSessionInfo[] {
+  const firstPaneCommand = new Map<string, string>();
+  for (const line of panesOut.split("\n")) {
+    if (!line) continue;
+    const [name, command = ""] = line.split("\t");
+    if (name && !firstPaneCommand.has(name)) firstPaneCommand.set(name, command);
+  }
+
+  const sessions: TmuxSessionInfo[] = [];
+  for (const line of listOut.split("\n")) {
+    if (!line) continue;
+    const [name, attached = "0", activity = "0"] = line.split("\t");
+    if (!name || name.startsWith(HIDDEN_SESSION_PREFIX) || !SESSION_NAME_RE.test(name)) continue;
+    const command = firstPaneCommand.get(name) ?? "";
+    sessions.push({
+      name,
+      attached: attached !== "0",
+      activity: Number.parseInt(activity, 10) || 0,
+      command,
+      alive: command !== "" && !SHELL_COMMANDS.has(command),
+      writable: name === defaultSession,
+    });
+  }
+
+  sessions.sort((a, b) => {
+    if (a.writable !== b.writable) return a.writable ? -1 : 1;
+    return b.activity - a.activity;
+  });
+  return sessions;
+}
+
+const app = new Hono();
+
+/**
+ * GET /api/terminal/sessions — enumerate the tmux sessions available to the
+ * terminal tab's session picker. Sits behind the same /api/* Telegram auth
+ * middleware as every other terminal route.
+ *
+ * The mini app treats `default` as the writable session; `sessions[i].name`
+ * feeds back into the WS `?session=` param (re-validated server-side there —
+ * this listing is a menu, never an authorization).
+ */
+app.get("/sessions", async (c) => {
+  try {
+    const [list, panes] = await Promise.all([
+      execFileAsync(
+        "tmux",
+        ["list-sessions", "-F", "#{session_name}\t#{session_attached}\t#{session_activity}"],
+        { timeout: TMUX_TIMEOUT_MS },
+      ),
+      execFileAsync(
+        "tmux",
+        ["list-panes", "-a", "-F", "#{session_name}\t#{pane_current_command}"],
+        { timeout: TMUX_TIMEOUT_MS },
+      ),
+    ]);
+    return c.json({
+      ok: true,
+      default: TMUX_SESSION,
+      sessions: parseSessions(list.stdout, panes.stdout, TMUX_SESSION),
+    });
+  } catch (err: any) {
+    // tmux exits non-zero when no server is running — surface as an error
+    // (not an empty-but-ok list) so the client falls back to the default
+    // session instead of rendering a misleading empty picker.
+    return c.json({ ok: false, error: err.message }, 500);
+  }
+});
+
+export { app as sessionsRoute };

--- a/apps/server/src/routes/terminal/slash-commands.ts
+++ b/apps/server/src/routes/terminal/slash-commands.ts
@@ -1,7 +1,7 @@
 import { Hono } from "hono";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
-import { execAsync, sendToTmux, TMUX_SESSION } from "../utils.js";
+import { execAsync, resolveTargetSession, sendToTmux, tmuxSessionExists, TMUX_SESSION } from "../utils.js";
 import { getTracer } from "../../lib/otel.js";
 import { SpanStatusCode } from "@opentelemetry/api";
 
@@ -53,6 +53,34 @@ const app = new Hono();
  */
 const RAW_KEY_TOKEN = /^[A-Za-z][A-Za-z0-9_-]*$/;
 
+/**
+ * Resolve the optional `session` body field shared by the restricted
+ * command palette endpoints (send-keys / compact / reload-plugins — the
+ * fixed verb set Liam wants usable against ANY fleet session, voice msg
+ * 1188). Returns the validated target session name, or a Response already
+ * sent to the client (400 bad name / 404 unknown session).
+ *
+ * The default session skips the existence probe on purpose — legacy
+ * behavior lets commands race a /restart-session recreate, and tmux's own
+ * error still surfaces as a 500 if it's truly gone. A client-picked
+ * session, by contrast, must exist before we send keys anywhere near it.
+ *
+ * NOT wired into /restart-session or /resize-terminal: those stay
+ * default-session-only by design (restart recreates the orchestrator
+ * launch command; resize has the window-size latch side effect) — the
+ * palette never offers them for other sessions.
+ */
+async function resolvePaletteTarget(c: any, body: any): Promise<{ session: string } | { response: Response }> {
+  const target = resolveTargetSession(body?.session);
+  if (!target.ok) {
+    return { response: c.json({ ok: false, error: target.error }, 400) };
+  }
+  if (target.session !== TMUX_SESSION && !(await tmuxSessionExists(target.session))) {
+    return { response: c.json({ ok: false, error: "unknown session" }, 404) };
+  }
+  return { session: target.session };
+}
+
 app.post("/send-keys", async (c) => {
   try {
     const body = await c.req.json();
@@ -60,6 +88,9 @@ app.post("/send-keys", async (c) => {
     if (!keys || typeof keys !== "string") {
       return c.json({ ok: false, error: "keys required" }, 400);
     }
+    const resolved = await resolvePaletteTarget(c, body);
+    if ("response" in resolved) return resolved.response;
+    const session = resolved.session;
     if (body.raw) {
       // Split on whitespace and validate each token against the allowlist.
       // Reject empty-after-split (e.g. all whitespace input) so we never call
@@ -76,9 +107,10 @@ app.post("/send-keys", async (c) => {
           );
         }
       }
-      // execFile with argv — no shell, no interpolation.
-      await tracedTmux('tmux.send-keys', TMUX_SESSION, 'raw', () =>
-        execFileAsync("tmux", ["send-keys", "-t", TMUX_SESSION, ...tokens])
+      // execFile with argv — no shell, no interpolation. `=` prefix:
+      // exact-match session lookup (the target can be client-picked).
+      await tracedTmux('tmux.send-keys', session, 'raw', () =>
+        execFileAsync("tmux", ["send-keys", "-t", `=${session}:`, ...tokens])
       );
     } else {
       // Literal text — use execFile (no shell) with `-l` and `--` so user
@@ -86,9 +118,9 @@ app.post("/send-keys", async (c) => {
       // path spawned /bin/sh -c on an interpolated string; JSON.stringify
       // only quotes for JS, NOT for shells, so `$(...)` and backticks in the
       // keys survived the quote and were executed by sh BEFORE tmux saw them.
-      await tracedTmux('tmux.send-keys', TMUX_SESSION, 'literal', async () => {
-        await execFileAsync("tmux", ["send-keys", "-t", TMUX_SESSION, "-l", "--", keys]);
-        await execFileAsync("tmux", ["send-keys", "-t", TMUX_SESSION, "Enter"]);
+      await tracedTmux('tmux.send-keys', session, 'literal', async () => {
+        await execFileAsync("tmux", ["send-keys", "-t", `=${session}:`, "-l", "--", keys]);
+        await execFileAsync("tmux", ["send-keys", "-t", `=${session}:`, "Enter"]);
       });
     }
     return c.json({ ok: true, action: "send-keys" });
@@ -102,12 +134,15 @@ app.post("/compact", async (c) => {
     const body = await c.req.json();
     const message = body.message as string;
     if (!message) return c.json({ ok: false, error: "message required" }, 400);
+    const resolved = await resolvePaletteTarget(c, body);
+    if ("response" in resolved) return resolved.response;
+    const session = resolved.session;
 
     // Send via tmux send-keys — execFile (no shell) with -l + -- so the
     // user-provided message cannot inject via $(...) or backticks.
-    await tracedTmux('tmux.compact', TMUX_SESSION, 'compact', async () => {
-      await execFileAsync("tmux", ["send-keys", "-t", TMUX_SESSION, "-l", "--", message]);
-      await execFileAsync("tmux", ["send-keys", "-t", TMUX_SESSION, "Enter"]);
+    await tracedTmux('tmux.compact', session, 'compact', async () => {
+      await execFileAsync("tmux", ["send-keys", "-t", `=${session}:`, "-l", "--", message]);
+      await execFileAsync("tmux", ["send-keys", "-t", `=${session}:`, "Enter"]);
     });
     return c.json({ ok: true, action: "compact" });
   } catch (err: any) {
@@ -117,8 +152,13 @@ app.post("/compact", async (c) => {
 
 app.post("/reload-plugins", async (c) => {
   try {
-    await tracedTmux('tmux.send-keys', TMUX_SESSION, 'reload-plugins', () =>
-      sendToTmux("/reload-plugins")
+    // Body is optional here (legacy clients POST with no body at all).
+    const body = await c.req.json().catch(() => ({}));
+    const resolved = await resolvePaletteTarget(c, body);
+    if ("response" in resolved) return resolved.response;
+    const session = resolved.session;
+    await tracedTmux('tmux.send-keys', session, 'reload-plugins', () =>
+      sendToTmux("/reload-plugins", session)
     );
     return c.json({ ok: true, action: "reload-plugins" });
   } catch (err: any) {

--- a/apps/server/src/routes/utils.ts
+++ b/apps/server/src/routes/utils.ts
@@ -6,6 +6,15 @@ import { join } from "node:path";
 export const execAsync = promisify(exec);
 const execFileAsync = promisify(execFile);
 
+// Canonical session-name allowlist, shared by every place a tmux session
+// name crosses a trust boundary: the boot-time TMUX_SESSION env validation
+// below, the `?session=` WS query param (terminal-ws.ts), and the
+// /api/terminal/sessions listing (terminal/sessions.ts). Same charset and
+// length bound as the cockpit's cockpit-attach wrapper — alphanumerics,
+// hyphens, underscores, dots, 1-64 chars. A name that fails this regex must
+// never reach a tmux argv.
+export const SESSION_NAME_RE = /^[A-Za-z0-9_.-]{1,64}$/;
+
 // TMUX_SESSION is consumed by execAsync (shell) in several helpers, so a
 // malicious `process.env.TMUX_SESSION` would break the fence. Validate
 // once at module load against the canonical tmux session-name charset
@@ -18,10 +27,10 @@ const execFileAsync = promisify(execFile);
 // rather than reading process.env directly so the validation is
 // unbypassable.
 const _rawTmuxSession = process.env.TMUX_SESSION || "claudes-world";
-if (!/^[A-Za-z0-9_.-]+$/.test(_rawTmuxSession)) {
+if (!SESSION_NAME_RE.test(_rawTmuxSession)) {
   throw new Error(
     `Invalid TMUX_SESSION name: ${JSON.stringify(_rawTmuxSession)}. ` +
-      `Only alphanumerics, hyphens, underscores, and dots are allowed.`,
+      `Only alphanumerics, hyphens, underscores, and dots are allowed (max 64 chars).`,
   );
 }
 export const TMUX_SESSION = _rawTmuxSession;
@@ -55,14 +64,58 @@ export const SESSION_NAMES_FILE = join(CLAUDES_WORLD, ".cpc-session-names");
 // path and returns a non-OK JSON response to the client.
 const TMUX_TIMEOUT_MS = 5_000;
 
-export async function sendToTmux(keys: string) {
+export type TargetSessionResult =
+  | { ok: true; session: string }
+  | { ok: false; error: string };
+
+/**
+ * Resolve the optional `session` field of a terminal REST body (the
+ * restricted command palette targets the session the terminal tab is
+ * viewing — Liam voice msg 1188). Absent/empty = the configured
+ * TMUX_SESSION, exactly today's behavior. Anything else is
+ * client-controlled input and must pass the shared allowlist before it can
+ * reach a tmux argv. Existence is the caller's concern (`tmux has-session`)
+ * — this only fences type and charset.
+ */
+export function resolveTargetSession(raw: unknown): TargetSessionResult {
+  if (raw === undefined || raw === null || raw === "") {
+    return { ok: true, session: TMUX_SESSION };
+  }
+  if (typeof raw !== "string" || !SESSION_NAME_RE.test(raw)) {
+    return { ok: false, error: "invalid session name" };
+  }
+  return { ok: true, session: raw };
+}
+
+/** True when the (already charset-validated) session exists on the tmux
+ *  server. Exact-match `=` prefix — no prefix-matching surprises. */
+export async function tmuxSessionExists(session: string): Promise<boolean> {
+  try {
+    await execFileAsync("tmux", ["has-session", "-t", `=${session}`], {
+      timeout: TMUX_TIMEOUT_MS,
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function sendToTmux(keys: string, session: string = TMUX_SESSION) {
   // The `--` separator stops tmux from interpreting `keys` as an option
   // if the first character is a hyphen. execFile already prevents shell
   // injection but this also prevents tmux-level argument confusion.
-  await execFileAsync("tmux", ["send-keys", "-t", TMUX_SESSION, "-l", "--", keys], {
+  //
+  // Target form `=<name>:` — the `=` forces exact-match session lookup
+  // (`session` may originate from a request body; exactness also protects
+  // against prefix collisions between real session names), and the trailing
+  // `:` is REQUIRED on pane-target commands: tmux 3.5a rejects a bare
+  // `=name` for send-keys/capture-pane/display-message with "can't find
+  // pane" (verified live on this host 2026-07-09); only session-target
+  // commands like has-session accept `=name` alone.
+  await execFileAsync("tmux", ["send-keys", "-t", `=${session}:`, "-l", "--", keys], {
     timeout: TMUX_TIMEOUT_MS,
   });
-  await execFileAsync("tmux", ["send-keys", "-t", TMUX_SESSION, "Enter"], {
+  await execFileAsync("tmux", ["send-keys", "-t", `=${session}:`, "Enter"], {
     timeout: TMUX_TIMEOUT_MS,
   });
 }

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -115,9 +115,17 @@ export function App() {
   // tab views. null = the server's default (writable) session. Deep-linkable
   // via #terminal&session=<name>, same convention as #files&file=<path>.
   const initialSessionRaw = hashParams.match(/(?:^|&)session=([^&]+)/)?.[1];
-  const initialSession = initialSessionRaw && SESSION_NAME_RE.test(decodeURIComponent(initialSessionRaw))
-    ? decodeURIComponent(initialSessionRaw)
-    : null;
+  let initialSession: string | null = null;
+  if (initialSessionRaw) {
+    try {
+      const decoded = decodeURIComponent(initialSessionRaw);
+      if (SESSION_NAME_RE.test(decoded)) initialSession = decoded;
+    } catch {
+      // Malformed percent-encoding in a hand-typed/truncated deep link
+      // (e.g. "#terminal&session=%") — treat as no session rather than
+      // throwing during initial render.
+    }
+  }
   const [activeSession, setActiveSession] = useState<string | null>(initialSession);
   const [sessionList, setSessionList] = useState<TmuxSessionInfo[]>([]);
   const [defaultSession, setDefaultSession] = useState<string | null>(null);
@@ -173,6 +181,12 @@ export function App() {
         if (data.ok) {
           setSessionList(data.sessions);
           setDefaultSession(data.default);
+          // Normalize a deep link that names the default session explicitly
+          // (#terminal&session=<default>): null IS the default everywhere
+          // else, and leaving the name in place misclassifies the session
+          // as non-default (restricted palette) until this fetch resolves —
+          // and would keep sending a redundant session field afterwards.
+          setActiveSession((cur) => (cur === data.default ? null : cur));
         }
       } catch { /* silent — picker just doesn't render */ }
     };
@@ -496,10 +510,12 @@ export function App() {
         </div>
       )}
 
-      {/* Session picker — terminal tab only, and only when there's a choice.
-          Also rendered when a hash deep-link points at a session the list
-          doesn't know (yet), so the user can navigate back out. */}
-      {activeTab === "terminal" && sessionList.length > 1 && (
+      {/* Session picker — terminal tab only, when there's a choice OR a
+          hash deep-link points at a non-default session (even one the
+          roster doesn't know), so a stale deep link always leaves the user
+          a pill to click back to the default instead of stranding them on
+          the error frame. */}
+      {activeTab === "terminal" && (sessionList.length > 1 || activeSession !== null) && sessionList.length > 0 && (
         <SessionPicker
           sessions={sessionList}
           active={activeSession ?? defaultSession ?? ""}

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -181,12 +181,15 @@ export function App() {
         if (data.ok) {
           setSessionList(data.sessions);
           setDefaultSession(data.default);
-          // Normalize a deep link that names the default session explicitly
-          // (#terminal&session=<default>): null IS the default everywhere
-          // else, and leaving the name in place misclassifies the session
-          // as non-default (restricted palette) until this fetch resolves —
-          // and would keep sending a redundant session field afterwards.
-          setActiveSession((cur) => (cur === data.default ? null : cur));
+          // Deliberately NOT normalizing activeSession here: a deep link
+          // that names the default session literally keeps its name in
+          // state, because Terminal is keyed on activeSession — mutating it
+          // to null would remount the terminal and tear down a healthy WS
+          // just to clean up the key (codex round-2). paletteSession below
+          // derives the default-vs-not classification on every render, so
+          // the restricted palette still self-corrects the moment this
+          // fetch resolves; the WS carrying an explicit default-session
+          // param is server-side identical to omitting it.
         }
       } catch { /* silent — picker just doesn't render */ }
     };

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -11,6 +11,13 @@ import { haptic } from "./lib/haptic";
 import { DebugOverlay } from "./debug/DebugOverlay";
 import { PrTicker } from "./components/PrTicker";
 import { HomeScreenPrompt } from "./components/HomeScreenPrompt";
+import { SessionPicker, type TmuxSessionInfo } from "./components/SessionPicker";
+
+// Client-side mirror of the server's session-name allowlist (SESSION_NAME_RE
+// in apps/server/src/routes/utils.ts). Applied to the hash deep-link value —
+// the server re-validates regardless; this just drops junk before it ever
+// becomes a WS param.
+const SESSION_NAME_RE = /^[A-Za-z0-9_.-]{1,64}$/;
 
 type Tab = "terminal" | "files" | "links" | "voice" | "prs";
 const TABS: Tab[] = ["terminal", "files", "links", "voice", "prs"];
@@ -103,6 +110,23 @@ export function App() {
     TABS.includes(initialTab as Tab) ? initialTab : "terminal"
   );
   const [reconnectKey, setReconnectKey] = useState(0);
+
+  // Multi-session terminal (world-os#218): which tmux session the terminal
+  // tab views. null = the server's default (writable) session. Deep-linkable
+  // via #terminal&session=<name>, same convention as #files&file=<path>.
+  const initialSessionRaw = hashParams.match(/(?:^|&)session=([^&]+)/)?.[1];
+  const initialSession = initialSessionRaw && SESSION_NAME_RE.test(decodeURIComponent(initialSessionRaw))
+    ? decodeURIComponent(initialSessionRaw)
+    : null;
+  const [activeSession, setActiveSession] = useState<string | null>(initialSession);
+  const [sessionList, setSessionList] = useState<TmuxSessionInfo[]>([]);
+  const [defaultSession, setDefaultSession] = useState<string | null>(null);
+  // Non-default session the restricted command palette targets, or null
+  // when viewing the default session. Treated as non-default until the
+  // session list proves a deep-linked name IS the default — targeting the
+  // default explicitly by name is harmless (server resolves both to the
+  // same session), so the pessimistic default is safe either way.
+  const paletteSession = activeSession !== null && activeSession !== defaultSession ? activeSession : null;
   const [initialFilePath] = useState<string | null>(initialFile);
   const [fileShowHidden, setFileShowHidden] = useState<boolean>(() => {
     try { return localStorage.getItem(HIDDEN_KEY) === "1"; } catch { return false; }
@@ -128,8 +152,47 @@ export function App() {
 
   const onConnectionChange = useCallback((c: boolean) => setConnected(c), []);
   const onReconnect = useCallback(() => {
-    fetch("/api/terminal/resize-terminal", { method: "POST" }).catch(() => {});
+    // resize-terminal targets the DEFAULT session on the server — skip it
+    // when viewing another session (it stays default-only by design: the
+    // resize-window manual-size latch side effect, see terminal-ws.ts).
+    if (!paletteSession) {
+      fetch("/api/terminal/resize-terminal", { method: "POST" }).catch(() => {});
+    }
     setReconnectKey((k) => k + 1);
+  }, [paletteSession]);
+
+  // Session list for the terminal's session picker — fetch on mount and
+  // refresh every 30s (same cadence as the cpc-branch poll below). On
+  // failure keep the last known list; an empty list hides the picker and
+  // the terminal falls back to the default session.
+  useEffect(() => {
+    const fetchSessions = async () => {
+      try {
+        const res = await fetch("/api/terminal/sessions", { headers: getAuthHeaders() });
+        const data = await res.json();
+        if (data.ok) {
+          setSessionList(data.sessions);
+          setDefaultSession(data.default);
+        }
+      } catch { /* silent — picker just doesn't render */ }
+    };
+    fetchSessions();
+    const interval = setInterval(fetchSessions, 30000);
+    return () => clearInterval(interval);
+  }, []);
+
+  const onSelectSession = useCallback((name: string | null) => {
+    setActiveSession(name);
+    // Keep the deep-link honest: rewrite #terminal&session=<name>,
+    // preserving any other hash params (e.g. token from keyboard-button
+    // links). replaceState so session-surfing doesn't pollute history.
+    const raw = window.location.hash.replace(/^#/, "");
+    const rest = raw.includes("&") ? raw.slice(raw.indexOf("&") + 1) : "";
+    const params = new URLSearchParams(rest);
+    if (name) params.set("session", name);
+    else params.delete("session");
+    const qs = params.toString();
+    window.history.replaceState(null, "", `#terminal${qs ? `&${qs}` : ""}`);
   }, []);
 
   // "Fit screen" (reconnect menu) — Terminal registers its trigger function
@@ -433,6 +496,17 @@ export function App() {
         </div>
       )}
 
+      {/* Session picker — terminal tab only, and only when there's a choice.
+          Also rendered when a hash deep-link points at a session the list
+          doesn't know (yet), so the user can navigate back out. */}
+      {activeTab === "terminal" && sessionList.length > 1 && (
+        <SessionPicker
+          sessions={sessionList}
+          active={activeSession ?? defaultSession ?? ""}
+          onSelect={onSelectSession}
+        />
+      )}
+
       {/* Content area — swipeable viewport */}
       <div
         style={{ flex: 1, minHeight: 0, overflow: "hidden", position: "relative" }}
@@ -453,7 +527,14 @@ export function App() {
           onTransitionEnd={() => setIsAnimating(false)}
         >
           <div style={{ width: `${100 / TABS.length}%`, height: "100%", flexShrink: 0 }}>
-            <Terminal key={reconnectKey} onConnectionChange={onConnectionChange} isActive={activeTab === "terminal"} fitScreenRef={fitScreenRef} onFitResult={onFitResult} />
+            <Terminal
+              key={`${reconnectKey}:${activeSession ?? ""}`}
+              session={activeSession}
+              onConnectionChange={onConnectionChange}
+              isActive={activeTab === "terminal"}
+              fitScreenRef={fitScreenRef}
+              onFitResult={onFitResult}
+            />
           </div>
           <div style={{ width: `${100 / TABS.length}%`, height: "100%", flexShrink: 0 }}>
             <FileViewer onClose={() => setActiveTab("terminal")} initialFile={initialFilePath} showHidden={fileShowHidden} sortMode={fileSortMode} onSortModeChange={setFileSortMode} onViewChange={setViewingFile} onPathChange={setCurrentFolder} />
@@ -478,6 +559,7 @@ export function App() {
           fitResult={fitResult}
           connected={connected}
           activeTab={activeTab}
+          terminalSession={paletteSession}
           fileShowHidden={fileShowHidden}
           setFileShowHidden={setFileShowHidden}
           fileSortMode={fileSortMode}

--- a/apps/web/src/components/SessionPicker.tsx
+++ b/apps/web/src/components/SessionPicker.tsx
@@ -1,0 +1,94 @@
+import { haptic } from "../lib/haptic";
+
+/** Shape served by GET /api/terminal/sessions (see apps/server/src/routes/terminal/sessions.ts). */
+export interface TmuxSessionInfo {
+  name: string;
+  attached: boolean;
+  activity: number;
+  command: string;
+  alive: boolean;
+  writable: boolean;
+}
+
+interface SessionPickerProps {
+  sessions: TmuxSessionInfo[];
+  /** Resolved name of the session currently viewed. */
+  active: string;
+  /** null selects the server default (writable) session. */
+  onSelect: (name: string | null) => void;
+}
+
+/**
+ * Horizontal pill strip above the terminal for switching which tmux session
+ * the terminal tab views. Server order is preserved (writable default
+ * first, then most recently active). The writable session carries a pencil
+ * mark; every other session is view-only, which the ActionBar communicates
+ * separately. Only rendered when there's actually a choice to make
+ * (App.tsx hides it for 0-1 sessions).
+ */
+export function SessionPicker({ sessions, active, onSelect }: SessionPickerProps) {
+  return (
+    <div
+      data-testid="session-picker"
+      style={{
+        display: "flex",
+        gap: 6,
+        padding: "6px 12px",
+        overflowX: "auto",
+        borderBottom: "1px solid var(--color-border)",
+        flexShrink: 0,
+        // Momentum scrolling in the Telegram WebView
+        WebkitOverflowScrolling: "touch",
+      }}
+      // The tab strip swipes between tabs on horizontal drag; scrolling the
+      // pill strip must not also swipe the tab. Same stopPropagation
+      // pattern as the header/action bar in App.tsx.
+      onTouchStart={(e) => e.stopPropagation()}
+    >
+      {sessions.map((s) => {
+        const isActive = s.name === active;
+        return (
+          <button
+            key={s.name}
+            onClick={() => {
+              if (isActive) return;
+              haptic.selection();
+              onSelect(s.writable ? null : s.name);
+            }}
+            style={{
+              display: "inline-flex",
+              alignItems: "center",
+              gap: 5,
+              padding: "3px 10px",
+              fontSize: 11,
+              whiteSpace: "nowrap",
+              flexShrink: 0,
+              borderRadius: 999,
+              cursor: "pointer",
+              background: isActive ? "var(--color-surface)" : "none",
+              color: isActive ? "var(--color-fg)" : "var(--color-muted)",
+              border: isActive
+                ? "1px solid var(--color-accent-blue)"
+                : "1px solid var(--color-border)",
+              fontWeight: isActive ? 600 : 400,
+            }}
+          >
+            <span
+              aria-hidden="true"
+              style={{
+                width: 6,
+                height: 6,
+                borderRadius: "50%",
+                flexShrink: 0,
+                background: s.alive ? "var(--color-accent-green)" : "var(--color-subtle)",
+                display: "inline-block",
+              }}
+            />
+            {s.name}
+            {s.writable && <span aria-label="writable session">&#9998;</span>}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/src/components/Terminal.tsx
+++ b/apps/web/src/components/Terminal.tsx
@@ -46,15 +46,22 @@ interface TerminalProps {
    * it looking like unconditional success.
    */
   onFitResult?: (result: FitResult) => void;
+  /**
+   * tmux session to view (multi-session picker). null/undefined = the
+   * server's default session (today's behavior). App.tsx keys this
+   * component by session, so each mount views exactly one session for its
+   * whole lifetime.
+   */
+  session?: string | null;
 }
 
-/** Build the WebSocket URL with auth params. */
-function buildWsUrl(): string {
+/** Build the WebSocket URL with auth (and optional session) params. */
+function buildWsUrl(session?: string | null): string {
   const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
+  const params = new URLSearchParams();
   const initData = window.Telegram?.WebApp?.initData || "";
-  let authParam = "";
   if (initData) {
-    authParam = `?auth=${encodeURIComponent(initData)}`;
+    params.set("auth", initData);
   } else {
     // Fallback: URL token from keyboard button, then saved session token
     const urlParams = new URLSearchParams(window.location.search);
@@ -62,12 +69,14 @@ function buildWsUrl(): string {
     const urlToken = urlParams.get("token") || hashParams.get("token") || "";
     const savedToken = localStorage.getItem("cpc-session-token") || "";
     const token = urlToken || savedToken;
-    if (token) authParam = `?token=${encodeURIComponent(token)}`;
+    if (token) params.set("token", token);
   }
-  return `${protocol}//${window.location.host}/ws/terminal${authParam}`;
+  if (session) params.set("session", session);
+  const qs = params.toString();
+  return `${protocol}//${window.location.host}/ws/terminal${qs ? `?${qs}` : ""}`;
 }
 
-export function Terminal({ onConnectionChange, isActive, fitScreenRef, onFitResult }: TerminalProps) {
+export function Terminal({ onConnectionChange, isActive, fitScreenRef, onFitResult, session }: TerminalProps) {
   const wrapperRef = useRef<HTMLDivElement>(null);
   const mountRef = useRef<HTMLDivElement>(null);
   const termRef = useRef<XTerm | null>(null);
@@ -83,6 +92,12 @@ export function Terminal({ onConnectionChange, isActive, fitScreenRef, onFitResu
   const onFitResultRef = useRef(onFitResult);
   onFitResultRef.current = onFitResult;
 
+  // Ref so connectWs (stable useCallback) always reads the current session
+  // without needing it as a dependency. In practice App.tsx remounts this
+  // component when the session changes, so the value is fixed per mount.
+  const sessionRef = useRef(session);
+  sessionRef.current = session;
+
   /** Open a WebSocket and wire it to the current xterm instance.
    *  Closes any existing connection first to prevent duplicates. */
   const connectWs = useCallback(() => {
@@ -95,7 +110,7 @@ export function Terminal({ onConnectionChange, isActive, fitScreenRef, onFitResu
       wsRef.current.close();
     }
 
-    const ws = new WebSocket(buildWsUrl());
+    const ws = new WebSocket(buildWsUrl(sessionRef.current));
 
     // Guard all handlers against stale sockets: if connectWs is called again
     // before the previous socket finishes closing, the old socket's events
@@ -146,6 +161,14 @@ export function Terminal({ onConnectionChange, isActive, fitScreenRef, onFitResu
           // the real outcome instead of showing false success.
           console.log(`[fit] rejected: ${msg.message}`);
           onFitResultRef.current?.({ ok: false, message: msg.message });
+        } else if (msg.type === "error") {
+          // Server-initiated close reasons (unknown session, session ended
+          // mid-view, auth failure). Render the reason into the terminal so
+          // the user sees WHY the view stopped instead of a silent freeze —
+          // the server closes the socket right after sending this, which
+          // flips the header dot to "offline" via onclose below.
+          console.log(`[ws] server error: ${msg.message}`);
+          term.write(`\r\n\x1b[31m[${msg.message}]\x1b[0m\r\n`);
         }
       } catch {
         term.write(event.data);

--- a/apps/web/src/components/__tests__/ActionBar.test.tsx
+++ b/apps/web/src/components/__tests__/ActionBar.test.tsx
@@ -513,7 +513,7 @@ describe("ActionBar", () => {
     fireEvent.click(screen.getByText("New"));
 
     await waitFor(() => {
-      expect(mockSendCompactCommand).toHaveBeenCalledWith("/new");
+      expect(mockSendCompactCommand).toHaveBeenCalledWith("/new", null);
     });
   });
 
@@ -536,7 +536,7 @@ describe("ActionBar", () => {
     fireEvent.click(screen.getByText("Compact"));
 
     await waitFor(() => {
-      expect(mockSendCompactCommand).toHaveBeenCalledWith("/compact");
+      expect(mockSendCompactCommand).toHaveBeenCalledWith("/compact", null);
     });
   });
 
@@ -554,7 +554,7 @@ describe("ActionBar", () => {
     fireEvent.click(screen.getByText("Compact"));
 
     await waitFor(() => {
-      expect(mockSendCompactCommand).toHaveBeenCalledWith("/compact auth refactor");
+      expect(mockSendCompactCommand).toHaveBeenCalledWith("/compact auth refactor", null);
     });
   });
 
@@ -661,5 +661,76 @@ describe("ActionBar", () => {
     render(<ActionBar activeTab="terminal" onReconnect={() => {}} />);
     const reconnectMenuBtn = screen.getByLabelText("Open reconnect menu");
     expect(reconnectMenuBtn).toBeInTheDocument();
+  });
+});
+
+// ─── Restricted palette: viewing a non-default tmux session ─────────────
+// (multi-session terminal, world-os#218 / Liam voice msg 1188)
+
+describe("ActionBar restricted session mode", () => {
+  const SESSION = "do-box--lane-a";
+
+  it("shows Reconnect and /commands but hides Git and the reconnect menu", () => {
+    render(<ActionBar activeTab="terminal" onReconnect={() => {}} terminalSession={SESSION} />);
+    expect(screen.getByText("Reconnect")).toBeInTheDocument();
+    expect(screen.getByText("/commands")).toBeInTheDocument();
+    // Default-session-only actions must not be reachable.
+    expect(screen.queryByText("Git")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Open reconnect menu")).not.toBeInTheDocument();
+  });
+
+  it("hides orchestrator-bookkeeping commands in the sheet and names the target", () => {
+    render(<ActionBar activeTab="terminal" onReconnect={() => {}} terminalSession={SESSION} />);
+    fireEvent.click(screen.getByText("/commands"));
+    expect(screen.getByTestId("bottom-sheet-title")).toHaveTextContent(`/commands → ${SESSION}`);
+    // Restricted verbs available:
+    expect(screen.getByText("Esc")).toBeInTheDocument();
+    expect(screen.getByText("/compact")).toBeInTheDocument();
+    expect(screen.getByText("/reload-plugins")).toBeInTheDocument();
+    // Default-session-only commands hidden:
+    expect(screen.queryByText("/new")).not.toBeInTheDocument();
+    expect(screen.queryByText("/resume")).not.toBeInTheDocument();
+    expect(screen.queryByText(/\/branch/)).not.toBeInTheDocument();
+    expect(screen.queryByText("/rename")).not.toBeInTheDocument();
+  });
+
+  it("threads the viewed session into key sends", () => {
+    render(<ActionBar activeTab="terminal" onReconnect={() => {}} terminalSession={SESSION} />);
+    fireEvent.click(screen.getByText("/commands"));
+    fireEvent.click(screen.getByText("Esc"));
+    expect(mockSendToTmux).toHaveBeenCalledWith("Escape", true, SESSION);
+  });
+
+  it("threads the viewed session into digit sends", () => {
+    render(<ActionBar activeTab="terminal" onReconnect={() => {}} terminalSession={SESSION} />);
+    fireEvent.click(screen.getByText("/commands"));
+    fireEvent.click(screen.getByText("2"));
+    expect(mockSendToTmux).toHaveBeenCalledWith("2", false, SESSION);
+  });
+
+  it("threads the viewed session into reload-plugins", () => {
+    render(<ActionBar activeTab="terminal" onReconnect={() => {}} terminalSession={SESSION} />);
+    fireEvent.click(screen.getByText("/commands"));
+    fireEvent.click(screen.getByText("/reload-plugins"));
+    expect(mockPostAction).toHaveBeenCalledWith(
+      "/api/terminal/reload-plugins",
+      { session: SESSION },
+    );
+  });
+
+  it("threads the viewed session into /compact", async () => {
+    render(<ActionBar activeTab="terminal" onReconnect={() => {}} terminalSession={SESSION} />);
+    fireEvent.click(screen.getByText("/commands"));
+    await waitFor(() => expect(screen.getByText("/compact")).toBeInTheDocument());
+    fireEvent.click(screen.getByText("/compact"));
+    await waitFor(() => expect(screen.getByText("Compact Now")).toBeInTheDocument());
+    fireEvent.click(screen.getByText("Compact Now"));
+    await waitFor(() => expect(screen.getByText("Compact Focus")).toBeInTheDocument());
+
+    // Submit without focus text sends plain /compact — to the viewed session
+    fireEvent.click(screen.getByText("Compact"));
+    await waitFor(() => {
+      expect(mockSendCompactCommand).toHaveBeenCalledWith("/compact", SESSION);
+    });
   });
 });

--- a/apps/web/src/components/action-bar/ActionBar.tsx
+++ b/apps/web/src/components/action-bar/ActionBar.tsx
@@ -32,7 +32,10 @@ import { usePreferences } from "../../hooks/usePreferences";
 // for a boolean with a sensible default of ON.
 const SEARCH_SCOPE_PREF = "searchCurrentFolderOnly";
 
-export function ActionBar({ onReconnect, onFitScreen, fitResult, connected, activeTab, fileShowHidden, setFileShowHidden, fileSortMode, setFileSortMode, viewingFile, currentFolder }: ActionBarProps) {
+export function ActionBar({ onReconnect, onFitScreen, fitResult, connected, activeTab, terminalSession, fileShowHidden, setFileShowHidden, fileSortMode, setFileSortMode, viewingFile, currentFolder }: ActionBarProps) {
+  // Viewing a non-default tmux session: the restricted palette targets it;
+  // default-session-only actions are hidden (see ActionBarProps docs).
+  const restrictedSession = terminalSession || null;
   const [status, setStatus] = useState<string | null>(null);
   const [modal, setModal] = useState<Modal>(null);
   const [compactFocus, setCompactFocus] = useState("");
@@ -124,10 +127,10 @@ export function ActionBar({ onReconnect, onFitScreen, fitResult, connected, acti
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [fitResult]);
 
-  const handleAction = async (endpoint: string, label: string) => {
+  const handleAction = async (endpoint: string, label: string, body?: Record<string, unknown>) => {
     setStatus(`Running ${label}...`);
     try {
-      const data = await postAction(endpoint);
+      const data = await postAction(endpoint, body);
       if (!data.ok) {
         haptic.error();
         setStatus(`Failed: ${data.error || "unknown error"}`);
@@ -161,7 +164,10 @@ export function ActionBar({ onReconnect, onFitScreen, fitResult, connected, acti
     setModal(null);
     setStatus(`${label}...`);
     try {
-      const data = await sendCompactCommand(message);
+      // Targets the viewed session (restrictedSession null = default). Only
+      // /compact reaches this with a non-default target — the sheet hides
+      // /new and /resume (the other handleCompact callers) when restricted.
+      const data = await sendCompactCommand(message, restrictedSession);
       if (data.ok) {
         haptic.success();
         setStatus(`${label} sent`);
@@ -415,16 +421,17 @@ export function ActionBar({ onReconnect, onFitScreen, fitResult, connected, acti
       modalNode = (
         <CommandsSheet
           onClose={() => setModal(null)}
-          onEsc={() => { void sendToTmux("Escape", true); setModal(null); setStatus("Sent: Esc"); }}
-          onDigit={(digit) => { void sendToTmux(String(digit)); setModal(null); setStatus(`Sent: ${digit}`); }}
-          onShiftTab={() => { void sendToTmux("BTab", true); setModal(null); setStatus("Sent: \u21e7Tab"); }}
-          onControlB={() => { void sendToTmux("C-b", true); setModal(null); setStatus("Sent: ^B"); }}
+          targetSession={restrictedSession}
+          onEsc={() => { void sendToTmux("Escape", true, restrictedSession); setModal(null); setStatus("Sent: Esc"); }}
+          onDigit={(digit) => { void sendToTmux(String(digit), false, restrictedSession); setModal(null); setStatus(`Sent: ${digit}`); }}
+          onShiftTab={() => { void sendToTmux("BTab", true, restrictedSession); setModal(null); setStatus("Sent: \u21e7Tab"); }}
+          onControlB={() => { void sendToTmux("C-b", true, restrictedSession); setModal(null); setStatus("Sent: ^B"); }}
           onNew={() => setModal("new-confirm")}
           onResume={() => { void loadSessionNames(); setModal("resume"); }}
           onFork={() => { setForkName(""); setModal("fork-name"); }}
           onRename={() => { setRenameName(""); setModal("rename"); }}
           onCompact={() => setModal("compact-confirm")}
-          onReloadPlugins={() => { setModal(null); void handleAction("/api/terminal/reload-plugins", "Reload plugins"); }}
+          onReloadPlugins={() => { setModal(null); void handleAction("/api/terminal/reload-plugins", "Reload plugins", restrictedSession ? { session: restrictedSession } : undefined); }}
         />
       );
       break;
@@ -590,7 +597,29 @@ export function ActionBar({ onReconnect, onFitScreen, fitResult, connected, acti
             TODO
           </button>
 
-          {activeTab === "terminal" && <>
+          {/* Restricted terminal row: viewing a non-default session. The
+              command palette targets the viewed session (Liam voice msg
+              1188); default-session-only actions — reconnect-menu's
+              Restart/Fit, git — are hidden so they can never act on the
+              wrong terminal. */}
+          {activeTab === "terminal" && restrictedSession && <>
+            {onReconnect && (
+              <button
+                onClick={() => { haptic.impact("light"); onReconnect(); }}
+                style={{ ...btnStyle, background: "#1a3a2a", color: "var(--color-accent-green)", border: "1px solid #2d5a3d" }}
+              >
+                Reconnect
+              </button>
+            )}
+            <button
+              onClick={() => { haptic.impact("light"); setModal("commands"); }}
+              style={{ ...btnStyle, background: "#2d2a3a", color: "var(--color-accent-purple)", border: "1px solid #4a3d6a" }}
+            >
+              /commands
+            </button>
+          </>}
+
+          {activeTab === "terminal" && !restrictedSession && <>
             {onReconnect && (
               <div style={{ display: "flex", flexShrink: 0 }}>
                 <button

--- a/apps/web/src/components/action-bar/CommandsSheet.tsx
+++ b/apps/web/src/components/action-bar/CommandsSheet.tsx
@@ -13,13 +13,28 @@ interface CommandsSheetProps {
   onRename: () => void;
   onCompact: () => void;
   onReloadPlugins: () => void;
+  /**
+   * Set when the terminal tab is viewing a non-default tmux session (the
+   * multi-session picker). The sheet then shows only the restricted
+   * palette that makes sense against any fleet session — keys (Esc /
+   * digits / ⇧Tab / ^B), /compact, /reload-plugins — and names the target
+   * so a nudge never lands on the wrong terminal. /new, /resume, /branch
+   * and /rename stay default-session-only: they drive the orchestrator's
+   * session-bookkeeping workflow (.cpc-session-names), which other lanes
+   * don't participate in.
+   */
+  targetSession?: string | null;
 }
 
 export function CommandsSheet(props: CommandsSheetProps) {
   const commandStyle = { ...btnStyle, padding: "4px 12px", textAlign: "left" as const, fontFamily: "monospace" };
+  const restricted = Boolean(props.targetSession);
 
   return (
-    <BottomSheet onClose={props.onClose} title="/commands">
+    <BottomSheet
+      onClose={props.onClose}
+      title={restricted ? `/commands → ${props.targetSession}` : "/commands"}
+    >
       <div style={{ display: "flex", flexDirection: "column", gap: 3 }}>
         <div style={{ display: "flex", gap: 6 }}>
           <button onClick={props.onEsc} style={{ ...btnStyle, flex: 1, padding: "12px 0", textAlign: "center", fontSize: 13, fontWeight: 600, color: "var(--color-accent-red)" }}>Esc</button>
@@ -31,22 +46,24 @@ export function CommandsSheet(props: CommandsSheetProps) {
           <button onClick={props.onShiftTab} style={{ ...btnStyle, flex: 1, padding: "12px 0", textAlign: "center", fontSize: 11, fontWeight: 600, color: "var(--color-accent-purple)" }}>{"\u21e7Tab"}</button>
           <button onClick={props.onControlB} style={{ ...btnStyle, flex: 1, padding: "12px 0", textAlign: "center", fontSize: 11, fontWeight: 600, color: "var(--color-accent-yellow)" }}>^B</button>
         </div>
-        <button onClick={props.onNew} style={{ ...commandStyle, background: "#3a2020", color: "var(--color-accent-red)", border: "1px solid #5a3030" }}>
-          /new
-          <div style={{ fontSize: 10, color: "#6a4040", marginTop: 1 }}>Start a new conversation</div>
-        </button>
-        <button onClick={props.onResume} style={{ ...commandStyle, background: "#1a3a2a", color: "var(--color-accent-green)", border: "1px solid #2d5a3d" }}>
-          /resume
-          <div style={{ fontSize: 10, color: "#4a7a5a", marginTop: 1 }}>Switch to a previous session</div>
-        </button>
-        <button onClick={props.onFork} style={commandStyle}>
-          /branch <span style={{ color: "var(--color-muted)", fontFamily: "inherit" }}>(fork)</span>
-          <div style={{ fontSize: 10, color: "var(--color-muted)", marginTop: 1 }}>Branch or fork this conversation</div>
-        </button>
-        <button onClick={props.onRename} style={commandStyle}>
-          /rename
-          <div style={{ fontSize: 10, color: "var(--color-muted)", marginTop: 1 }}>Give this session a name</div>
-        </button>
+        {!restricted && <>
+          <button onClick={props.onNew} style={{ ...commandStyle, background: "#3a2020", color: "var(--color-accent-red)", border: "1px solid #5a3030" }}>
+            /new
+            <div style={{ fontSize: 10, color: "#6a4040", marginTop: 1 }}>Start a new conversation</div>
+          </button>
+          <button onClick={props.onResume} style={{ ...commandStyle, background: "#1a3a2a", color: "var(--color-accent-green)", border: "1px solid #2d5a3d" }}>
+            /resume
+            <div style={{ fontSize: 10, color: "#4a7a5a", marginTop: 1 }}>Switch to a previous session</div>
+          </button>
+          <button onClick={props.onFork} style={commandStyle}>
+            /branch <span style={{ color: "var(--color-muted)", fontFamily: "inherit" }}>(fork)</span>
+            <div style={{ fontSize: 10, color: "var(--color-muted)", marginTop: 1 }}>Branch or fork this conversation</div>
+          </button>
+          <button onClick={props.onRename} style={commandStyle}>
+            /rename
+            <div style={{ fontSize: 10, color: "var(--color-muted)", marginTop: 1 }}>Give this session a name</div>
+          </button>
+        </>}
         <button onClick={props.onCompact} style={{ ...commandStyle, background: "#2d3a5a", color: "var(--color-accent-blue)", border: "1px solid #3d4a6a" }}>
           /compact
           <div style={{ fontSize: 10, color: "#4a5a8a", marginTop: 1 }}>Compress conversation context</div>

--- a/apps/web/src/components/action-bar/api.ts
+++ b/apps/web/src/components/action-bar/api.ts
@@ -23,10 +23,13 @@ async function jsonFetch<T>(input: RequestInfo | URL, init?: RequestInit): Promi
   return res.json() as Promise<T>;
 }
 
-export async function postAction(endpoint: string) {
+export async function postAction(endpoint: string, body?: Record<string, unknown>) {
   const res = await fetch(endpoint, {
     method: "POST",
-    headers: getAuthHeaders(),
+    headers: body
+      ? { ...getAuthHeaders(), "Content-Type": "application/json" }
+      : getAuthHeaders(),
+    ...(body ? { body: JSON.stringify(body) } : {}),
   });
   const data = await res.json();
   // Derive `ok` explicitly so a JSON `ok` field in the body cannot override
@@ -89,17 +92,24 @@ export async function fetchGitBranch() {
   return data.ok ? ({ branch: data.branch, treeType: data.treeType } as GitBranch) : null;
 }
 
-export async function sendToTmux(keys: string, raw = false) {
+export async function sendToTmux(keys: string, raw = false, session?: string | null) {
   // Most callers fire-and-forget via `void sendToTmux(...)`. Swallow fetch
   // failures here so those call sites don't produce unhandled promise
   // rejections in the browser. The API itself doesn't return a useful
   // success signal — it's best-effort "type this into the tmux pane".
   // (Copilot round-2 review.)
+  // `session` targets the restricted command palette at the tmux session
+  // the terminal tab is viewing (Liam voice msg 1188); omitted/null = the
+  // server's default session, exactly the legacy behavior.
   try {
     await fetch("/api/terminal/send-keys", {
       method: "POST",
       headers: { "Content-Type": "application/json", ...getAuthHeaders() },
-      body: JSON.stringify(raw ? { keys, raw: true } : { keys }),
+      body: JSON.stringify({
+        keys,
+        ...(raw ? { raw: true } : {}),
+        ...(session ? { session } : {}),
+      }),
     });
   } catch (err) {
     // Swallowed so fire-and-forget callers don't throw unhandled rejections,
@@ -108,13 +118,14 @@ export async function sendToTmux(keys: string, raw = false) {
   }
 }
 
-export async function sendCompactCommand(message: string) {
+export async function sendCompactCommand(message: string, session?: string | null) {
   return jsonFetch<{ ok?: boolean; error?: string }>("/api/terminal/compact", {
     method: "POST",
     headers: { ...getAuthHeaders(), "Content-Type": "application/json" },
-    body: JSON.stringify({ message }),
+    body: JSON.stringify({ message, ...(session ? { session } : {}) }),
   });
 }
+
 
 export async function renameSession(name: string) {
   return jsonFetch<{ ok?: boolean; error?: string }>("/api/session/rename", {

--- a/apps/web/src/components/action-bar/types.ts
+++ b/apps/web/src/components/action-bar/types.ts
@@ -13,6 +13,16 @@ export interface ActionBarProps {
   fitResult?: { ok: boolean; message?: string; ts: number } | null;
   connected?: boolean;
   activeTab?: string;
+  /**
+   * Non-default tmux session the terminal tab is viewing (multi-session
+   * picker), or null/undefined for the default session. When set, the
+   * restricted command palette (Esc / digits / ⇧Tab / ^B, /compact,
+   * /reload-plugins) targets THIS session — Liam's "nudge a stuck lane
+   * past a menu" flow (voice msg 1188) — while default-session-only
+   * actions (restart, fit, git, /new, /resume, /branch, /rename) are
+   * hidden so they can never act on the wrong terminal.
+   */
+  terminalSession?: string | null;
   fileShowHidden?: boolean;
   setFileShowHidden?: (v: boolean) => void;
   fileSortMode?: SortMode;


### PR DESCRIPTION
## What (Liam voice 1169 / 1185 / 1188)

Open CPC → terminal tab → **switch between ALL fleet tmux sessions**, deep-link to a specific terminal, and nudge any lane past a menu. **No writable terminals anywhere** — the terminal view stays the read-only screen-scrape for every session; the only writes are the existing restricted command palette, now aimed at the session you're viewing.

## Server

- **`GET /api/terminal/sessions`** — tmux roster (`list-sessions` + `list-panes -a`, execFile argv). `_`-prefixed infra sessions hidden; default session pinned first, then most-recent activity. Standard `/api/*` Telegram auth.
- **`/ws/terminal?session=<name>`** — per-connection targeting. Client-controlled name is charset-fenced (shared `SESSION_NAME_RE`, `^[A-Za-z0-9_.-]{1,64}$` — same allowlist as the cockpit wrapper) and **existence-checked before polling**; invalid/unknown → error frame + close 4004; a lane dying mid-view → close 4010 instead of a frozen last frame. The default session keeps its legacy no-probe tolerance so `/restart-session` reconnects still ride through.
- **Restricted palette targets the viewed session** (Liam 1188): `send-keys` / `compact` / `reload-plugins` accept a validated `session` body field (400 bad name / 404 unknown). `restart-session`, `resize-terminal`, and WS `fit` stay **default-session-only by design** (orchestrator launch command; the window-size manual-latch incident) — `fit` on a view-only session returns `fit-error` and can never reach `resize-window`.
- **tmux 3.5a gotcha caught by live verification** (mocked unit tests cannot see this): pane-target commands (`send-keys`/`capture-pane`/`display-message`) reject bare `=name` with `can't find pane`; exact-match targeting needs **`=name:`**. Session-target commands (`has-session`) take `=name`. Verified live on-host both ways.

## Web

- **SessionPicker** pill strip above the terminal (alive dot, ✎ on the writable default), rendered when >1 session; roster refreshes every 30 s.
- **Deep links**: `#terminal&session=<name>` (matches the `#files&file=` convention), `replaceState`, other hash params preserved.
- ActionBar **restricted mode** on non-default sessions: Reconnect + `/commands` only; the sheet names its target (`/commands → <session>`) and hides `/new` `/resume` `/branch` `/rename` (orchestrator session-bookkeeping) plus git/restart/fit.
- Server error frames render in red in the terminal instead of a silent freeze.

## Verification

- **Tests**: server 331/331, web 267/267 (new: sessions parser/route, WS session targeting + fit gating, palette session targeting incl. 400/404 fences, ActionBar restricted mode).
- **Live E2E 10/10** against a worktree server on :39990 with genuinely signed Telegram initData: roster (8 live sessions, keepalive hidden, default pinned+writable), WS streaming of a scratch tmux session (marker visible in pane frames), unknown/invalid session close codes, unauth 401, and `send-keys` **physically arriving** in the target tmux pane (verified via capture). Scratch session + test server torn down after; prod untouched.

## Plan / policy trail

- Plan + auth addendum: [world-os#218 comment](https://github.com/claudes-world/world-os/issues/218#issuecomment-4929228894)
- Write policy: decided by Liam (voice 1188) — no writable terminals; restricted palette per selected session. This PR implements exactly that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)