### PR TITLE
feat(audio): auto-send to Telegram when generation completes (#275)

### DIFF
--- a/apps/web/src/components/__tests__/ActionBar.test.tsx
+++ b/apps/web/src/components/__tests__/ActionBar.test.tsx
@@ -201,6 +201,55 @@ describe("ActionBar", () => {
     }
   });
 
+  it("automatically sends generated audio to Telegram exactly once", async () => {
+    render(<ActionBar activeTab="files" viewingFile={{ path: "/tmp/README.md", name: "README.md" }} />);
+    fireEvent.click(screen.getByText("Audio"));
+
+    await waitFor(() => expect(screen.getByText("Generate Audio")).toBeInTheDocument());
+    fireEvent.click(screen.getByText("Generate Audio"));
+
+    await waitFor(() => {
+      expect(mockSendAudioTelegram).toHaveBeenCalledWith("/tmp/audio.ogg", expect.any(AbortSignal));
+    });
+    expect(mockSendAudioTelegram).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not send audio to Telegram when generation fails", async () => {
+    mockGenerateAudio.mockResolvedValue({ ok: false, error: "Generation failed" });
+
+    render(<ActionBar activeTab="files" viewingFile={{ path: "/tmp/README.md", name: "README.md" }} />);
+    fireEvent.click(screen.getByText("Audio"));
+
+    await waitFor(() => expect(screen.getByText("Generate Audio")).toBeInTheDocument());
+    fireEvent.click(screen.getByText("Generate Audio"));
+
+    await waitFor(() => expect(screen.getByText("Failed: Generation failed")).toBeInTheDocument());
+    expect(mockSendAudioTelegram).not.toHaveBeenCalled();
+  });
+
+  it("allows a manual retry after automatic sending fails", async () => {
+    mockSendAudioTelegram
+      .mockResolvedValueOnce({ ok: false, error: "Telegram unavailable" })
+      .mockResolvedValueOnce({ ok: true });
+
+    render(<ActionBar activeTab="files" viewingFile={{ path: "/tmp/README.md", name: "README.md" }} />);
+    fireEvent.click(screen.getByText("Audio"));
+
+    await waitFor(() => expect(screen.getByText("Generate Audio")).toBeInTheDocument());
+    fireEvent.click(screen.getByText("Generate Audio"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Failed: Telegram unavailable")).toBeInTheDocument();
+      expect(screen.getByText("Send to Telegram")).toBeInTheDocument();
+    });
+    expect(mockSendAudioTelegram).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByText("Send to Telegram"));
+
+    await waitFor(() => expect(mockSendAudioTelegram).toHaveBeenCalledTimes(2));
+    expect(mockSendAudioTelegram).toHaveBeenLastCalledWith("/tmp/audio.ogg", expect.any(AbortSignal));
+  });
+
   it("hides Reconnect button when onReconnect is not provided", () => {
     render(<ActionBar activeTab="terminal" />);
     expect(screen.queryByText("Reconnect")).not.toBeInTheDocument();

--- a/apps/web/src/components/__tests__/ActionBar.test.tsx
+++ b/apps/web/src/components/__tests__/ActionBar.test.tsx
@@ -227,6 +227,35 @@ describe("ActionBar", () => {
     expect(mockSendAudioTelegram).not.toHaveBeenCalled();
   });
 
+  it("clears stale audio status when regeneration fails", async () => {
+    mockCheckAudio.mockResolvedValue({ exists: true, path: "/tmp/stale.ogg" });
+    mockGenerateAudio.mockResolvedValue({ ok: false, error: "Generation failed" });
+
+    render(<ActionBar activeTab="files" viewingFile={{ path: "/tmp/README.md", name: "README.md" }} />);
+    fireEvent.click(screen.getByText("Audio"));
+
+    await waitFor(() => expect(screen.getByText("Audio file exists")).toBeInTheDocument());
+    fireEvent.click(screen.getByText("Regenerate"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Failed: Generation failed")).toBeInTheDocument();
+      expect(screen.getByText("No audio file found")).toBeInTheDocument();
+    });
+    expect(screen.queryByText("Send to Telegram")).not.toBeInTheDocument();
+  });
+
+  it("shows an unknown error when audio generation fails without an error message", async () => {
+    mockGenerateAudio.mockResolvedValue({ ok: false });
+
+    render(<ActionBar activeTab="files" viewingFile={{ path: "/tmp/README.md", name: "README.md" }} />);
+    fireEvent.click(screen.getByText("Audio"));
+
+    await waitFor(() => expect(screen.getByText("Generate Audio")).toBeInTheDocument());
+    fireEvent.click(screen.getByText("Generate Audio"));
+
+    await waitFor(() => expect(screen.getByText("Failed: unknown error")).toBeInTheDocument());
+  });
+
   it("allows a manual retry after automatic sending fails", async () => {
     mockSendAudioTelegram
       .mockResolvedValueOnce({ ok: false, error: "Telegram unavailable" })
@@ -248,6 +277,18 @@ describe("ActionBar", () => {
 
     await waitFor(() => expect(mockSendAudioTelegram).toHaveBeenCalledTimes(2));
     expect(mockSendAudioTelegram).toHaveBeenLastCalledWith("/tmp/audio.ogg", expect.any(AbortSignal));
+  });
+
+  it("shows an unknown error when sending audio fails without an error message", async () => {
+    mockSendAudioTelegram.mockResolvedValue({ ok: false });
+
+    render(<ActionBar activeTab="files" viewingFile={{ path: "/tmp/README.md", name: "README.md" }} />);
+    fireEvent.click(screen.getByText("Audio"));
+
+    await waitFor(() => expect(screen.getByText("Generate Audio")).toBeInTheDocument());
+    fireEvent.click(screen.getByText("Generate Audio"));
+
+    await waitFor(() => expect(screen.getByText("Failed: unknown error")).toBeInTheDocument());
   });
 
   it("hides Reconnect button when onReconnect is not provided", () => {

--- a/apps/web/src/components/__tests__/ActionBar.test.tsx
+++ b/apps/web/src/components/__tests__/ActionBar.test.tsx
@@ -202,16 +202,78 @@ describe("ActionBar", () => {
   });
 
   it("automatically sends generated audio to Telegram exactly once", async () => {
+    let resolveGenerate!: (value: { ok: true; path: string }) => void;
+    let resolveSend!: (value: { ok: true }) => void;
+    mockCheckAudio.mockResolvedValue({ exists: true, path: "/tmp/cached.ogg" });
+    mockGenerateAudio.mockImplementation(() => new Promise((resolve) => { resolveGenerate = resolve; }));
+    mockSendAudioTelegram.mockImplementation(() => new Promise((resolve) => { resolveSend = resolve; }));
+
     render(<ActionBar activeTab="files" viewingFile={{ path: "/tmp/README.md", name: "README.md" }} />);
     fireEvent.click(screen.getByText("Audio"));
 
-    await waitFor(() => expect(screen.getByText("Generate Audio")).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText("Regenerate")).toBeInTheDocument());
+    const generateButton = screen.getByText("Regenerate");
+    const sendButton = screen.getByText("Send to Telegram");
+
+    fireEvent.click(generateButton);
+    fireEvent.click(generateButton);
+    fireEvent.click(sendButton);
+
+    expect(mockGenerateAudio).toHaveBeenCalledTimes(1);
+    expect(mockSendAudioTelegram).not.toHaveBeenCalled();
+
+    await act(async () => {
+      resolveGenerate({ ok: true, path: "/tmp/generated.ogg" });
+    });
+
+    await waitFor(() => {
+      expect(mockSendAudioTelegram).toHaveBeenCalledWith("/tmp/generated.ogg", expect.any(AbortSignal));
+    });
+
+    await act(async () => {
+      resolveSend({ ok: true });
+    });
+
+    await waitFor(() => expect(screen.getByText("Send to Telegram")).toBeInTheDocument());
+    expect(mockSendAudioTelegram).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not let a stale audio check overwrite generated audio", async () => {
+    let resolveStaleCheck!: (value: { exists: true; path: string }) => void;
+    mockCheckAudio
+      .mockImplementationOnce(() => new Promise((resolve) => { resolveStaleCheck = resolve; }))
+      .mockResolvedValueOnce({ exists: false });
+    mockGenerateAudio.mockResolvedValue({ ok: true, path: "/tmp/generated.ogg" });
+
+    const { rerender } = render(
+      <ActionBar activeTab="files" viewingFile={{ path: "/tmp/old.md", name: "old.md" }} />
+    );
+    fireEvent.click(screen.getByText("Audio"));
+    await waitFor(() => expect(mockCheckAudio).toHaveBeenCalledWith("/tmp/old.md"));
+
+    rerender(
+      <ActionBar activeTab="files" viewingFile={{ path: "/tmp/new.md", name: "new.md" }} />
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Audio" }));
+    await waitFor(() => {
+      expect(mockCheckAudio).toHaveBeenCalledWith("/tmp/new.md");
+      expect(screen.getByText("Generate Audio")).toBeInTheDocument();
+    });
     fireEvent.click(screen.getByText("Generate Audio"));
 
     await waitFor(() => {
-      expect(mockSendAudioTelegram).toHaveBeenCalledWith("/tmp/audio.ogg", expect.any(AbortSignal));
+      expect(mockSendAudioTelegram).toHaveBeenCalledWith("/tmp/generated.ogg", expect.any(AbortSignal));
+      expect(screen.getByText("Send to Telegram")).toBeInTheDocument();
     });
-    expect(mockSendAudioTelegram).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveStaleCheck({ exists: true, path: "/tmp/stale-old.ogg" });
+    });
+
+    fireEvent.click(screen.getByText("Send to Telegram"));
+    await waitFor(() => expect(mockSendAudioTelegram).toHaveBeenCalledTimes(2));
+    expect(mockSendAudioTelegram).toHaveBeenLastCalledWith("/tmp/generated.ogg", expect.any(AbortSignal));
+    expect(mockSendAudioTelegram).not.toHaveBeenCalledWith("/tmp/stale-old.ogg", expect.anything());
   });
 
   it("does not send audio to Telegram when generation fails", async () => {

--- a/apps/web/src/components/action-bar/ActionBar.tsx
+++ b/apps/web/src/components/action-bar/ActionBar.tsx
@@ -304,49 +304,9 @@ export function ActionBar({ onReconnect, onFitScreen, fitResult, connected, acti
       }
     }
   };
-  const handleGenerateAudio = async (filePath: string) => {
-    if (audioInFlightRef.current) return;
-    audioInFlightRef.current = true;
-    setAudioLoading(true);
-    setAudioOp("generating");
-    setStatus("Generating audio...");
-    try {
-      const controller = new AbortController();
-      const timeout = setTimeout(() => controller.abort(), 60000);
-      try {
-        const data = await generateAudio(filePath, controller.signal);
-        if (data.ok) {
-          haptic.success();
-          setAudioStatus({ exists: true, path: data.path });
-          setStatus("Audio generated");
-        } else {
-          haptic.error();
-          setStatus(`Failed: ${data.error}`);
-        }
-      } finally {
-        // clearTimeout in finally so a thrown fetch doesn't leave the
-        // 60s timeout dangling and accumulating. (Copilot round-3 review.)
-        clearTimeout(timeout);
-      }
-    } catch (err) {
-      haptic.error();
-      setStatus(
-        err instanceof DOMException && err.name === "AbortError"
-          ? "Timed out"
-          : `Error: ${err instanceof Error ? err.message : String(err)}`
-      );
-    } finally {
-      audioInFlightRef.current = false;
-      setAudioOp("idle");
-      setAudioLoading(false);
-    }
-  };
-  const handleSendAudio = async (audioPath: string) => {
-    if (audioInFlightRef.current) return;
-    audioInFlightRef.current = true;
-    setAudioLoading(true);
+  const sendAudio = async (audioPath: string, pendingStatus = "Sending to Telegram...") => {
     setAudioOp("sending");
-    setStatus("Sending to Telegram...");
+    setStatus(pendingStatus);
     try {
       const controller = new AbortController();
       const timeout = setTimeout(() => controller.abort(), 30000);
@@ -371,6 +331,52 @@ export function ActionBar({ onReconnect, onFitScreen, fitResult, connected, acti
           ? "Timed out"
           : `Error: ${err instanceof Error ? err.message : String(err)}`
       );
+    }
+  };
+  const handleGenerateAudio = async (filePath: string) => {
+    if (audioInFlightRef.current) return;
+    audioInFlightRef.current = true;
+    setAudioLoading(true);
+    setAudioOp("generating");
+    setStatus("Generating audio...");
+    try {
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), 60000);
+      let data: Awaited<ReturnType<typeof generateAudio>>;
+      try {
+        data = await generateAudio(filePath, controller.signal);
+      } finally {
+        // clearTimeout in finally so a thrown fetch doesn't leave the
+        // 60s timeout dangling and accumulating. (Copilot round-3 review.)
+        clearTimeout(timeout);
+      }
+      if (data.ok && data.path) {
+        haptic.success();
+        setAudioStatus({ exists: true, path: data.path });
+        await sendAudio(data.path, "Audio generated — sending to Telegram…");
+      } else {
+        haptic.error();
+        setStatus(`Failed: ${data.error}`);
+      }
+    } catch (err) {
+      haptic.error();
+      setStatus(
+        err instanceof DOMException && err.name === "AbortError"
+          ? "Timed out"
+          : `Error: ${err instanceof Error ? err.message : String(err)}`
+      );
+    } finally {
+      audioInFlightRef.current = false;
+      setAudioOp("idle");
+      setAudioLoading(false);
+    }
+  };
+  const handleSendAudio = async (audioPath: string) => {
+    if (audioInFlightRef.current) return;
+    audioInFlightRef.current = true;
+    setAudioLoading(true);
+    try {
+      await sendAudio(audioPath);
     } finally {
       audioInFlightRef.current = false;
       setAudioOp("idle");

--- a/apps/web/src/components/action-bar/ActionBar.tsx
+++ b/apps/web/src/components/action-bar/ActionBar.tsx
@@ -317,7 +317,7 @@ export function ActionBar({ onReconnect, onFitScreen, fitResult, connected, acti
           setStatus("Sent to Telegram");
         } else {
           haptic.error();
-          setStatus(`Failed: ${data.error}`);
+          setStatus(`Failed: ${data.error || "unknown error"}`);
         }
       } finally {
         // clearTimeout in finally so a thrown fetch doesn't leave the
@@ -336,6 +336,7 @@ export function ActionBar({ onReconnect, onFitScreen, fitResult, connected, acti
   const handleGenerateAudio = async (filePath: string) => {
     if (audioInFlightRef.current) return;
     audioInFlightRef.current = true;
+    setAudioStatus(null);
     setAudioLoading(true);
     setAudioOp("generating");
     setStatus("Generating audio...");
@@ -356,7 +357,7 @@ export function ActionBar({ onReconnect, onFitScreen, fitResult, connected, acti
         await sendAudio(data.path, "Audio generated — sending to Telegram…");
       } else {
         haptic.error();
-        setStatus(`Failed: ${data.error}`);
+        setStatus(`Failed: ${data.error || (data.ok ? "Missing audio path" : "unknown error")}`);
       }
     } catch (err) {
       haptic.error();

--- a/apps/web/src/components/action-bar/ActionBar.tsx
+++ b/apps/web/src/components/action-bar/ActionBar.tsx
@@ -68,6 +68,10 @@ export function ActionBar({ onReconnect, onFitScreen, fitResult, connected, acti
   // click handler, so a ref-based lock is the only way to prevent two
   // concurrent backend audio jobs racing each other.
   const audioInFlightRef = useRef(false);
+  // Monotonically versions cache checks so a response from an older sheet
+  // open/file cannot overwrite the state established by a newer check or by
+  // the generate-and-send chain.
+  const audioCheckSeqRef = useRef(0);
   const [gitBranch, setGitBranch] = useState<GitBranch | null>(null);
   const searchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const searchAbortRef = useRef<AbortController | null>(null);
@@ -283,6 +287,7 @@ export function ActionBar({ onReconnect, onFitScreen, fitResult, connected, acti
   }, [searchCurrentFolderOnly, currentFolder, modal]);
 
   const handleCheckAudio = async (filePath: string) => {
+    const seq = ++audioCheckSeqRef.current;
     // If a generate or send is already in-flight, don't clobber its
     // loading/op state with a check — just show the in-progress panel.
     if (audioInFlightRef.current) return;
@@ -291,14 +296,18 @@ export function ActionBar({ onReconnect, onFitScreen, fitResult, connected, acti
     setAudioOp("checking");
     try {
       const status = await checkAudio(filePath);
-      // Guard: if generate/send started while check was in-flight, don't
-      // overwrite their loading/op state with a stale check result.
+      // Guards: a newer check (or the generate chain, which bumps the seq)
+      // owns the UI now — a stale result must not overwrite it. Same for a
+      // generate/send that started while this check was in-flight.
+      if (seq !== audioCheckSeqRef.current) return;
       if (!audioInFlightRef.current) setAudioStatus(status);
     } catch {
+      if (seq !== audioCheckSeqRef.current) return;
       if (!audioInFlightRef.current) setAudioStatus(null);
     } finally {
-      // Only clear loading if no generate/send started while we were checking
-      if (!audioInFlightRef.current) {
+      // Only clear loading if this check still owns the UI and no
+      // generate/send started while we were checking.
+      if (seq === audioCheckSeqRef.current && !audioInFlightRef.current) {
         setAudioOp("idle");
         setAudioLoading(false);
       }
@@ -334,6 +343,7 @@ export function ActionBar({ onReconnect, onFitScreen, fitResult, connected, acti
     }
   };
   const handleGenerateAudio = async (filePath: string) => {
+    ++audioCheckSeqRef.current;
     if (audioInFlightRef.current) return;
     audioInFlightRef.current = true;
     setAudioStatus(null);


### PR DESCRIPTION
## Summary
- On audio-gen success the app now auto-posts to Telegram (same payload as the manual button — the doc deep link, courtesy of #274) instead of requiring a second tap.
- Send core extracted into a shared `sendAudio` helper used by both the auto-chain and the manual button so the paths can't drift; the chain runs **inside the same `audioInFlightRef` window**, making double-send structurally impossible (the manual button is unreachable while in-flight).
- Failed auto-send keeps `audioStatus` populated: the modal shows the generated file with *Send to Telegram* as the retry path.
- Generate/send keep their independent 60s/30s timeout semantics. Server untouched.

## Tests
Three new tests: auto-send fires exactly once with the generated path; generation failure sends nothing; manual retry works after auto-send failure. Suite: 52/52 ActionBar tests, typecheck + vite build clean (independently re-run by the orchestrating agent).

Fixes #275
Depends on #274 (merged, ed9a504). Part of the dev-cpc-features integration group.

🤖 Generated with [Claude Code](https://claude.com/claude-code)