### PR TITLE
feat(file-viewer): show parent path above filename (#243)

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -7,6 +7,29 @@ import { getFileIcon } from "./file-icons";
 import "./FileViewer.css";
 
 const PASTE_MAX_BYTES = 1024 * 1024;
+const FILE_PATH_MAX_LENGTH = 60;
+
+/**
+ * Compact a path around its middle, preferring directory boundaries so the
+ * filesystem root and the most specific trailing directories stay visible.
+ */
+export function middleTruncatePath(path: string, maxLength = FILE_PATH_MAX_LENGTH): string {
+  if (path.length <= maxLength) return path;
+  if (maxLength <= 1) return "\u2026".slice(0, Math.max(0, maxLength));
+
+  const visibleLength = maxLength - 1;
+  const prefixBudget = Math.ceil(visibleLength / 2);
+  const suffixBudget = Math.floor(visibleLength / 2);
+  const boundaryPrefixEnd = path.lastIndexOf("/", prefixBudget - 1) + 1;
+  const boundarySuffixStart = path.indexOf("/", path.length - suffixBudget);
+  const prefixEnd = boundaryPrefixEnd > 1 ? boundaryPrefixEnd : prefixBudget;
+  const suffixStart = boundarySuffixStart >= 0 ? boundarySuffixStart : path.length - suffixBudget;
+
+  if (prefixEnd >= suffixStart) {
+    return `${path.slice(0, prefixBudget)}\u2026${path.slice(-suffixBudget)}`;
+  }
+  return `${path.slice(0, prefixEnd)}\u2026${path.slice(suffixStart)}`;
+}
 
 /**
  * Build a default filename from content. If the first non-empty line is a
@@ -135,6 +158,7 @@ export function FileViewer({ onClose, initialFile, showHidden = false, sortMode 
   const [fileContent, setFileContent] = useState<string | null>(null);
   const [fileName, setFileName] = useState<string>("");
   const [filePath, setFilePath] = useState<string>("");
+  const [filePathExpanded, setFilePathExpanded] = useState(false);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [collapsedRanges, setCollapsedRanges] = useState<Set<number>>(new Set());
@@ -385,6 +409,7 @@ export function FileViewer({ onClose, initialFile, showHidden = false, sortMode 
       setFileContent(data.content);
       setFileName(name);
       setFilePath(path);
+      setFilePathExpanded(false);
       onViewChange?.({ path, name });
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to read file");
@@ -551,6 +576,10 @@ export function FileViewer({ onClose, initialFile, showHidden = false, sortMode 
     });
   }, [entries, showHidden, sortMode]);
   const shortPath = currentPath.replace("/home/claude/", "~/");
+  const fileDirectoryPath = useMemo(() => {
+    const lastSlash = filePath.lastIndexOf("/");
+    return lastSlash <= 0 ? "/" : `${filePath.slice(0, lastSlash)}/`;
+  }, [filePath]);
 
   return (
     <div className="cpc-file-viewer" style={{ display: "flex", flexDirection: "column", height: "100%", width: "100%", maxWidth: "100%", overflowX: "hidden" }}>
@@ -639,6 +668,39 @@ export function FileViewer({ onClose, initialFile, showHidden = false, sortMode 
             );
           })}
         </div>
+      )}
+
+      {/* Compact parent path for the open file. This sits immediately above
+          the existing filename/control row and shares its swipe isolation. */}
+      {fileContent !== null && (
+        <button
+          type="button"
+          onClick={() => setFilePathExpanded((expanded) => !expanded)}
+          onTouchStart={(e) => e.stopPropagation()}
+          onTouchMove={(e) => e.stopPropagation()}
+          onTouchEnd={(e) => e.stopPropagation()}
+          aria-expanded={filePathExpanded}
+          aria-label={`${filePathExpanded ? "Collapse" : "Expand"} parent directory path`}
+          style={{
+            width: "100%",
+            minHeight: 16,
+            padding: "0 8px",
+            boxSizing: "border-box",
+            border: "none",
+            background: "none",
+            color: "var(--color-muted)",
+            cursor: "pointer",
+            fontFamily: "inherit",
+            fontSize: 10,
+            lineHeight: "16px",
+            textAlign: "center",
+            whiteSpace: filePathExpanded ? "normal" : "nowrap",
+            overflowWrap: filePathExpanded ? "anywhere" : undefined,
+            flexShrink: 0,
+          }}
+        >
+          {filePathExpanded ? fileDirectoryPath : middleTruncatePath(fileDirectoryPath)}
+        </button>
       )}
 
       {/* Header

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -22,12 +22,43 @@ export function middleTruncatePath(path: string, maxLength = FILE_PATH_MAX_LENGT
   const suffixBudget = Math.floor(visibleLength / 2);
   const boundaryPrefixEnd = path.lastIndexOf("/", prefixBudget - 1) + 1;
   const boundarySuffixStart = path.indexOf("/", path.length - suffixBudget);
-  const prefixEnd = boundaryPrefixEnd > 1 ? boundaryPrefixEnd : prefixBudget;
-  const suffixStart = boundarySuffixStart >= 0 ? boundarySuffixStart : path.length - suffixBudget;
+  const minPrefixSnapLength = Math.ceil(prefixBudget / 2);
+  const minSuffixSnapLength = Math.ceil(suffixBudget / 2);
+  let prefixEnd =
+    boundaryPrefixEnd > 1 && boundaryPrefixEnd >= minPrefixSnapLength
+      ? boundaryPrefixEnd
+      : prefixBudget;
+  let suffixStart =
+    boundarySuffixStart >= 0 &&
+    path.length - boundarySuffixStart >= minSuffixSnapLength
+      ? boundarySuffixStart
+      : path.length - suffixBudget;
 
   if (prefixEnd >= suffixStart) {
-    return `${path.slice(0, prefixBudget)}\u2026${path.slice(-suffixBudget)}`;
+    prefixEnd = prefixBudget;
+    suffixStart = path.length - suffixBudget;
   }
+
+  // Hard cuts use UTF-16 indices. Move a cut inward if it would leave one
+  // half of a surrogate pair visible; moving inward also preserves the
+  // maxLength guarantee.
+  if (
+    prefixEnd > 0 &&
+    prefixEnd < path.length &&
+    /[\uD800-\uDBFF]/.test(path[prefixEnd - 1]) &&
+    /[\uDC00-\uDFFF]/.test(path[prefixEnd])
+  ) {
+    prefixEnd -= 1;
+  }
+  if (
+    suffixStart > 0 &&
+    suffixStart < path.length &&
+    /[\uD800-\uDBFF]/.test(path[suffixStart - 1]) &&
+    /[\uDC00-\uDFFF]/.test(path[suffixStart])
+  ) {
+    suffixStart += 1;
+  }
+
   return `${path.slice(0, prefixEnd)}\u2026${path.slice(suffixStart)}`;
 }
 
@@ -696,6 +727,12 @@ export function FileViewer({ onClose, initialFile, showHidden = false, sortMode 
             textAlign: "center",
             whiteSpace: filePathExpanded ? "normal" : "nowrap",
             overflowWrap: filePathExpanded ? "anywhere" : undefined,
+            maxHeight: filePathExpanded ? 72 : undefined,
+            overflow: filePathExpanded ? undefined : "hidden",
+            overflowX: filePathExpanded ? "hidden" : undefined,
+            overflowY: filePathExpanded ? "auto" : undefined,
+            WebkitOverflowScrolling: filePathExpanded ? "touch" : undefined,
+            textOverflow: filePathExpanded ? undefined : "ellipsis",
             flexShrink: 0,
           }}
         >

--- a/apps/web/src/components/__tests__/FileViewer.test.tsx
+++ b/apps/web/src/components/__tests__/FileViewer.test.tsx
@@ -171,6 +171,49 @@ describe("FileViewer", () => {
       expect.objectContaining({ name: "README.md" }),
     );
   });
+
+  it("caps the expanded parent path and ellipsizes the collapsed path", async () => {
+    render(<FileViewer onClose={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("README.md")).toBeInTheDocument();
+    });
+
+    fetchMock.mockImplementation(async (url: string) => {
+      if (typeof url === "string" && url.includes("/api/files/read")) {
+        return {
+          ok: true,
+          json: async () => ({
+            content: "# Test",
+            path: "/home/claude/claudes-world/README.md",
+            name: "README.md",
+          }),
+        };
+      }
+      if (typeof url === "string" && url.includes("/api/terminal/dir-branch")) {
+        return makeDirBranchResponse();
+      }
+      return { ok: false, status: 404, json: async () => ({}) };
+    });
+
+    fireEvent.click(screen.getByText("README.md"));
+
+    const collapsedButton = await screen.findByRole("button", {
+      name: "Expand parent directory path",
+    });
+    expect(collapsedButton).toHaveStyle({ overflow: "hidden", textOverflow: "ellipsis" });
+
+    fireEvent.click(collapsedButton);
+
+    const expandedButton = screen.getByRole("button", {
+      name: "Collapse parent directory path",
+    });
+    expect(expandedButton).toHaveStyle({
+      maxHeight: "72px",
+      overflowX: "hidden",
+      overflowY: "auto",
+    });
+  });
 });
 
 describe("SORT_OPTIONS export", () => {
@@ -199,11 +242,44 @@ describe("middleTruncatePath", () => {
   it("middle-truncates a long path while preserving prefix and trailing directories", () => {
     const path = "/home/claude/claudes-world/.claude/skills/some/really/deeply/nested/foo/";
     const truncated = middleTruncatePath(path);
+    const [prefix, suffix] = truncated.split("\u2026");
 
     expect(truncated).toContain("\u2026");
     expect(truncated).toMatch(/^\/home\/claude\//);
     expect(truncated).toMatch(/\/deeply\/nested\/foo\/$/);
+    expect(prefix.endsWith("/")).toBe(true);
+    expect(suffix.startsWith("/")).toBe(true);
     expect(truncated.length).toBeLessThanOrEqual(60);
+  });
+
+  it("falls back to a hard suffix cut when a boundary would waste most of the budget", () => {
+    const maxLength = 60;
+    const path = "/home/claude/code/claude-pocket-console-worktrees/feat-issue-243-fileviewer-path/";
+    const truncated = middleTruncatePath(path, maxLength);
+
+    expect(path).toHaveLength(81);
+    expect(truncated).toContain("\u2026");
+    expect(truncated).toMatch(/fileviewer-path\/$/);
+    expect(truncated.length).toBeGreaterThanOrEqual(maxLength - 12);
+    expect(truncated.length).toBeLessThanOrEqual(maxLength);
+  });
+
+  it("falls back to a hard prefix cut when a boundary would waste most of the budget", () => {
+    const path = `/a/${"p".repeat(50)}/meaningful/suffix/`;
+    const truncated = middleTruncatePath(path, 60);
+    const [prefix] = truncated.split("\u2026");
+
+    expect(prefix).toHaveLength(30);
+    expect(prefix.endsWith("p")).toBe(true);
+    expect(truncated.length).toBeLessThanOrEqual(60);
+  });
+
+  it("does not split surrogate pairs at hard cuts", () => {
+    const truncated = middleTruncatePath("abcd\ud83d\ude00efghi\ud83d\ude80jkl", 10);
+
+    expect(truncated).toBe("abcd\u2026jkl");
+    expect(truncated).not.toMatch(/[\uD800-\uDFFF]/);
+    expect(truncated.length).toBeLessThanOrEqual(10);
   });
 
   it("leaves a path at the exact boundary unchanged", () => {

--- a/apps/web/src/components/__tests__/FileViewer.test.tsx
+++ b/apps/web/src/components/__tests__/FileViewer.test.tsx
@@ -25,7 +25,7 @@ vi.mock("../file-icons", () => ({
   getFileIcon: () => null,
 }));
 
-import { FileViewer, SORT_OPTIONS } from "../FileViewer";
+import { FileViewer, SORT_OPTIONS, middleTruncatePath } from "../FileViewer";
 
 let fetchMock: ReturnType<typeof vi.fn>;
 
@@ -188,5 +188,27 @@ describe("SORT_OPTIONS export", () => {
       expect(opt.short).toBeTruthy();
       expect(opt.long).toBeTruthy();
     }
+  });
+});
+
+describe("middleTruncatePath", () => {
+  it("leaves a short path unchanged", () => {
+    expect(middleTruncatePath("/home/claude/code/")).toBe("/home/claude/code/");
+  });
+
+  it("middle-truncates a long path while preserving prefix and trailing directories", () => {
+    const path = "/home/claude/claudes-world/.claude/skills/some/really/deeply/nested/foo/";
+    const truncated = middleTruncatePath(path);
+
+    expect(truncated).toContain("\u2026");
+    expect(truncated).toMatch(/^\/home\/claude\//);
+    expect(truncated).toMatch(/\/deeply\/nested\/foo\/$/);
+    expect(truncated.length).toBeLessThanOrEqual(60);
+  });
+
+  it("leaves a path at the exact boundary unchanged", () => {
+    const path = `/${"a".repeat(58)}/`;
+    expect(path).toHaveLength(60);
+    expect(middleTruncatePath(path)).toBe(path);
   });
 });


### PR DESCRIPTION
Closes #243.

Parent directory of the open file now renders as a compact muted line above the filename row (16px, centered, --color-muted). Paths >60 chars middle-truncate at directory boundaries keeping root prefix + trailing dirs; tap toggles the full wrapping path. No clipboard copy (out of scope per issue). Directory-listing view unchanged; swipe isolation follows the existing header pattern.

Tests: middleTruncatePath unit tests (short/long/exact-boundary); web 270/270 + server 346/346, typecheck + build pass.

Visual proof to follow in-PR before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)