### PR TITLE
fix(audio): send-to-telegram deep-links the source doc, not the mp3 (#274)

### DIFF
--- a/apps/server/src/routes/__tests__/audio.test.ts
+++ b/apps/server/src/routes/__tests__/audio.test.ts
@@ -208,6 +208,30 @@ describe("/send-telegram path allowlist (M-2)", () => {
     expect(cmd).toBe("curl");
     expect(args).toContain(`audio=@${audioPath}`);
   });
+
+  it("deep-links the sibling markdown doc when it exists", async () => {
+    const audioPath = join(sandbox, "note.mp3");
+    const docPath = join(sandbox, "note.md");
+    const { status } = await postJson("/send-telegram", { path: audioPath });
+    expect(status).toBe(200);
+
+    const [, args] = execFileSpy.mock.calls[0];
+    const replyMarkup = args.find((arg: string) => arg.startsWith("reply_markup="));
+    expect(replyMarkup).toContain(encodeURIComponent(docPath));
+    expect(replyMarkup).not.toContain(encodeURIComponent(audioPath));
+  });
+
+  it("falls back to deep-linking the audio when no sibling markdown doc exists", async () => {
+    const audioPath = join(sandbox, "standalone.mp3");
+    writeFileSync(audioPath, "standalone-audio-bytes");
+
+    const { status } = await postJson("/send-telegram", { path: audioPath });
+    expect(status).toBe(200);
+
+    const [, args] = execFileSpy.mock.calls[0];
+    const replyMarkup = args.find((arg: string) => arg.startsWith("reply_markup="));
+    expect(replyMarkup).toContain(encodeURIComponent(audioPath));
+  });
 });
 
 describe("/check path allowlist (M-5 adjacent)", () => {

--- a/apps/server/src/routes/__tests__/audio.test.ts
+++ b/apps/server/src/routes/__tests__/audio.test.ts
@@ -38,6 +38,7 @@ let sandbox: string;
 let allowedFile: string;
 let evilSibling: string;
 let testAllowedRoots: string[] = [];
+const deniedPaths = new Set<string>();
 
 vi.mock("../../lib/path-allowed.js", async () => {
   const real = await vi.importActual<typeof import("../../lib/path-allowed.js")>(
@@ -46,6 +47,7 @@ vi.mock("../../lib/path-allowed.js", async () => {
   return {
     ...real,
     isPathAllowed: async (candidate: string, _ignoredRoots: string[]) => {
+      if (deniedPaths.has(candidate)) return false;
       return real.isPathAllowed(candidate, testAllowedRoots);
     },
   };
@@ -108,6 +110,7 @@ afterAll(() => {
 
 beforeEach(() => {
   execFileSpy.mockClear();
+  deniedPaths.clear();
   __resetRealRootCacheForTests();
 });
 
@@ -219,6 +222,20 @@ describe("/send-telegram path allowlist (M-2)", () => {
     const replyMarkup = args.find((arg: string) => arg.startsWith("reply_markup="));
     expect(replyMarkup).toContain(encodeURIComponent(docPath));
     expect(replyMarkup).not.toContain(encodeURIComponent(audioPath));
+  });
+
+  it("falls back to the audio path when the sibling markdown doc is not allowed", async () => {
+    const audioPath = join(sandbox, "note.mp3");
+    const docPath = join(sandbox, "note.md");
+    deniedPaths.add(docPath);
+
+    const { status } = await postJson("/send-telegram", { path: audioPath });
+    expect(status).toBe(200);
+
+    const [, args] = execFileSpy.mock.calls[0];
+    const replyMarkup = args.find((arg: string) => arg.startsWith("reply_markup="));
+    expect(replyMarkup).toContain(encodeURIComponent(audioPath));
+    expect(replyMarkup).not.toContain(encodeURIComponent(docPath));
   });
 
   it("falls back to deep-linking the audio when no sibling markdown doc exists", async () => {

--- a/apps/server/src/routes/audio.ts
+++ b/apps/server/src/routes/audio.ts
@@ -181,11 +181,12 @@ app.post("/send-telegram", async (c) => {
     const fileName = audioPath.split("/").pop() || "audio.mp3";
     const shortPath = audioPath.replace(/^\/home\/claude\//, "~/");
     const docPath = audioPath.replace(/\.mp3$/i, ".md");
-    // Guard the derived doc path before existsSync() so a planted symlink can't
-    // reveal whether an out-of-bounds file exists. Fall back to the audio link.
+    // Allowlist-guard the derived doc path so a planted symlink can't reveal
+    // whether an out-of-bounds file exists; its realpath() also proves the doc
+    // exists, in one lookup — a separate existsSync() would reopen the
+    // check-then-use race PR #292 closed for reads. Fall back to the audio link.
     // Known limitation: an uppercase-extension sibling (note.MD) is not discovered and falls back to the audio link.
-    const deepLinkPath =
-      (await isPathAllowed(resolve(docPath))) && existsSync(docPath) ? docPath : audioPath;
+    const deepLinkPath = (await isPathAllowed(resolve(docPath))) ? docPath : audioPath;
     const encodedPath = encodeURIComponent(deepLinkPath);
     const deepUrl = `https://cpc.claude.do/#file=${encodedPath}`;
 

--- a/apps/server/src/routes/audio.ts
+++ b/apps/server/src/routes/audio.ts
@@ -180,7 +180,10 @@ app.post("/send-telegram", async (c) => {
     const { botToken, chatId } = await getTelegramCreds();
     const fileName = audioPath.split("/").pop() || "audio.mp3";
     const shortPath = audioPath.replace(/^\/home\/claude\//, "~/");
-    const encodedPath = encodeURIComponent(audioPath);
+    const docPath = audioPath.replace(/\.mp3$/i, ".md");
+    // Deep-link the source doc because the doc view exposes its sidecar audio.
+    const deepLinkPath = existsSync(docPath) ? docPath : audioPath;
+    const encodedPath = encodeURIComponent(deepLinkPath);
     const deepUrl = `https://cpc.claude.do/#file=${encodedPath}`;
 
     // Shell out via execFile — argv array, no /bin/bash interpolation. The

--- a/apps/server/src/routes/audio.ts
+++ b/apps/server/src/routes/audio.ts
@@ -181,8 +181,11 @@ app.post("/send-telegram", async (c) => {
     const fileName = audioPath.split("/").pop() || "audio.mp3";
     const shortPath = audioPath.replace(/^\/home\/claude\//, "~/");
     const docPath = audioPath.replace(/\.mp3$/i, ".md");
-    // Deep-link the source doc because the doc view exposes its sidecar audio.
-    const deepLinkPath = existsSync(docPath) ? docPath : audioPath;
+    // Guard the derived doc path before existsSync() so a planted symlink can't
+    // reveal whether an out-of-bounds file exists. Fall back to the audio link.
+    // Known limitation: an uppercase-extension sibling (note.MD) is not discovered and falls back to the audio link.
+    const deepLinkPath =
+      (await isPathAllowed(resolve(docPath))) && existsSync(docPath) ? docPath : audioPath;
     const encodedPath = encodeURIComponent(deepLinkPath);
     const deepUrl = `https://cpc.claude.do/#file=${encodedPath}`;
 


### PR DESCRIPTION
## Summary
- `/api/audio/send-telegram` built the 'Read in Pocket Console' deep link from the **audio path**, so tapping it opened the raw `.mp3` in the file viewer instead of the source markdown doc (whose view already exposes the sidecar audio).
- Now derives the sibling `.md` (`<doc>.mp3` → `<doc>.md`) and deep-links it when it exists on disk; falls back to the audio path for standalone mp3s so the send never breaks.
- Caption/title unchanged — strictly the deep link, per issue scope.

## Tests
- Two new regression tests in `audio.test.ts` asserting the `reply_markup` curl argv contains the encoded `.md` path (and not the `.mp3`) when the doc exists, and falls back to the `.mp3` when it doesn't.
- `vitest run src/routes/__tests__/audio.test.ts`: 16/16 pass. `tsc --noEmit`: clean. (Independently re-run by the orchestrating agent, not just the implementer.)

Fixes #274
Part of the dev-cpc-features integration group (audio/share stack #274→#275→#276).

🤖 Generated with [Claude Code](https://claude.com/claude-code)