### PR TITLE
feat(files): view-only roots — agent workspaces (legacy lanes) + /tmp, read/write root split

### DIFF
--- a/apps/server/src/lib/path-allowed.ts
+++ b/apps/server/src/lib/path-allowed.ts
@@ -1,4 +1,4 @@
-import { realpath } from "node:fs/promises";
+import { realpath, open, type FileHandle } from "node:fs/promises";
 import { resolve, sep } from "node:path";
 import { getTracer } from "./otel.js";
 import { SpanStatusCode } from "@opentelemetry/api";
@@ -97,6 +97,69 @@ export function __resetRealRootCacheForTests(): void {
     );
   }
   realRootCache.clear();
+}
+
+export type OpenAllowedResult =
+  | { ok: true; handle: FileHandle; realPath: string }
+  | { ok: false; reason: "not-found" | "denied" | "error" };
+
+/**
+ * Race-safe replacement for "isPathAllowed(p) then read p by name".
+ *
+ * The by-name pattern is a check-then-use TOCTOU: a path that passes the
+ * allowlist check can be swapped for a symlink before the subsequent
+ * open()/readFile()/readdir(), redirecting the read to a disallowed file.
+ * Benign while every allowed root was owned by the CPC account; a real
+ * allowlist bypass once a WORLD-WRITABLE root (/tmp) is in the read list —
+ * any local process can plant a file, let it pass the check, then swap in a
+ * symlink to e.g. ~/.ssh/id_rsa (PR #292 codex HIGH).
+ *
+ * Fix: open first (following symlinks — the "allow a symlink whose target
+ * is inside a root" semantics are preserved), then validate the OPENED
+ * inode's real path via `/proc/self/fd/<fd>`. The fd is pinned to one
+ * concrete inode, so whatever the attacker swapped, we validate the file we
+ * will actually read — never the name. Callers MUST read from the returned
+ * handle (or its `/proc/self/fd` path for readdir), never reopen by name.
+ *
+ * Linux-only by design (this is a Linux host); `/proc/self/fd` is the
+ * pinned-fd identity. On a platform without it the realpath resolves to a
+ * non-allowed path and the call fails closed.
+ */
+export async function openAllowedForRead(
+  absPath: string,
+  allowedRoots: readonly string[],
+): Promise<OpenAllowedResult> {
+  let handle: FileHandle;
+  try {
+    // "r" follows symlinks including the final component (preserving the
+    // legacy allow-symlink-into-root behavior); the post-open check below
+    // is what makes that safe.
+    handle = await open(resolve(absPath), "r");
+  } catch (err: any) {
+    return { ok: false, reason: err?.code === "ENOENT" ? "not-found" : "error" };
+  }
+  try {
+    // realpath('/proc/self/fd/N') resolves the kernel's magic symlink to the
+    // canonical path of the inode this fd holds — the authoritative identity.
+    const realPath = await realpath(`/proc/self/fd/${handle.fd}`);
+    for (const root of allowedRoots) {
+      let realRoot: string;
+      try {
+        realRoot = await getRealRoot(root);
+      } catch {
+        continue;
+      }
+      const rootWithSep = realRoot.endsWith(sep) ? realRoot : realRoot + sep;
+      if (realPath === realRoot || realPath.startsWith(rootWithSep)) {
+        return { ok: true, handle, realPath };
+      }
+    }
+    await handle.close();
+    return { ok: false, reason: "denied" };
+  } catch {
+    await handle.close();
+    return { ok: false, reason: "error" };
+  }
 }
 
 export async function isPathAllowed(

--- a/apps/server/src/lib/path-allowed.ts
+++ b/apps/server/src/lib/path-allowed.ts
@@ -35,13 +35,39 @@ const realRootCache = new Map<string, Promise<string>>();
 
 const pathTracer = getTracer('cpc-server-security');
 
-export const ALLOWED_FILE_ROOTS = [
+/**
+ * Roots CPC may WRITE into (file upload, paste, audio-generation sidecars).
+ * Deliberately narrower than the read list below: the viewer expansion for
+ * agent workspaces + /tmp (Liam voice 1238) is read-only — /tmp especially
+ * is world-writable shared space that CPC must never write into, and legacy
+ * lane workspaces are other agents' working state. This list is exactly the
+ * pre-expansion allowlist, so the write surface is unchanged.
+ */
+export const ALLOWED_WRITE_ROOTS = [
   "/home/claude/claudes-world",
   "/home/claude/code",
   "/home/claude/bin",
   "/home/claude/.claude",
   "/home/claude/claudes-world/.claude",
   "/home/claude/.world",
+] as const;
+
+/**
+ * Roots the file viewer may READ (list/read/search/download/send-to-chat).
+ * Superset of the write roots plus view-only additions:
+ *  - /home/claude/.worldos/lanes — legacy lane workspaces (current-gen lane
+ *    workspaces live under ~/.world, already covered above)
+ *  - /tmp — agents share artifacts there (tmpfs; whatever the server user
+ *    can read). Symlink escapes are neutralized by isPathAllowed's realpath
+ *    resolution: a /tmp symlink pointing outside the allowlist resolves to
+ *    its real target and is denied.
+ * Keep every entry an explicit absolute path — no globs, no env-derived
+ * wildcards; that property is what makes the traversal guard auditable.
+ */
+export const ALLOWED_FILE_ROOTS = [
+  ...ALLOWED_WRITE_ROOTS,
+  "/home/claude/.worldos/lanes",
+  "/tmp",
 ] as const;
 
 

--- a/apps/server/src/routes/__tests__/files-write-roots.test.ts
+++ b/apps/server/src/routes/__tests__/files-write-roots.test.ts
@@ -1,0 +1,143 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+/**
+ * Read-roots vs write-roots split (file-viewer expansion, Liam voice 1238):
+ * view-only roots (/tmp, legacy lane workspaces) must be listable/readable
+ * but NEVER writable — upload and paste are gated on the narrower
+ * ALLOWED_WRITE_ROOTS.
+ *
+ * Unlike file-upload.test.ts (whose mock ignores the roots argument), this
+ * suite substitutes the two root CONSTANTS with sandbox directories and
+ * leaves isPathAllowed fully real, so the routes' choice of which list to
+ * pass is exactly what's under test.
+ *
+ * Also covers the synthetic /home/claude listing: every TOP-LEVEL root
+ * (not nested inside another root) appears, including roots outside
+ * /home/claude, labeled by their real path.
+ */
+
+let sandbox: string;
+let readOnlyRoot: string; // stands in for /tmp or ~/.worldos/lanes
+let writableRoot: string; // stands in for e.g. ~/claudes-world
+let nestedRoot: string; // a root nested inside writableRoot (like claudes-world/.claude)
+
+// files.ts captures `const ALLOWED_ROOTS = ALLOWED_FILE_ROOTS` at import
+// time, before beforeAll can create the sandbox — so the mocked constants
+// must be STABLE ARRAY REFERENCES whose contents are filled in later.
+// vi.hoisted lifts them above the hoisted vi.mock factory.
+const mockRoots = vi.hoisted(() => ({
+  file: [] as string[],
+  write: [] as string[],
+}));
+
+vi.mock("../../lib/path-allowed.js", async () => {
+  const real = await vi.importActual<typeof import("../../lib/path-allowed.js")>(
+    "../../lib/path-allowed.js",
+  );
+  return {
+    ...real,
+    ALLOWED_FILE_ROOTS: mockRoots.file,
+    ALLOWED_WRITE_ROOTS: mockRoots.write,
+  };
+});
+
+const { filesRoute } = await import("../files.js");
+const { __resetRealRootCacheForTests } = await vi.importActual<
+  typeof import("../../lib/path-allowed.js")
+>("../../lib/path-allowed.js");
+
+beforeAll(() => {
+  process.env.NODE_ENV = "test";
+  sandbox = mkdtempSync(join(tmpdir(), "cpc-write-roots-"));
+  readOnlyRoot = join(sandbox, "view-only");
+  writableRoot = join(sandbox, "writable");
+  nestedRoot = join(writableRoot, "nested-root");
+  mkdirSync(readOnlyRoot, { recursive: true });
+  mkdirSync(nestedRoot, { recursive: true });
+  writeFileSync(join(readOnlyRoot, "artifact.txt"), "shared artifact");
+  mockRoots.file.push(writableRoot, nestedRoot, readOnlyRoot);
+  mockRoots.write.push(writableRoot, nestedRoot);
+  __resetRealRootCacheForTests();
+});
+
+afterAll(() => {
+  rmSync(sandbox, { recursive: true, force: true });
+  __resetRealRootCacheForTests();
+});
+
+async function get(path: string) {
+  const res = await filesRoute.request(path);
+  return { status: res.status, body: (await res.json()) as any };
+}
+
+describe("view-only roots are readable", () => {
+  it("lists a directory under a read-only root", async () => {
+    const { status, body } = await get(`/list?path=${encodeURIComponent(readOnlyRoot)}`);
+    expect(status).toBe(200);
+    expect(body.items.map((i: any) => i.name)).toContain("artifact.txt");
+  });
+
+  it("reads a file under a read-only root", async () => {
+    const { status, body } = await get(`/read?path=${encodeURIComponent(join(readOnlyRoot, "artifact.txt"))}`);
+    expect(status).toBe(200);
+    expect(body.content).toBe("shared artifact");
+  });
+});
+
+describe("view-only roots reject writes", () => {
+  it("403s an upload into a read-only root", async () => {
+    const form = new FormData();
+    form.append("file", new File(["data"], "evil.txt"));
+    form.append("dir", readOnlyRoot);
+    const res = await filesRoute.request("/upload", { method: "POST", body: form });
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as any;
+    expect(body.error).toBe("Access denied");
+  });
+
+  it("403s a paste into a read-only root", async () => {
+    const res = await filesRoute.request("/paste", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ content: "hello", filename: "note.md", dir: readOnlyRoot }),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("still accepts an upload into a writable root", async () => {
+    const form = new FormData();
+    form.append("file", new File(["data"], "ok.txt"));
+    form.append("dir", writableRoot);
+    const res = await filesRoute.request("/upload", { method: "POST", body: form });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as any;
+    expect(body.ok).toBe(true);
+  });
+
+  it("still accepts a paste into a writable root", async () => {
+    const res = await filesRoute.request("/paste", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ content: "hello", filename: "note2.md", dir: writableRoot }),
+    });
+    expect(res.status).toBe(200);
+  });
+});
+
+describe("synthetic home lists top-level roots only", () => {
+  it("includes read-only and writable top-level roots, excludes nested roots", async () => {
+    const { status, body } = await get(`/list?path=${encodeURIComponent("/home/claude")}`);
+    expect(status).toBe(200);
+    const paths = body.items.map((i: any) => i.path);
+    expect(paths).toContain(writableRoot);
+    expect(paths).toContain(readOnlyRoot);
+    // Nested inside writableRoot → reachable by browsing, not shown at top level.
+    expect(paths).not.toContain(nestedRoot);
+    // Roots outside /home/claude are labeled by their real path, not basename.
+    const readOnlyItem = body.items.find((i: any) => i.path === readOnlyRoot);
+    expect(readOnlyItem.name).toBe(readOnlyRoot);
+  });
+});

--- a/apps/server/src/routes/__tests__/files.test.ts
+++ b/apps/server/src/routes/__tests__/files.test.ts
@@ -289,18 +289,15 @@ describe("GET /read", () => {
     expect(body.error).toBe("Access denied");
   });
 
-  it("returns 500 for a non-existent file inside an allowed dir", async () => {
-    // isPathAllowed requires realpath to succeed, so a non-existent file
-    // is rejected at the isPathAllowed stage (returns false → 403).
-    // However, if the file disappears between the check and the read,
-    // the route would return 500. We test the 403 path since that's the
-    // normal flow for missing files.
+  it("returns 404 for a non-existent file inside an allowed dir", async () => {
+    // The race-safe open (openAllowedForRead) distinguishes ENOENT
+    // (not-found → 404) from an allowlist rejection (denied → 403), which
+    // is a more honest status than the old realpath-fails-so-403 behavior.
     const filePath = join(sandbox, "does-not-exist.txt");
     const res = await filesRoute.request(
       `/read?path=${encodeURIComponent(filePath)}`,
     );
-    // realpath fails for non-existent → isPathAllowed returns false → 403
-    expect(res.status).toBe(403);
+    expect(res.status).toBe(404);
   });
 
   it("returns 413 for a file larger than 1MB", async () => {

--- a/apps/server/src/routes/__tests__/files.test.ts
+++ b/apps/server/src/routes/__tests__/files.test.ts
@@ -647,7 +647,7 @@ describe("POST /paste", () => {
 // GET /list — synthetic home view (/home/claude)
 // ---------------------------------------------------------------------------
 describe("GET /list — synthetic home view", () => {
-  it("returns only allowlisted subdirs of /home/claude, never disallowed siblings", async () => {
+  it("returns only allowlisted top-level roots, never disallowed siblings", async () => {
     const res = await filesRoute.request(
       `/list?path=${encodeURIComponent("/home/claude")}`,
     );
@@ -662,25 +662,36 @@ describe("GET /list — synthetic home view", () => {
     expect(body.parent).toBeNull();
     expect(Array.isArray(body.items)).toBe(true);
 
-    // Every returned item must be a directory whose path starts with /home/claude/
+    // Every returned item must be a directory that IS an allowlisted root —
+    // the view is built purely from the allowlist (which now includes
+    // top-level roots outside /home/claude, e.g. /tmp), never from readdir.
+    const { ALLOWED_FILE_ROOTS } = await vi.importActual<
+      typeof import("../../lib/path-allowed.js")
+    >("../../lib/path-allowed.js");
     for (const item of body.items) {
       expect(item.type).toBe("dir");
-      expect(item.path.startsWith("/home/claude/")).toBe(true);
+      expect(ALLOWED_FILE_ROOTS).toContain(item.path);
     }
 
     const names = body.items.map((i) => i.name);
 
-    // Allowlisted direct children must be present
+    // Allowlisted top-level roots must be present
     expect(names).toContain("claudes-world");
     expect(names).toContain("code");
     expect(names).toContain("bin");
     expect(names).toContain(".claude");
     expect(names).toContain(".world");
+    // View-only roots (Liam voice 1238): labeled home-relative / by real path
+    expect(names).toContain(".worldos/lanes");
+    expect(names).toContain("/tmp");
 
     // Disallowed siblings must never appear
     expect(names).not.toContain(".ssh");
     expect(names).not.toContain(".secrets");
-    expect(names).not.toContain("claudes-world/.claude"); // nested root, not a direct child
+    // Nested root (claudes-world/.claude) is reachable by browsing its
+    // parent, never shown at top level.
+    const paths = body.items.map((i) => i.path);
+    expect(paths).not.toContain("/home/claude/claudes-world/.claude");
   });
 
   it("returns 403 for direct file-read on /home/claude", async () => {

--- a/apps/server/src/routes/__tests__/files.test.ts
+++ b/apps/server/src/routes/__tests__/files.test.ts
@@ -4,6 +4,7 @@ import {
   mkdtempSync,
   readFileSync,
   rmSync,
+  symlinkSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -35,6 +36,7 @@ import { __resetRealRootCacheForTests } from "../../lib/path-allowed.js";
  */
 
 let sandbox: string;
+let outsideSecret: string;
 let testAllowedRoots: string[] = [];
 
 vi.mock("../../lib/path-allowed.js", async () => {
@@ -45,6 +47,12 @@ vi.mock("../../lib/path-allowed.js", async () => {
     ...real,
     isPathAllowed: async (candidate: string, _ignoredAllowedRoots: string[]) => {
       return real.isPathAllowed(candidate, testAllowedRoots);
+    },
+    // /read, /list, /download validate via the race-safe openAllowedForRead;
+    // delegate to the real impl against the test roots so the allowlist
+    // boundary is exercised against the sandbox rather than the host.
+    openAllowedForRead: async (candidate: string, _ignoredAllowedRoots: string[]) => {
+      return real.openAllowedForRead(candidate, testAllowedRoots);
     },
   };
 });
@@ -71,10 +79,18 @@ beforeAll(() => {
   writeFileSync(join(sandbox, "data.json"), '{"key": "value"}');
   writeFileSync(join(sandbox, ".hidden-file"), "secret");
   writeFileSync(join(sandbox, "sub", "nested.md"), "# Nested\n\nContent here.");
+
+  // A secret file OUTSIDE every allowed root, with a distinctive large size,
+  // and a symlink to it planted INSIDE the listable sandbox. Models a
+  // world-writable-/tmp symlink; /list must not leak the target's size/mtime.
+  outsideSecret = mkdtempSync(join(tmpdir(), "cpc-files-outside-"));
+  writeFileSync(join(outsideSecret, "secret.bin"), "S".repeat(654321));
+  symlinkSync(join(outsideSecret, "secret.bin"), join(sandbox, "leak-link.bin"));
 });
 
 afterAll(() => {
   rmSync(sandbox, { recursive: true, force: true });
+  rmSync(outsideSecret, { recursive: true, force: true });
   __resetRealRootCacheForTests();
 });
 
@@ -117,6 +133,20 @@ describe("GET /roots", () => {
 // GET /list
 // ---------------------------------------------------------------------------
 describe("GET /list", () => {
+  it("does NOT leak an out-of-root symlink target's size/mtime (reports the link's own metadata)", async () => {
+    const res = await filesRoute.request(`/list?path=${encodeURIComponent(sandbox)}`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      items: Array<{ name: string; type: string; size: number }>;
+    };
+    const link = body.items.find((i) => i.name === "leak-link.bin");
+    expect(link).toBeDefined();
+    // The out-of-root secret is 654321 bytes. lstat must report the link's
+    // own size (small), never the followed target's — no metadata leak.
+    expect(link!.size).not.toBe(654321);
+    expect(link!.size).toBeLessThan(4096);
+  });
+
   it("lists directory contents for an allowed path", async () => {
     const res = await filesRoute.request(`/list?path=${encodeURIComponent(sandbox)}`);
     expect(res.status).toBe(200);

--- a/apps/server/src/routes/__tests__/markdown.test.ts
+++ b/apps/server/src/routes/__tests__/markdown.test.ts
@@ -15,9 +15,9 @@ import type { ChildProcess } from "node:child_process";
  *
  * Strategy:
  *   - Mock `../../db.js` to stub the prepared-statement cache layer
- *   - Mock `../../lib/path-allowed.js` to control path authorization
+ *   - Mock `../../lib/path-allowed.js` (`openAllowedForRead`) to control
+ *     path authorization AND file I/O via a fake fd handle
  *   - Mock `node:child_process` spawn to simulate the Claude CLI
- *   - Mock `node:fs/promises` readFile/stat to control file I/O
  *   - The route is a standalone Hono sub-app, tested via `app.request()`
  */
 
@@ -41,25 +41,24 @@ vi.mock("../../db.js", () => {
 });
 
 // --- path-allowed mock ---
-let pathAllowedResult = true;
+// The route now reads via openAllowedForRead (race-safe: open+validate the
+// fd, read from the handle). We mock it to return a controllable fake
+// handle whose stat/readFile drive the same states the old fs mock did.
+type OpenState = "ok" | "denied" | "not-found" | "error";
+let openState: OpenState = "ok";
+const fakeHandle = {
+  stat: vi.fn(async () => ({ isFile: () => true, size: 100 }) as any),
+  readFile: vi.fn(async () => "# Hello\n\nSome markdown content."),
+  close: vi.fn(async () => {}),
+};
 vi.mock("../../lib/path-allowed.js", () => ({
   ALLOWED_FILE_ROOTS: ["/allowed"],
-  isPathAllowed: vi.fn(async () => pathAllowedResult),
+  openAllowedForRead: vi.fn(async () =>
+    openState === "ok"
+      ? { ok: true, handle: fakeHandle, realPath: "/allowed/doc.md" }
+      : { ok: false, reason: openState },
+  ),
 }));
-
-// --- fs/promises mock ---
-const statResult = { isFile: () => true, size: 100 };
-const readFileResult = "# Hello\n\nSome markdown content.";
-vi.mock("node:fs/promises", async () => {
-  const actual = await vi.importActual<typeof import("node:fs/promises")>(
-    "node:fs/promises",
-  );
-  return {
-    ...actual,
-    stat: vi.fn(async () => statResult),
-    readFile: vi.fn(async () => readFileResult),
-  };
-});
 
 // --- child_process mock ---
 // We build a fake ChildProcess with controllable stdout/stderr/close events.
@@ -108,9 +107,6 @@ vi.mock("node:child_process", async () => {
 // ---------------------------------------------------------------------------
 const { markdownRoute } = await import("../markdown.js");
 
-// Reimport mocked fs to control per-test return values
-const fsMock = await import("node:fs/promises");
-
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -149,18 +145,15 @@ function rejectCliWith(code: number, stderr = ""): void {
 // ---------------------------------------------------------------------------
 
 beforeEach(() => {
-  pathAllowedResult = true;
+  openState = "ok";
   selectCacheGet.mockReturnValue(null);
   insertCacheRun.mockClear();
   spawnSpy.mockClear();
 
-  // Reset fs mocks to defaults
-  vi.mocked(fsMock.stat).mockResolvedValue(
-    { isFile: () => true, size: 100 } as any,
-  );
-  vi.mocked(fsMock.readFile).mockResolvedValue(
-    "# Hello\n\nSome markdown content.",
-  );
+  // Reset the fake handle to defaults (readable 100-byte .md file)
+  fakeHandle.stat.mockResolvedValue({ isFile: () => true, size: 100 } as any);
+  fakeHandle.readFile.mockResolvedValue("# Hello\n\nSome markdown content.");
+  fakeHandle.close.mockResolvedValue(undefined);
 });
 
 afterEach(() => {
@@ -216,7 +209,7 @@ describe("POST /summarize — input validation", () => {
 
 describe("POST /summarize — path security", () => {
   it("returns 403 for a disallowed path", async () => {
-    pathAllowedResult = false;
+    openState = "denied";
     const res = await postSummarize({ path: "/secret/private.md" });
     expect(res.status).toBe(403);
     const body = (await res.json()) as { ok: boolean; error: string };
@@ -226,7 +219,7 @@ describe("POST /summarize — path security", () => {
 
 describe("POST /summarize — file validation", () => {
   it("returns 404 when file does not exist", async () => {
-    vi.mocked(fsMock.stat).mockRejectedValueOnce(new Error("ENOENT"));
+    openState = "not-found";
     const res = await postSummarize({ path: "/allowed/missing.md" });
     expect(res.status).toBe(404);
     const body = (await res.json()) as { ok: boolean; error: string };
@@ -234,7 +227,7 @@ describe("POST /summarize — file validation", () => {
   });
 
   it("returns 400 when path is a directory, not a file", async () => {
-    vi.mocked(fsMock.stat).mockResolvedValueOnce({
+    fakeHandle.stat.mockResolvedValueOnce({
       isFile: () => false,
       size: 0,
     } as any);
@@ -245,7 +238,7 @@ describe("POST /summarize — file validation", () => {
   });
 
   it("returns 413 when file exceeds max size", async () => {
-    vi.mocked(fsMock.stat).mockResolvedValueOnce({
+    fakeHandle.stat.mockResolvedValueOnce({
       isFile: () => true,
       size: 1_000_000,
     } as any);
@@ -256,15 +249,15 @@ describe("POST /summarize — file validation", () => {
   });
 
   it("returns 400 when file is empty", async () => {
-    vi.mocked(fsMock.readFile).mockResolvedValueOnce("   \n  \n  ");
+    fakeHandle.readFile.mockResolvedValueOnce("   \n  \n  ");
     const res = await postSummarize({ path: "/allowed/empty.md" });
     expect(res.status).toBe(400);
     const body = (await res.json()) as { ok: boolean; error: string };
     expect(body.error).toBe("File is empty");
   });
 
-  it("returns 500 when readFile fails", async () => {
-    vi.mocked(fsMock.readFile).mockRejectedValueOnce(new Error("EACCES"));
+  it("returns 500 when read fails", async () => {
+    fakeHandle.readFile.mockRejectedValueOnce(new Error("EACCES"));
     const res = await postSummarize({ path: "/allowed/unreadable.md" });
     expect(res.status).toBe(500);
     const body = (await res.json()) as { ok: boolean; error: string };
@@ -293,7 +286,7 @@ describe("POST /summarize — cache behavior", () => {
     // Don't mock selectCacheGet here — force=true skips the cache lookup
     // entirely, so a mockReturnValueOnce would never be consumed and would
     // leak into the next test.
-    vi.mocked(fsMock.readFile).mockResolvedValueOnce(
+    fakeHandle.readFile.mockResolvedValueOnce(
       "# Force-refresh unique content\n\nBody.",
     );
     const res = postSummarize({ path: "/allowed/doc.md", force: true });
@@ -319,7 +312,7 @@ describe("POST /summarize — CLI happy path", () => {
   it("returns summary from CLI and writes to cache", async () => {
     // Use unique content so the in-flight deduplication map key differs
     // from other tests (keyed by content hash + prompt version + model).
-    vi.mocked(fsMock.readFile).mockResolvedValueOnce(
+    fakeHandle.readFile.mockResolvedValueOnce(
       "# Unique content for cache-write test\n\nBody text.",
     );
     const res = postSummarize({ path: "/allowed/doc.md" });

--- a/apps/server/src/routes/__tests__/path-allowed.test.ts
+++ b/apps/server/src/routes/__tests__/path-allowed.test.ts
@@ -4,6 +4,7 @@ import {
   mkdtempSync,
   rmSync,
   symlinkSync,
+  unlinkSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -11,6 +12,7 @@ import { join, parse } from "node:path";
 import {
   __resetRealRootCacheForTests,
   isPathAllowed,
+  openAllowedForRead,
 } from "../../lib/path-allowed.js";
 
 /**
@@ -195,6 +197,67 @@ describe("isPathAllowed", () => {
     expect(
       await isPathAllowed(join(allowedRoot, "escape-link", "loot.txt"), [allowedRoot]),
     ).toBe(false);
+  });
+
+  describe("openAllowedForRead (race-safe open+validate)", () => {
+    it("opens a real file inside an allowed root and reports its real path", async () => {
+      const r = await openAllowedForRead(join(allowedRoot, "ok.txt"), [allowedRoot]);
+      expect(r.ok).toBe(true);
+      if (r.ok) {
+        expect(r.realPath).toBe(join(allowedRoot, "ok.txt"));
+        expect((await r.handle.readFile()).toString()).toBe("ok");
+        await r.handle.close();
+      }
+    });
+
+    it("follows a symlink whose target is INSIDE an allowed root (legacy semantics preserved)", async () => {
+      const linkInside = join(allowedRoot, "inside-link.txt");
+      symlinkSync(join(allowedRoot, "ok.txt"), linkInside, symlinkType);
+      try {
+        const r = await openAllowedForRead(linkInside, [allowedRoot]);
+        expect(r.ok).toBe(true);
+        if (r.ok) await r.handle.close();
+      } finally {
+        unlinkSync(linkInside);
+      }
+    });
+
+    it("denies (and closes) a symlink whose target is OUTSIDE all roots", async () => {
+      // The fd is opened (following the link) but validated against the
+      // OPENED inode's real path — /proc/self/fd — so the escape is caught
+      // even though open() itself succeeded.
+      const r = await openAllowedForRead(join(allowedRoot, "escape-link", "loot.txt"), [allowedRoot]);
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.reason).toBe("denied");
+    });
+
+    it("closes the race: a file swapped for an out-of-root symlink after a name check is still rejected", async () => {
+      // Model the TOCTOU: a path that WOULD pass a by-name check is swapped
+      // for an escape symlink before the read. openAllowedForRead validates
+      // the opened fd's identity, so it can only ever return ok for the file
+      // it actually holds — never the swapped-in secret.
+      const racy = join(allowedRoot, "racy.txt");
+      // State A: legit file → allowed.
+      writeFileSync(racy, "legit");
+      const a = await openAllowedForRead(racy, [allowedRoot]);
+      expect(a.ok).toBe(true);
+      if (a.ok) {
+        expect((await a.handle.readFile()).toString()).toBe("legit");
+        await a.handle.close();
+      }
+      // State B: swapped to a symlink pointing outside → denied, no leak.
+      unlinkSync(racy);
+      symlinkSync(join(outsideDir, "loot.txt"), racy, symlinkType);
+      const b = await openAllowedForRead(racy, [allowedRoot]);
+      expect(b.ok).toBe(false);
+      unlinkSync(racy);
+    });
+
+    it("reports not-found for a missing file (distinct from denied)", async () => {
+      const r = await openAllowedForRead(join(allowedRoot, "nope.txt"), [allowedRoot]);
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.reason).toBe("not-found");
+    });
   });
 
   it("memoizes realpath(root) via an on-disk swap of the root target", async () => {

--- a/apps/server/src/routes/__tests__/path-allowed.test.ts
+++ b/apps/server/src/routes/__tests__/path-allowed.test.ts
@@ -167,6 +167,36 @@ describe("isPathAllowed", () => {
     ).toBe(true);
   });
 
+  it("read roots include the view-only additions; write roots do not (Liam voice 1238)", async () => {
+    const { ALLOWED_FILE_ROOTS, ALLOWED_WRITE_ROOTS } = await import(
+      "../../lib/path-allowed.js"
+    );
+    // View-only roots readable…
+    expect(ALLOWED_FILE_ROOTS).toContain("/tmp");
+    expect(ALLOWED_FILE_ROOTS).toContain("/home/claude/.worldos/lanes");
+    // …but never writable.
+    expect(ALLOWED_WRITE_ROOTS).not.toContain("/tmp");
+    expect(ALLOWED_WRITE_ROOTS).not.toContain("/home/claude/.worldos/lanes");
+    // Write roots are a strict subset of read roots (every writable place
+    // is also viewable), and the write list is exactly the pre-expansion
+    // allowlist so the write surface never widened.
+    for (const root of ALLOWED_WRITE_ROOTS) {
+      expect(ALLOWED_FILE_ROOTS).toContain(root);
+    }
+    expect(ALLOWED_WRITE_ROOTS.length).toBeLessThan(ALLOWED_FILE_ROOTS.length);
+  });
+
+  it("denies a /tmp-style symlink that points outside every allowed root", async () => {
+    // /tmp is world-writable: any local process can plant a symlink there.
+    // The escape-link fixture models exactly that — a link inside an
+    // allowed root targeting a directory outside all roots. realpath
+    // resolution must reject both the link and anything beneath it.
+    expect(await isPathAllowed(join(allowedRoot, "escape-link"), [allowedRoot])).toBe(false);
+    expect(
+      await isPathAllowed(join(allowedRoot, "escape-link", "loot.txt"), [allowedRoot]),
+    ).toBe(false);
+  });
+
   it("memoizes realpath(root) via an on-disk swap of the root target", async () => {
     // Spying on `realpath` in ESM is blocked by vitest (module namespace
     // is not configurable), so we verify memoization by observing a behavior

--- a/apps/server/src/routes/__tests__/search-scope.test.ts
+++ b/apps/server/src/routes/__tests__/search-scope.test.ts
@@ -48,6 +48,12 @@ vi.mock("../../lib/path-allowed.js", async () => {
     isPathAllowed: async (candidate: string, _ignoredAllowedRoots: string[]) => {
       return real.isPathAllowed(candidate, testAllowedRoots);
     },
+    // /search now validates the scope + every walked dir via the race-safe
+    // openAllowedForRead; delegate to the real impl against the test roots so
+    // the same security semantics are exercised against the sandbox.
+    openAllowedForRead: async (candidate: string, _ignoredAllowedRoots: string[]) => {
+      return real.openAllowedForRead(candidate, testAllowedRoots);
+    },
   };
 });
 
@@ -156,13 +162,12 @@ describe("/search?scope= (Search UX C3)", () => {
     expect(body.error).toBe("Access denied");
   });
 
-  it("rejects a non-existent scope under an allowed root with 403 (realpath fails)", async () => {
-    // isPathAllowed canonicalizes the candidate via realpath; a non-existent
-    // path resolves to false, which the route translates into 403. This
-    // documents the current behavior so a future "create-on-demand" change
-    // has to update the assertion deliberately.
+  it("returns 404 for a non-existent scope under an allowed root", async () => {
+    // The race-safe openAllowedForRead distinguishes a missing scope
+    // (open ENOENT → not-found → 404) from an allowlist rejection (403) —
+    // a more honest status than the old realpath-fails-so-403 behavior.
     const { status } = await callSearch(TOKEN, join(sandbox, "does-not-exist"));
-    expect(status).toBe(403);
+    expect(status).toBe(404);
   });
 
   it("returns an empty results array when q is shorter than 2 chars (unchanged minimum-length guard)", async () => {

--- a/apps/server/src/routes/audio.ts
+++ b/apps/server/src/routes/audio.ts
@@ -5,7 +5,7 @@ import { promisify } from "node:util";
 import { resolve } from "node:path";
 import { loadOpenAIEnv, getTelegramCreds } from "./utils.js";
 import {
-  ALLOWED_FILE_ROOTS,
+  ALLOWED_WRITE_ROOTS,
   isPathAllowed as isPathAllowedShared,
 } from "../lib/path-allowed.js";
 import { getTracer } from "../lib/otel.js";
@@ -16,8 +16,14 @@ const execFileAsync = promisify(execFile);
 // Load OpenAI env on module init
 loadOpenAIEnv();
 
+// Audio generation WRITES an .mp3 sidecar next to the source markdown, so
+// this whole route is scoped to the WRITE roots — the view-only file roots
+// (/tmp, legacy lane workspaces) must never gain a disk-write path. Using
+// write roots for /check too keeps the feature's surface consistent: audio
+// exists only where audio can be generated (exactly the pre-expansion
+// behavior).
 function isPathAllowed(absPath: string): Promise<boolean> {
-  return isPathAllowedShared(absPath, ALLOWED_FILE_ROOTS);
+  return isPathAllowedShared(absPath, ALLOWED_WRITE_ROOTS);
 }
 
 const audioTracer = getTracer('cpc-server-audio');

--- a/apps/server/src/routes/files.ts
+++ b/apps/server/src/routes/files.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 import { bodyLimit } from "hono/body-limit";
 import { randomBytes } from "node:crypto";
 import {
+  lstat,
   open,
   readdir,
   stat,
@@ -245,7 +246,15 @@ app.get("/list", async (c) => {
         .map(async (e) => {
           const fullPath = join(resolved, e.name);
           try {
-            const st = await stat(join(fdDir, e.name));
+            // lstat, NOT stat: for a symlink entry, report the LINK's own
+            // metadata, never the followed target's. A bare stat() follows
+            // the symlink with no allowlist check on where it lands, leaking
+            // byte-exact size + mtime + existence of arbitrary out-of-root
+            // files a planted /tmp symlink points at (gemini MEDIUM). `type`
+            // already uses the non-following Dirent, so this just aligns
+            // size/modified with the same don't-follow rule. Clicking an
+            // entry re-runs /read, which resolves+validates via fd.
+            const st = await lstat(join(fdDir, e.name));
             return {
               name: e.name,
               path: fullPath,

--- a/apps/server/src/routes/files.ts
+++ b/apps/server/src/routes/files.ts
@@ -14,6 +14,7 @@ import { constants as fsConstants } from "node:fs";
 import { Readable } from "node:stream";
 import {
   ALLOWED_FILE_ROOTS,
+  ALLOWED_WRITE_ROOTS,
   isPathAllowed as isPathAllowedShared,
 } from "../lib/path-allowed.js";
 
@@ -39,6 +40,12 @@ const ALLOWED_ROOTS = ALLOWED_FILE_ROOTS;
 
 function isPathAllowed(absPath: string): Promise<boolean> {
   return isPathAllowedShared(absPath, ALLOWED_ROOTS);
+}
+
+/** Write-endpoint gate (upload/paste): the narrower ALLOWED_WRITE_ROOTS —
+ *  the view-only roots (/tmp, legacy lane workspaces) must stay read-only. */
+function isWritePathAllowed(absPath: string): Promise<boolean> {
+  return isPathAllowedShared(absPath, ALLOWED_WRITE_ROOTS);
 }
 
 function pruneExpiredDownloadTickets(now = Date.now()) {
@@ -140,17 +147,25 @@ app.get("/list", async (c) => {
   const dir = c.req.query("path") || BASE_DIR;
   const resolved = resolve(dir);
 
-  // Synthetic home view: construct listing from allowlist, never readdir /home/claude.
+  // Synthetic home view: construct listing from allowlist, never readdir
+  // /home/claude. Shows every TOP-LEVEL allowed root — one that isn't nested
+  // inside another allowed root (nested ones, e.g. claudes-world/.claude,
+  // are reachable by browsing their parent). Roots outside /home/claude
+  // (/tmp, ~/.worldos/lanes) appear here too, labeled by their real path,
+  // so view-only roots are reachable without memorizing paths. Still built
+  // purely from the allowlist, so disallowed siblings can never appear.
   if (resolved === HOME_CLAUDE) {
-    const items = ALLOWED_ROOTS
-      .map((r) => resolve(r))
-      .filter((r) => {
-        // Only include roots whose immediate parent is /home/claude
-        const parentDir = resolve(r, "..");
-        return parentDir === HOME_CLAUDE;
-      })
+    const resolvedRoots = ALLOWED_ROOTS.map((r) => resolve(r));
+    const items = resolvedRoots
+      .filter((r) =>
+        !resolvedRoots.some((other) => other !== r && r.startsWith(other + sep)),
+      )
       .map((r) => ({
-        name: basename(r),
+        name: resolve(r, "..") === HOME_CLAUDE
+          ? basename(r)
+          : r.startsWith(HOME_CLAUDE + sep)
+            ? r.slice(HOME_CLAUDE.length + 1)
+            : r,
         path: r,
         type: "dir" as const,
       }));
@@ -459,7 +474,7 @@ app.post(
   }
 
   const resolved = resolve(dir);
-  if (!await isPathAllowed(resolved)) {
+  if (!await isWritePathAllowed(resolved)) {
     return c.json({ error: "Access denied" }, 403);
   }
 
@@ -633,7 +648,7 @@ app.post(
   }
 
   const resolved = resolve(dir);
-  if (!(await isPathAllowed(resolved))) {
+  if (!(await isWritePathAllowed(resolved))) {
     return c.json({ error: "Access denied" }, 403);
   }
 

--- a/apps/server/src/routes/files.ts
+++ b/apps/server/src/routes/files.ts
@@ -55,6 +55,25 @@ function openAllowedForRead(absPath: string) {
   return openAllowedForReadShared(absPath, ALLOWED_ROOTS);
 }
 
+/**
+ * Race-safe directory listing: open+validate the dir's fd identity, then
+ * readdir THROUGH the pinned fd. Returns null if the dir isn't within an
+ * allowed root or can't be read. Used by /search's BFS so a symlink swapped
+ * onto any walked directory (including a client `?scope=` over world-writable
+ * /tmp) can't redirect the listing outside the allowlist.
+ */
+async function readdirAllowedEntries(dir: string) {
+  const opened = await openAllowedForRead(dir);
+  if (!opened.ok) return null;
+  try {
+    return await readdir(`/proc/self/fd/${opened.handle.fd}`, { withFileTypes: true });
+  } catch {
+    return null;
+  } finally {
+    await opened.handle.close();
+  }
+}
+
 function pruneExpiredDownloadTickets(now = Date.now()) {
   for (const [ticket, record] of downloadTickets) {
     if (record.expiresAt <= now) {
@@ -433,16 +452,30 @@ app.get("/search", async (c) => {
 
   const scopeRaw = c.req.query("scope");
   let roots: readonly string[] = ALLOWED_ROOTS;
+  // Canonical scope path (from the validated fd) used for both BFS seeding
+  // and the scope-prefix filter, so a `?scope=` symlink can't skew either.
+  let scopeMatchRoot: string | null = null;
   if (scopeRaw) {
-    const scopeResolved = resolve(scopeRaw);
-    // Reject scopes that aren't inside an allowed root. Same check as every
-    // other file route — realpath-canonicalizing both sides and enforcing a
-    // true path-segment boundary — so a symlink escape or sibling-prefix
-    // bypass can't smuggle an out-of-tree path in via `?scope=`.
-    if (!(await isPathAllowed(scopeResolved))) {
-      return c.json({ error: "Access denied" }, 403);
+    // Race-safe: validate the scope by opening it and checking the OPENED
+    // fd's real identity (not the name), so a symlink escape or a mid-request
+    // swap over world-writable /tmp can't smuggle an out-of-tree path in.
+    const opened = await openAllowedForRead(resolve(scopeRaw));
+    if (!opened.ok) {
+      return c.json(
+        { error: opened.reason === "not-found" ? "Not found" : "Access denied" },
+        opened.reason === "not-found" ? 404 : 403,
+      );
     }
-    roots = [scopeResolved];
+    try {
+      const st = await opened.handle.stat();
+      if (!st.isDirectory()) {
+        return c.json({ error: "Scope is not a directory" }, 400);
+      }
+      scopeMatchRoot = opened.realPath;
+    } finally {
+      await opened.handle.close();
+    }
+    roots = [scopeMatchRoot];
   }
 
   const results: { name: string; path: string; type: string; relPath: string }[] = [];
@@ -454,7 +487,6 @@ app.get("/search", async (c) => {
   // Pre-compute the scope prefix (with trailing separator so we get a true
   // path-segment boundary and `/a/b-evil` can't match scope `/a/b`). The
   // scope itself is also a valid match, so we check for equality separately.
-  const scopeMatchRoot = scopeRaw ? resolve(scopeRaw) : null;
   const scopeMatchPrefix = scopeMatchRoot
     ? (scopeMatchRoot.endsWith(sep) ? scopeMatchRoot : scopeMatchRoot + sep)
     : null;
@@ -463,7 +495,10 @@ app.get("/search", async (c) => {
     const [dir, depth] = queue.shift()!;
     if (depth > 8) continue;
     try {
-      const entries = await readdir(dir, { withFileTypes: true });
+      // Validate + list every walked dir by its fd identity (race-safe),
+      // never a bare readdir(dir) that a symlink swap could redirect.
+      const entries = await readdirAllowedEntries(dir);
+      if (!entries) continue;
       for (const e of entries) {
         if (results.length >= MAX) break;
         if (e.name.startsWith(".") && !e.name.startsWith(".claude")) continue;

--- a/apps/server/src/routes/files.ts
+++ b/apps/server/src/routes/files.ts
@@ -4,7 +4,6 @@ import { randomBytes } from "node:crypto";
 import {
   open,
   readdir,
-  readFile,
   stat,
   unlink,
 } from "node:fs/promises";
@@ -16,6 +15,7 @@ import {
   ALLOWED_FILE_ROOTS,
   ALLOWED_WRITE_ROOTS,
   isPathAllowed as isPathAllowedShared,
+  openAllowedForRead as openAllowedForReadShared,
 } from "../lib/path-allowed.js";
 
 const app = new Hono();
@@ -48,6 +48,13 @@ function isWritePathAllowed(absPath: string): Promise<boolean> {
   return isPathAllowedShared(absPath, ALLOWED_WRITE_ROOTS);
 }
 
+/** Race-safe open+validate against the read roots (see path-allowed.ts).
+ *  Use for every content read of a client-supplied path now that a
+ *  world-writable root (/tmp) is in the allowlist. */
+function openAllowedForRead(absPath: string) {
+  return openAllowedForReadShared(absPath, ALLOWED_ROOTS);
+}
+
 function pruneExpiredDownloadTickets(now = Date.now()) {
   for (const [ticket, record] of downloadTickets) {
     if (record.expiresAt <= now) {
@@ -57,43 +64,54 @@ function pruneExpiredDownloadTickets(now = Date.now()) {
 }
 
 async function getDownloadableFile(filePath: string): Promise<
-  | { ok: true; path: string; size: number; name: string }
+  | { ok: true; handle: import("node:fs/promises").FileHandle; path: string; size: number; name: string }
   | { ok: false; status: 400 | 403 | 404 | 413 | 500; error: string }
 > {
   const resolved = resolve(filePath);
-  if (!await isPathAllowed(resolved)) {
+  // Race-safe: open+validate the fd, then stream from THAT fd (never reopen
+  // by name) so a symlink swapped in after the check can't redirect the
+  // download to a disallowed file. Callers either stream from the handle
+  // (createDownloadResponse) or close it immediately if they only needed the
+  // validation (the ticket POST).
+  const opened = await openAllowedForRead(resolved);
+  if (!opened.ok) {
+    if (opened.reason === "not-found") return { ok: false, status: 404, error: "File not found" };
     return { ok: false, status: 403, error: "Access denied" };
   }
+  const { handle } = opened;
 
   try {
-    const st = await stat(resolved);
+    const st = await handle.stat();
     if (!st.isFile()) {
+      await handle.close();
       return { ok: false, status: 400, error: "Not a file" };
     }
-
     if (st.size > DOWNLOAD_MAX_BYTES) {
+      await handle.close();
       return { ok: false, status: 413, error: `File too large (max ${DOWNLOAD_MAX_BYTES / (1024 * 1024)}MB)` };
     }
-
     return {
       ok: true,
+      handle,
       path: resolved,
       size: st.size,
       name: basename(resolved) || "file",
     };
   } catch (err: any) {
-    if (err?.code === "ENOENT") {
-      return { ok: false, status: 404, error: "File not found" };
-    }
+    await handle.close();
     console.error("[files/download] stat error:", err);
     return { ok: false, status: 500, error: "Failed to read file" };
   }
 }
 
-function createDownloadResponse(file: { path: string; size: number; name: string }) {
+function createDownloadResponse(file: { handle: import("node:fs/promises").FileHandle; size: number; name: string }) {
   const encodedName = encodeURIComponent(file.name);
   const safeName = file.name.replace(/["\r\n]/g, "") || "file";
-  const body = Readable.toWeb(createReadStream(file.path)) as unknown as BodyInit;
+  // Stream from the validated fd (createReadStream adopts and closes it on
+  // end/error via autoClose) — no by-name reopen.
+  const body = Readable.toWeb(
+    createReadStream("", { fd: file.handle.fd, autoClose: true }),
+  ) as unknown as BodyInit;
 
   return new Response(body, {
     status: 200,
@@ -177,12 +195,26 @@ app.get("/list", async (c) => {
     });
   }
 
-  if (!await isPathAllowed(resolved)) {
+  // Race-safe: open the directory, validate the opened fd's real identity,
+  // then readdir THROUGH the pinned fd (its /proc/self/fd path) so a symlink
+  // swapped in after the check can't redirect the listing to, say, ~/.ssh.
+  const openedDir = await openAllowedForRead(resolved);
+  if (!openedDir.ok) {
+    if (openedDir.reason === "not-found") return c.json({ error: "Not found" }, 404);
     return c.json({ error: "Access denied" }, 403);
   }
+  const dirHandle = openedDir.handle;
+  // Entry paths are reported to the client as `resolved/<name>` (a clicked
+  // entry re-runs the full open-and-validate on /read), but every disk touch
+  // here goes through the pinned fd dir so the listing itself is race-safe.
+  const fdDir = `/proc/self/fd/${dirHandle.fd}`;
 
   try {
-    const entries = await readdir(resolved, { withFileTypes: true });
+    const dstat = await dirHandle.stat();
+    if (!dstat.isDirectory()) {
+      return c.json({ error: "Not a directory" }, 400);
+    }
+    const entries = await readdir(fdDir, { withFileTypes: true });
     const items = await Promise.all(
       entries
         .filter((e) => {
@@ -194,7 +226,7 @@ app.get("/list", async (c) => {
         .map(async (e) => {
           const fullPath = join(resolved, e.name);
           try {
-            const st = await stat(fullPath);
+            const st = await stat(join(fdDir, e.name));
             return {
               name: e.name,
               path: fullPath,
@@ -236,6 +268,8 @@ app.get("/list", async (c) => {
     });
   } catch (err: any) {
     return c.json({ error: err.message }, 500);
+  } finally {
+    await dirHandle.close();
   }
 });
 
@@ -251,12 +285,22 @@ app.get("/read", async (c) => {
   if (resolved === HOME_CLAUDE) {
     return c.json({ error: "Access denied" }, 403);
   }
-  if (!await isPathAllowed(resolved)) {
+
+  // Race-safe: open first, then validate the opened fd's real identity. All
+  // reads below go through the handle (never re-open `resolved` by name), so
+  // a symlink swapped in after the check can't redirect the read.
+  const opened = await openAllowedForRead(resolved);
+  if (!opened.ok) {
+    if (opened.reason === "not-found") return c.json({ error: "File not found" }, 404);
     return c.json({ error: "Access denied" }, 403);
   }
+  const { handle } = opened;
 
   try {
-    const st = await stat(resolved);
+    const st = await handle.stat();
+    if (st.isDirectory()) {
+      return c.json({ error: "Not a file" }, 400);
+    }
 
     // Don't read files larger than 1MB
     if (st.size > 1024 * 1024) {
@@ -279,32 +323,24 @@ app.get("/read", async (c) => {
         (n) => baseName.startsWith(n),
       );
 
+    const content = await handle.readFile();
     if (!isText && st.size > 0) {
-      // Try reading first 512 bytes to check for binary
-      const content = await readFile(resolved);
-      const sample = content.subarray(0, 512);
-      if (sample.includes(0)) {
+      // Binary sniff on the first 512 bytes of what we actually read.
+      if (content.subarray(0, 512).includes(0)) {
         return c.json({ error: "Binary file" }, 415);
       }
-      return c.json({
-        path: resolved,
-        name: baseName,
-        content: content.toString("utf-8"),
-        size: st.size,
-        modified: st.mtime.toISOString(),
-      });
     }
-
-    const content = await readFile(resolved, "utf-8");
     return c.json({
       path: resolved,
       name: baseName,
-      content,
+      content: content.toString("utf-8"),
       size: st.size,
       modified: st.mtime.toISOString(),
     });
   } catch (err: any) {
     return c.json({ error: err.message }, 500);
+  } finally {
+    await handle.close();
   }
 });
 
@@ -327,6 +363,10 @@ app.post("/download-ticket", async (c) => {
   if (!file.ok) {
     return c.json({ error: file.error }, file.status);
   }
+  // The ticket POST only validates downloadability; the actual GET re-opens
+  // and re-validates via fd, so release this handle now (don't leak it for
+  // the whole ticket TTL).
+  await file.handle.close();
 
   const ticket = randomBytes(16).toString("hex");
   downloadTickets.set(ticket, {

--- a/apps/server/src/routes/markdown.ts
+++ b/apps/server/src/routes/markdown.ts
@@ -1,19 +1,21 @@
 import { Hono } from "hono";
 import { bodyLimit } from "hono/body-limit";
-import { readFile, stat } from "node:fs/promises";
 import { resolve } from "node:path";
 import { createHash, randomBytes } from "node:crypto";
 import { spawn } from "node:child_process";
 import { db } from "../db.js";
 import {
   ALLOWED_FILE_ROOTS,
-  isPathAllowed as isPathAllowedShared,
+  openAllowedForRead as openAllowedForReadShared,
 } from "../lib/path-allowed.js";
 
 const app = new Hono();
 
-function isPathAllowed(absPath: string): Promise<boolean> {
-  return isPathAllowedShared(absPath, ALLOWED_FILE_ROOTS);
+/** Race-safe open+validate against the read roots (see path-allowed.ts) —
+ *  /tmp is world-writable, so a check-then-readFile-by-name would be a
+ *  TOCTOU. Read from the returned handle, never reopen by name. */
+function openAllowedForRead(absPath: string) {
+  return openAllowedForReadShared(absPath, ALLOWED_FILE_ROOTS);
 }
 
 // Env vars are read LAZILY (via getters) instead of snapshotted at module
@@ -331,44 +333,47 @@ app.post(
   const forceRefresh = body.force === true;
 
   const resolved = resolve(rawPath);
-  if (!(await isPathAllowed(resolved))) {
-    return c.json({ ok: false, error: "Access denied" }, 403);
-  }
   if (!resolved.toLowerCase().endsWith(".md")) {
     return c.json({ ok: false, error: "Only .md files are supported" }, 400);
   }
 
-  let st;
-  try {
-    st = await stat(resolved);
-  } catch {
-    return c.json({ ok: false, error: "File not found" }, 404);
+  // Race-safe: open+validate the fd, then read from the handle (never reopen
+  // `resolved` by name) so a /tmp symlink swap can't redirect the read.
+  const opened = await openAllowedForRead(resolved);
+  if (!opened.ok) {
+    if (opened.reason === "not-found") return c.json({ ok: false, error: "File not found" }, 404);
+    return c.json({ ok: false, error: "Access denied" }, 403);
   }
-  if (!st.isFile()) {
-    return c.json({ ok: false, error: "Not a file" }, 400);
-  }
+  const handle = opened.handle;
+
   // Read env values lazily (after loadEnv has run) — see getter definitions.
   const maxBytes = getMaxBytes();
   const model = getModel();
   const promptVersion = getPromptVersion();
-  if (st.size > maxBytes) {
-    return c.json(
-      { ok: false, error: `File too large for TL;DR (max ${Math.round(maxBytes / 1024)}KB)` },
-      413,
-    );
-  }
 
   let content: string;
   try {
-    content = await readFile(resolved, "utf-8");
+    const st = await handle.stat();
+    if (!st.isFile()) {
+      return c.json({ ok: false, error: "Not a file" }, 400);
+    }
+    if (st.size > maxBytes) {
+      return c.json(
+        { ok: false, error: `File too large for TL;DR (max ${Math.round(maxBytes / 1024)}KB)` },
+        413,
+      );
+    }
+    content = await handle.readFile("utf-8");
   } catch (err: any) {
     // Don't echo raw fs error message — can include absolute paths and
     // errno codes. Log server-side, return generic. (Copilot review.)
     console.error(
-      `[markdown/summarize] readFile(${resolved}) failed:`,
+      `[markdown/summarize] read(${resolved}) failed:`,
       err?.message,
     );
     return c.json({ ok: false, error: "Failed to read file" }, 500);
+  } finally {
+    await handle.close();
   }
   if (!content.trim()) {
     return c.json({ ok: false, error: "File is empty" }, 400);

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -572,9 +572,12 @@ export function FileViewer({ onClose, initialFile, showHidden = false, sortMode 
             { label: "code", path: "/home/claude/code" },
             { label: "bin", path: "/home/claude/bin" },
             { label: "\ud83c\udf10 .claude", path: "/home/claude/claudes-world/.claude" },
-            // View-only roots (Liam voice 1238): agent workspaces + shared /tmp.
-            // Current-gen lane workspaces live under .world/groups/<group>/<lane>/workspace.
+            // .world holds current-gen lane workspaces
+            // (.world/groups/<group>/<lane>/workspace) \u2014 a pre-existing root,
+            // surfaced here as a chip for the first time.
             { label: "\ud83d\uddc2 .world", path: "/home/claude/.world" },
+            // View-only roots added in Liam voice 1238: legacy lane
+            // workspaces + shared /tmp.
             { label: "lanes", path: "/home/claude/.worldos/lanes" },
             { label: "/tmp", path: "/tmp" },
           ].map((root) => (

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -572,6 +572,11 @@ export function FileViewer({ onClose, initialFile, showHidden = false, sortMode 
             { label: "code", path: "/home/claude/code" },
             { label: "bin", path: "/home/claude/bin" },
             { label: "\ud83c\udf10 .claude", path: "/home/claude/claudes-world/.claude" },
+            // View-only roots (Liam voice 1238): agent workspaces + shared /tmp.
+            // Current-gen lane workspaces live under .world/groups/<group>/<lane>/workspace.
+            { label: "\ud83d\uddc2 .world", path: "/home/claude/.world" },
+            { label: "lanes", path: "/home/claude/.worldos/lanes" },
+            { label: "/tmp", path: "/tmp" },
           ].map((root) => (
             <button
               key={root.path}


### PR DESCRIPTION
## What (Liam voice 1238)

Browse **agent workspaces** and **/tmp** from the CPC file viewer — strictly read-only, explicit allowlist only.

## Design

**Read/write root split.** `ALLOWED_WRITE_ROOTS` = exactly the pre-expansion allowlist (upload, paste, and audio-generation sidecars keep today's write surface, unchanged). `ALLOWED_FILE_ROOTS` = write roots **plus** two view-only additions:

- `/home/claude/.worldos/lanes` — legacy lane workspaces. (Current-gen lane workspaces under `~/.world/groups/*/*/workspace` were **already covered** by the existing `/home/claude/.world` root — no change needed there.)
- `/tmp` — shared artifact space (tmpfs; whatever the server user can read).

Every entry stays an explicit absolute path — no globs, no env-derived wildcards.

**Threat model for /tmp** (world-writable — any local process can plant symlinks): `isPathAllowed` realpaths every candidate, so a `/tmp` symlink pointing outside the allowlist resolves to its true target and is denied. Regression-tested with a real symlink fixture, and live-verified with an actual `/tmp → ~/.ssh` link (denied on list and read-through).

**Write endpoints** (`/upload`, `/paste`) gate on the write roots — a 403 for any view-only root. **Audio** (writes `.mp3` next to the source md) is scoped to write roots entirely, so no disk-write path ever reaches /tmp or another agent's workspace.

**Navigation:** the synthetic `/home/claude` view now lists every **top-level** allowed root (nested roots hidden, non-home roots labeled by real path), and the FileViewer quick-access chips gain `.world` / `lanes` / `/tmp`.

## Verification

- **Tests:** 340 server / 267 web green. New `files-write-roots` suite uses roots-respecting mocks (the pre-existing upload harness ignores the roots argument, so it couldn't see this split); new membership + symlink-escape cases in `path-allowed`; synthetic-home test updated to the top-level rule.
- **Live E2E 10/10** against a worktree server on :39990 with signed initData: list/read in /tmp and legacy lanes, synthetic home shows both, upload/paste/audio-generate into /tmp all 403, real symlink escape denied, baseline roots unaffected. Fixtures and server torn down after; prod untouched.

Deploys with the release window, per the task brief.

🤖 Generated with [Claude Code](https://claude.com/claude-code)