### PR TITLE
feat(app): bot path aliases + default landing → /claude_do_bot (#240)

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -103,8 +103,8 @@ export function App() {
   const [connected, setConnected] = useState(false);
   const [initialRoute] = useState(() => {
     const route = resolveInitialAppState(window.location.pathname, window.location.hash);
-    const isInitialDev = window.location.hostname.includes("cpc-dev")
-      || window.location.pathname.startsWith("/dev");
+    // Redirects only originate at exact "/", so path-prefixed dev deployments are naturally excluded.
+    const isInitialDev = window.location.hostname.includes("cpc-dev");
     if (route.redirectPath && !isInitialDev) {
       window.history.replaceState(
         null,

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -12,14 +12,12 @@ import { DebugOverlay } from "./debug/DebugOverlay";
 import { PrTicker } from "./components/PrTicker";
 import { HomeScreenPrompt } from "./components/HomeScreenPrompt";
 import { SessionPicker, type TmuxSessionInfo } from "./components/SessionPicker";
+import {
+  buildLandingUrl,
+  resolveInitialAppState,
+  type AppTab as Tab,
+} from "./lib/app-routing";
 
-// Client-side mirror of the server's session-name allowlist (SESSION_NAME_RE
-// in apps/server/src/routes/utils.ts). Applied to the hash deep-link value —
-// the server re-validates regardless; this just drops junk before it ever
-// becomes a WS param.
-const SESSION_NAME_RE = /^[A-Za-z0-9_.-]{1,64}$/;
-
-type Tab = "terminal" | "files" | "links" | "voice" | "prs";
 const TABS: Tab[] = ["terminal", "files", "links", "voice", "prs"];
 const SWIPE_THRESHOLD = 120;
 
@@ -103,30 +101,26 @@ const VALID_SORTS: SortMode[] = ["name-asc", "name-desc", "date-asc", "date-desc
 export function App() {
   const [authed, setAuthed] = useState(() => hasAuth());
   const [connected, setConnected] = useState(false);
-  const hashParams = window.location.hash.replace("#", "");
-  const initialFile = hashParams.match(/file=([^&]+)/)?.[1] ? decodeURIComponent(hashParams.match(/file=([^&]+)/)![1]) : null;
-  const initialTab = initialFile ? "files" : (hashParams.split("&")[0] || "terminal") as Tab;
-  const [activeTab, setActiveTab] = useState<Tab>(
-    TABS.includes(initialTab as Tab) ? initialTab : "terminal"
-  );
+  const [initialRoute] = useState(() => {
+    const route = resolveInitialAppState(window.location.pathname, window.location.hash);
+    const isInitialDev = window.location.hostname.includes("cpc-dev")
+      || window.location.pathname.startsWith("/dev");
+    if (route.redirectPath && !isInitialDev) {
+      window.history.replaceState(
+        null,
+        "",
+        buildLandingUrl(route.redirectPath, window.location.search, window.location.hash),
+      );
+    }
+    return route;
+  });
+  const [activeTab, setActiveTab] = useState<Tab>(initialRoute.tab);
   const [reconnectKey, setReconnectKey] = useState(0);
 
   // Multi-session terminal (world-os#218): which tmux session the terminal
   // tab views. null = the server's default (writable) session. Deep-linkable
   // via #terminal&session=<name>, same convention as #files&file=<path>.
-  const initialSessionRaw = hashParams.match(/(?:^|&)session=([^&]+)/)?.[1];
-  let initialSession: string | null = null;
-  if (initialSessionRaw) {
-    try {
-      const decoded = decodeURIComponent(initialSessionRaw);
-      if (SESSION_NAME_RE.test(decoded)) initialSession = decoded;
-    } catch {
-      // Malformed percent-encoding in a hand-typed/truncated deep link
-      // (e.g. "#terminal&session=%") — treat as no session rather than
-      // throwing during initial render.
-    }
-  }
-  const [activeSession, setActiveSession] = useState<string | null>(initialSession);
+  const [activeSession, setActiveSession] = useState<string | null>(initialRoute.session);
   const [sessionList, setSessionList] = useState<TmuxSessionInfo[]>([]);
   const [defaultSession, setDefaultSession] = useState<string | null>(null);
   // Non-default session the restricted command palette targets, or null
@@ -135,7 +129,7 @@ export function App() {
   // default explicitly by name is harmless (server resolves both to the
   // same session), so the pessimistic default is safe either way.
   const paletteSession = activeSession !== null && activeSession !== defaultSession ? activeSession : null;
-  const [initialFilePath] = useState<string | null>(initialFile);
+  const [initialFilePath] = useState<string | null>(initialRoute.file);
   const [fileShowHidden, setFileShowHidden] = useState<boolean>(() => {
     try { return localStorage.getItem(HIDDEN_KEY) === "1"; } catch { return false; }
   });

--- a/apps/web/src/lib/__tests__/app-routing.test.ts
+++ b/apps/web/src/lib/__tests__/app-routing.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { buildLandingUrl, resolveInitialAppState } from "../app-routing";
+
+describe("resolveInitialAppState", () => {
+  it("resolves root to the default bot alias and a cosmetic redirect", () => {
+    expect(resolveInitialAppState("/", "")).toEqual({
+      tab: "terminal",
+      session: null,
+      file: null,
+      redirectPath: "/claude_do_bot",
+    });
+  });
+
+  it("resolves /claude_do_bot to the default terminal session", () => {
+    expect(resolveInitialAppState("/claude_do_bot", "")).toEqual({
+      tab: "terminal",
+      session: null,
+      file: null,
+      redirectPath: null,
+    });
+  });
+
+  it("lets a file hash deep link win over the alias", () => {
+    expect(resolveInitialAppState("/claude_do_bot", "#files&file=%2Ftmp%2Fnotes.md")).toEqual({
+      tab: "files",
+      session: null,
+      file: "/tmp/notes.md",
+      redirectPath: null,
+    });
+  });
+
+  it("preserves terminal session deep-link resolution and validation", () => {
+    expect(resolveInitialAppState("/claude_do_bot", "#terminal&session=pm.test-1")).toEqual({
+      tab: "terminal",
+      session: "pm.test-1",
+      file: null,
+      redirectPath: null,
+    });
+    expect(resolveInitialAppState("/claude_do_bot", "#terminal&session=invalid%2Fname").session).toBeNull();
+  });
+
+  it("preserves voice token hash routing", () => {
+    expect(resolveInitialAppState("/claude_do_bot", "#voice&token=secret")).toEqual({
+      tab: "voice",
+      session: null,
+      file: null,
+      redirectPath: null,
+    });
+  });
+
+  it("uses current defaults for an unknown path", () => {
+    expect(resolveInitialAppState("/unknown", "")).toEqual({
+      tab: "terminal",
+      session: null,
+      file: null,
+      redirectPath: null,
+    });
+  });
+
+  it("does not redirect the /dev path", () => {
+    expect(resolveInitialAppState("/dev", "").redirectPath).toBeNull();
+  });
+});
+
+describe("buildLandingUrl", () => {
+  it("preserves search and hash verbatim", () => {
+    expect(buildLandingUrl("/claude_do_bot", "?token=a%2Bb&mode=1", "#voice&token=hash-token"))
+      .toBe("/claude_do_bot?token=a%2Bb&mode=1#voice&token=hash-token");
+  });
+});

--- a/apps/web/src/lib/__tests__/app-routing.test.ts
+++ b/apps/web/src/lib/__tests__/app-routing.test.ts
@@ -20,6 +20,24 @@ describe("resolveInitialAppState", () => {
     });
   });
 
+  it("ignores a foreign Telegram hash when resolving the root redirect", () => {
+    expect(resolveInitialAppState("/", "#tgWebAppData=abc&tgWebAppVersion=7")).toEqual({
+      tab: "terminal",
+      session: null,
+      file: null,
+      redirectPath: "/claude_do_bot",
+    });
+  });
+
+  it("ignores a foreign Telegram hash when resolving the bot alias", () => {
+    expect(resolveInitialAppState("/claude_do_bot", "#tgWebAppData=abc&tgWebAppVersion=7")).toEqual({
+      tab: "terminal",
+      session: null,
+      file: null,
+      redirectPath: null,
+    });
+  });
+
   it("lets a file hash deep link win over the alias", () => {
     expect(resolveInitialAppState("/claude_do_bot", "#files&file=%2Ftmp%2Fnotes.md")).toEqual({
       tab: "files",
@@ -48,6 +66,14 @@ describe("resolveInitialAppState", () => {
     });
   });
 
+  it.each([
+    ["#files&file=%2Ftmp%2Fnotes.md", "files"],
+    ["#terminal&session=pm.test-1", "terminal"],
+    ["#voice&token=secret", "voice"],
+  ] as const)("lets the app deep link %s suppress the root redirect", (hash, tab) => {
+    expect(resolveInitialAppState("/", hash)).toMatchObject({ tab, redirectPath: null });
+  });
+
   it("uses current defaults for an unknown path", () => {
     expect(resolveInitialAppState("/unknown", "")).toEqual({
       tab: "terminal",
@@ -66,5 +92,13 @@ describe("buildLandingUrl", () => {
   it("preserves search and hash verbatim", () => {
     expect(buildLandingUrl("/claude_do_bot", "?token=a%2Bb&mode=1", "#voice&token=hash-token"))
       .toBe("/claude_do_bot?token=a%2Bb&mode=1#voice&token=hash-token");
+  });
+
+  it("preserves a foreign Telegram hash during the landing redirect", () => {
+    expect(buildLandingUrl(
+      "/claude_do_bot",
+      "",
+      "#tgWebAppData=abc&tgWebAppVersion=7",
+    )).toBe("/claude_do_bot#tgWebAppData=abc&tgWebAppVersion=7");
   });
 });

--- a/apps/web/src/lib/app-routing.ts
+++ b/apps/web/src/lib/app-routing.ts
@@ -1,0 +1,86 @@
+export type AppTab = "terminal" | "files" | "links" | "voice" | "prs";
+
+type BotPathAlias = Readonly<{
+  tab: AppTab;
+  session: string | null;
+}>;
+
+export const BOT_PATH_ALIASES: Readonly<Record<string, BotPathAlias>> = {
+  "/claude_do_bot": { tab: "terminal", session: null },
+};
+
+const DEFAULT_BOT_PATH = "/claude_do_bot";
+const DEFAULT_STATE: InitialAppState = {
+  tab: "terminal",
+  session: null,
+  file: null,
+};
+const TABS: AppTab[] = ["terminal", "files", "links", "voice", "prs"];
+
+// Client-side mirror of the server's session-name allowlist (SESSION_NAME_RE
+// in apps/server/src/routes/utils.ts). The server re-validates every session;
+// this drops invalid names before they become WebSocket parameters.
+const SESSION_NAME_RE = /^[A-Za-z0-9_.-]{1,64}$/;
+
+export interface InitialAppState {
+  tab: AppTab;
+  session: string | null;
+  file: string | null;
+}
+
+export interface InitialAppResolution extends InitialAppState {
+  redirectPath: string | null;
+}
+
+function validatedSession(session: string | null): string | null {
+  return session !== null && SESSION_NAME_RE.test(session) ? session : null;
+}
+
+function resolveHashState(hashParams: string): InitialAppState {
+  const fileMatch = hashParams.match(/file=([^&]+)/)?.[1];
+  const file = fileMatch ? decodeURIComponent(fileMatch) : null;
+  const requestedTab = file
+    ? "files"
+    : (hashParams.split("&")[0] || "terminal") as AppTab;
+
+  let session: string | null = null;
+  const sessionMatch = hashParams.match(/(?:^|&)session=([^&]+)/)?.[1];
+  if (sessionMatch) {
+    try {
+      session = validatedSession(decodeURIComponent(sessionMatch));
+    } catch {
+      // A malformed hand-typed/truncated session deep link behaves like the
+      // default session instead of throwing during the initial render.
+    }
+  }
+
+  return {
+    tab: TABS.includes(requestedTab) ? requestedTab : "terminal",
+    session,
+    file,
+  };
+}
+
+/** Resolve the first-render route without reading from or mutating window. */
+export function resolveInitialAppState(pathname: string, hash: string): InitialAppResolution {
+  const hashParams = hash.replace(/^#/, "");
+  if (hashParams) {
+    return { ...resolveHashState(hashParams), redirectPath: null };
+  }
+
+  const redirectPath = pathname === "/" ? DEFAULT_BOT_PATH : null;
+  const alias = BOT_PATH_ALIASES[pathname] ?? (redirectPath ? BOT_PATH_ALIASES[redirectPath] : undefined);
+  if (!alias) return { ...DEFAULT_STATE, redirectPath };
+
+  return {
+    tab: alias.tab,
+    session: validatedSession(alias.session),
+    file: null,
+    redirectPath,
+  };
+}
+
+/** Build the replaceState URL while leaving auth query/hash text untouched. */
+export function buildLandingUrl(pathname: string, search: string, hash: string): string {
+  return `${pathname}${search}${hash}`;
+}

--- a/apps/web/src/lib/app-routing.ts
+++ b/apps/web/src/lib/app-routing.ts
@@ -16,6 +16,7 @@ const DEFAULT_STATE: InitialAppState = {
   file: null,
 };
 const TABS: AppTab[] = ["terminal", "files", "links", "voice", "prs"];
+const DEEP_LINK_PARAM_RE = /(?:^|&)(?:file|session|token)=/;
 
 // Client-side mirror of the server's session-name allowlist (SESSION_NAME_RE
 // in apps/server/src/routes/utils.ts). The server re-validates every session;
@@ -61,10 +62,15 @@ function resolveHashState(hashParams: string): InitialAppState {
   };
 }
 
+function isAppDeepLink(hashParams: string): boolean {
+  const firstSegment = hashParams.split("&", 1)[0];
+  return TABS.includes(firstSegment as AppTab) || DEEP_LINK_PARAM_RE.test(hashParams);
+}
+
 /** Resolve the first-render route without reading from or mutating window. */
 export function resolveInitialAppState(pathname: string, hash: string): InitialAppResolution {
   const hashParams = hash.replace(/^#/, "");
-  if (hashParams) {
+  if (isAppDeepLink(hashParams)) {
     return { ...resolveHashState(hashParams), redirectPath: null };
   }
 


### PR DESCRIPTION
Closes #240.

Client-side only (the SPA fallback from #287 already serves any path). New `lib/app-routing.ts`: BOT_PATH_ALIASES map (`/claude_do_bot` → terminal @ default/orchestrator session — designed so #241's `/pm_dobot` is a one-line addition) + `resolveInitialAppState(pathname, hash)`. Resolution order: hash deep-link wins → path alias → defaults. Landing at `/` cosmetically `history.replaceState`s to `/claude_do_bot`, preserving `?token` search + hash verbatim; no reload; dev contexts (cpc-dev host, /dev path) never redirect. Existing deep links (#files&file=, #terminal&session=, #voice&token=) provably unchanged (tests). No server, keyboard, or launcher-hook changes.

Tests: 8 routing cases; web 275/275, typecheck + build pass.

Visual proof (redirect + deep-links driving the real app) to follow in-PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)