### PR TITLE
feat(markdown-viewer): strip YAML frontmatter, collapsed metadata pill (#242)

### DIFF
--- a/apps/web/src/__tests__/MarkdownViewer.test.tsx
+++ b/apps/web/src/__tests__/MarkdownViewer.test.tsx
@@ -205,6 +205,64 @@ describe("MarkdownViewer — YAML frontmatter", () => {
     expect(screen.getByRole("button", { name: "metadata" })).toBeTruthy();
     expect(container.querySelector(".md-content")!.textContent).toBe("Body only.");
   });
+
+  it("leaves a horizontal rule followed by a setext heading unchanged", () => {
+    const content = "---\nTitle\n---\nbody";
+    const { container } = renderMd(content);
+
+    expect(extractFrontmatter(content)).toEqual({ body: content, metadata: null });
+    expect(screen.queryByRole("button", { name: "metadata" })).toBeNull();
+    expect(container.querySelector(".md-content hr")).toBeTruthy();
+    expect(screen.getByRole("heading", { level: 2, name: "Title" })).toBeTruthy();
+    expect(container.querySelector(".md-content")!.textContent).toContain("body");
+  });
+
+  it("leaves adjacent horizontal rules unchanged", () => {
+    const content = "---\n\n---\n\nBody after rules.";
+    const { container } = renderMd(content);
+
+    expect(extractFrontmatter(content)).toEqual({ body: content, metadata: null });
+    expect(screen.queryByRole("button", { name: "metadata" })).toBeNull();
+    expect(container.querySelectorAll(".md-content hr")).toHaveLength(2);
+    expect(container.querySelector(".md-content")!.textContent).toContain(
+      "Body after rules.",
+    );
+  });
+
+  it("strips frontmatter containing an indented nested list", () => {
+    const content = "---\nkey:\n  - item\n---\nNested body.";
+    const { container } = renderMd(content);
+
+    expect(screen.getByRole("button", { name: "metadata" })).toBeTruthy();
+    expect(container.querySelector(".md-content")!.textContent).toBe("Nested body.");
+  });
+
+  it("strips frontmatter containing a comment", () => {
+    const content = "---\n# metadata comment\nkey: value\n---\nComment body.";
+    const { container } = renderMd(content);
+
+    expect(screen.getByRole("button", { name: "metadata" })).toBeTruthy();
+    expect(container.querySelector(".md-content")!.textContent).toBe("Comment body.");
+  });
+
+  it("collapses metadata when its contents change", () => {
+    const { rerender } = renderMd("---\ntitle: First\n---\nFirst body.");
+    const metadataButton = screen.getByRole("button", { name: "metadata" });
+
+    fireEvent.click(metadataButton);
+    expect(metadataButton.getAttribute("aria-expanded")).toBe("true");
+
+    rerender(
+      <MarkdownViewer
+        content={"---\ntitle: Second\n---\nSecond body."}
+        fileName="second.md"
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "metadata" }).getAttribute("aria-expanded"),
+    ).toBe("false");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/apps/web/src/__tests__/MarkdownViewer.test.tsx
+++ b/apps/web/src/__tests__/MarkdownViewer.test.tsx
@@ -7,7 +7,10 @@
 import React from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent, createEvent } from "@testing-library/react";
-import { MarkdownViewer } from "../components/MarkdownViewer";
+import {
+  extractFrontmatter,
+  MarkdownViewer,
+} from "../components/MarkdownViewer";
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -117,6 +120,90 @@ describe("MarkdownViewer — rendering basics", () => {
     const { container } = renderMd("> This is a quote");
     const bq = container.querySelector("blockquote");
     expect(bq).toBeTruthy();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// YAML frontmatter
+// ---------------------------------------------------------------------------
+
+describe("MarkdownViewer — YAML frontmatter", () => {
+  it("strips frontmatter from the document and reveals it from a collapsed metadata pill", () => {
+    const { container } = renderMd(
+      "---\ntitle: Hidden metadata\ntags:\n  - cpc\n---\n# Visible title\n\nVisible body.",
+    );
+
+    const metadataButton = screen.getByRole("button", { name: "metadata" });
+    expect(metadataButton.getAttribute("aria-expanded")).toBe("false");
+    expect(container.querySelector(".md-content")!.textContent).not.toContain(
+      "Hidden metadata",
+    );
+    expect(screen.getByRole("heading", { name: "Visible title" })).toBeTruthy();
+
+    fireEvent.click(metadataButton);
+
+    expect(metadataButton.getAttribute("aria-expanded")).toBe("true");
+    expect(container.querySelector("pre")!.textContent).toContain(
+      "title: Hidden metadata",
+    );
+  });
+
+  it("renders a document without frontmatter unchanged", () => {
+    const content = "# Plain document\n\nFirst paragraph.";
+    const { container } = renderMd(content);
+
+    expect(extractFrontmatter(content)).toEqual({ body: content, metadata: null });
+    expect(screen.queryByRole("button", { name: "metadata" })).toBeNull();
+    expect(screen.getByRole("heading", { name: "Plain document" })).toBeTruthy();
+    expect(container.querySelector(".md-content p")!.textContent).toBe(
+      "First paragraph.",
+    );
+  });
+
+  it("does not treat an unterminated opening fence as frontmatter", () => {
+    const { container } = renderMd("---\n\n# Heading after a horizontal rule");
+
+    expect(screen.queryByRole("button", { name: "metadata" })).toBeNull();
+    expect(container.querySelector(".md-content hr")).toBeTruthy();
+    expect(
+      screen.getByRole("heading", { name: "Heading after a horizontal rule" }),
+    ).toBeTruthy();
+  });
+
+  it("does not close frontmatter when a value contains three dashes", () => {
+    const { container } = renderMd(
+      "---\nsummary: before --- after\nowner: cpc\n---\n# Actual document",
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "metadata" }));
+
+    expect(container.querySelector("pre")!.textContent).toContain(
+      "summary: before --- after",
+    );
+    expect(container.querySelector("pre")!.textContent).toContain("owner: cpc");
+    expect(screen.getByRole("heading", { name: "Actual document" })).toBeTruthy();
+  });
+
+  it("handles CRLF frontmatter and a closing fence with trailing whitespace", () => {
+    const { container } = renderMd(
+      "---\r\ntitle: Windows\r\nowner: cpc\r\n---   \r\n# CRLF document\r\n\r\nBody text.",
+    );
+
+    expect(screen.getByRole("heading", { name: "CRLF document" })).toBeTruthy();
+    expect(container.querySelector(".md-content")!.textContent).not.toContain(
+      "title: Windows",
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "metadata" }));
+    expect(container.querySelector("pre")!.textContent).toContain("title: Windows");
+    expect(container.querySelector("pre")!.textContent).toContain("owner: cpc");
+  });
+
+  it("strips an empty frontmatter block cleanly", () => {
+    const { container } = renderMd("---\n---\nBody only.");
+
+    expect(screen.getByRole("button", { name: "metadata" })).toBeTruthy();
+    expect(container.querySelector(".md-content")!.textContent).toBe("Body only.");
   });
 });
 

--- a/apps/web/src/components/MarkdownViewer.tsx
+++ b/apps/web/src/components/MarkdownViewer.tsx
@@ -15,6 +15,33 @@ interface MarkdownViewerProps {
   fileName: string;
 }
 
+interface FrontmatterResult {
+  body: string;
+  metadata: string | null;
+}
+
+/**
+ * Extract a leading YAML frontmatter block without attempting to parse YAML.
+ * An unterminated opening fence is ordinary markdown and is left untouched.
+ */
+export function extractFrontmatter(content: string): FrontmatterResult {
+  const openingFence = /^---[ \t]*\r?\n/.exec(content);
+  if (!openingFence) return { body: content, metadata: null };
+
+  const closingFencePattern = /^---[ \t]*\r?$/gm;
+  closingFencePattern.lastIndex = openingFence[0].length;
+  const closingFence = closingFencePattern.exec(content);
+  if (!closingFence) return { body: content, metadata: null };
+
+  let bodyStart = closingFence.index + closingFence[0].length;
+  if (content[bodyStart] === "\n") bodyStart += 1;
+
+  return {
+    body: content.slice(bodyStart),
+    metadata: content.slice(openingFence[0].length, closingFence.index),
+  };
+}
+
 export const markdownRemarkPlugins = [remarkGfm, remarkBreaks, remarkAlert];
 
 // rehype-highlight runs first so code blocks get syntax spans before slug/section processing.
@@ -83,6 +110,63 @@ function isMermaidCodeChild(child: ReactNode): boolean {
 
 /** Stop horizontal touch events from bubbling to the app-level tab-swipe handler. */
 const stopTouchPropagation = (e: React.TouchEvent) => e.stopPropagation();
+
+function FrontmatterMetadata({ metadata }: { metadata: string }) {
+  const [expanded, setExpanded] = useState(false);
+
+  return (
+    <div style={{ marginBottom: 12 }}>
+      <button
+        type="button"
+        aria-expanded={expanded}
+        onClick={() => setExpanded((current) => !current)}
+        style={{
+          display: "inline-flex",
+          alignItems: "center",
+          gap: 6,
+          minHeight: 28,
+          padding: "4px 10px",
+          border: "1px solid var(--color-border)",
+          borderRadius: 999,
+          background: "var(--color-surface)",
+          color: "var(--color-muted)",
+          fontSize: 11,
+          fontWeight: 600,
+          cursor: "pointer",
+          WebkitTapHighlightColor: "transparent",
+        }}
+      >
+        <span aria-hidden="true" style={{ fontSize: 9 }}>
+          {expanded ? "\u25BC" : "\u25B6"}
+        </span>
+        metadata
+      </button>
+      {expanded && (
+        <pre
+          onTouchMove={stopTouchPropagation}
+          style={{
+            margin: "8px 0 0",
+            padding: "10px 12px",
+            overflowX: "auto",
+            WebkitOverflowScrolling: "touch",
+            touchAction: "pan-x pan-y",
+            border: "1px solid var(--color-border)",
+            borderRadius: 6,
+            background: "var(--color-surface)",
+            color: "var(--color-fg-muted)",
+            fontFamily: "'JetBrains Mono', 'Fira Code', monospace",
+            fontSize: 11,
+            lineHeight: 1.5,
+            whiteSpace: "pre-wrap",
+            overflowWrap: "break-word",
+          }}
+        >
+          {metadata}
+        </pre>
+      )}
+    </div>
+  );
+}
 
 function PreBlock({ children, node: _node, ...props }: React.ComponentPropsWithoutRef<'pre'> & ExtraProps) {
   const childArray = Children.toArray(children);
@@ -177,6 +261,7 @@ function computeEffectiveHidden(
 
 export function MarkdownViewer({ content, fileName: _fileName }: MarkdownViewerProps) {
   const [foldedIds, setFoldedIds] = useState<Set<string>>(new Set());
+  const { body, metadata } = useMemo(() => extractFrontmatter(content), [content]);
 
   // Collect heading entries as heading components render (Finding 1 fix).
   // This replaces the fragile regex parser — slugs now come directly from
@@ -532,13 +617,14 @@ export function MarkdownViewer({ content, fileName: _fileName }: MarkdownViewerP
           display: none;
         }
       `}</style>
+      {metadata !== null && <FrontmatterMetadata metadata={metadata} />}
       <div className="md-content">
         <ReactMarkdown
           remarkPlugins={markdownRemarkPlugins}
           rehypePlugins={markdownRehypePlugins}
           components={components}
         >
-          {content}
+          {body}
         </ReactMarkdown>
       </div>
     </div>

--- a/apps/web/src/components/MarkdownViewer.tsx
+++ b/apps/web/src/components/MarkdownViewer.tsx
@@ -1,4 +1,4 @@
-import React, { Children, isValidElement, useState, useCallback, useMemo, useRef, type ReactNode } from "react";
+import React, { Children, isValidElement, useState, useCallback, useEffect, useMemo, useRef, type ReactNode } from "react";
 import ReactMarkdown, { type Components, type ExtraProps } from "react-markdown";
 import remarkGfm from "remark-gfm";
 import remarkBreaks from "remark-breaks";
@@ -33,12 +33,22 @@ export function extractFrontmatter(content: string): FrontmatterResult {
   const closingFence = closingFencePattern.exec(content);
   if (!closingFence) return { body: content, metadata: null };
 
+  const metadata = content.slice(openingFence[0].length, closingFence.index);
+  const metadataLines = metadata.split(/\r?\n/);
+  const nonEmptyLines = metadataLines.filter((line) => line.length > 0);
+  const hasYamlShape = nonEmptyLines.every((line) =>
+    /^\s|^#|^[A-Za-z0-9_.$-]+\s*:(\s|$)/.test(line),
+  );
+  if (metadata !== "" && (nonEmptyLines.length === 0 || !hasYamlShape)) {
+    return { body: content, metadata: null };
+  }
+
   let bodyStart = closingFence.index + closingFence[0].length;
   if (content[bodyStart] === "\n") bodyStart += 1;
 
   return {
     body: content.slice(bodyStart),
-    metadata: content.slice(openingFence[0].length, closingFence.index),
+    metadata,
   };
 }
 
@@ -113,6 +123,10 @@ const stopTouchPropagation = (e: React.TouchEvent) => e.stopPropagation();
 
 function FrontmatterMetadata({ metadata }: { metadata: string }) {
   const [expanded, setExpanded] = useState(false);
+
+  useEffect(() => {
+    setExpanded(false);
+  }, [metadata]);
 
   return (
     <div style={{ marginBottom: 12 }}>


### PR DESCRIPTION
Closes #242.

YAML frontmatter (memory entries, SKILL.md, ADRs shared via share-doc) no longer renders as inline text. Detection: `---` on line 1 + next full-line `---` (CRLF + trailing-whitespace tolerant; unterminated fence = ordinary markdown, untouched). Stripped by default; a collapsed **metadata** pill above the doc expands to show the raw block. No new deps, applies to every MarkdownViewer call site.

Tests: 6 new cases (strip, no-frontmatter, unterminated fence, `---` inside value, CRLF, empty block); web suite 273/273, typecheck + build pass.

Visual proof to follow in-PR before merge (visual-proof gate, Liam 1403).

🤖 Generated with [Claude Code](https://claude.com/claude-code)