### PR TITLE
fix(terminal): locale-proof tmux session listing (#246)

### DIFF
--- a/apps/server/src/routes/__tests__/terminal-sessions.test.ts
+++ b/apps/server/src/routes/__tests__/terminal-sessions.test.ts
@@ -125,6 +125,30 @@ describe("parseSessions", () => {
     expect(sessions.map((s) => s.name)).toEqual(["ok-name"]);
   });
 
+  it("drops list rows with extra fields instead of spoofing a real session", () => {
+    const sessions = parseSessions(
+      "real|0|100\nreal|1|9999999999|0|100",
+      "real|bash",
+      "claudes-world",
+    );
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0]).toMatchObject({ name: "real", attached: false, activity: 100 });
+  });
+
+  it("keeps the real command when its pane row precedes a pipe-name impostor", () => {
+    const sessions = parseSessions(
+      "real|0|100",
+      "real|bash\nreal|x|claude",
+      "claudes-world",
+    );
+    expect(sessions[0].command).toBe("bash");
+  });
+
+  it("ignores pane rows whose first-split name fails the allowlist", () => {
+    const sessions = parseSessions("real|0|100", "real;garbage|claude", "claudes-world");
+    expect(sessions[0].command).toBe("");
+  });
+
   it("treats a session with no pane rows as not alive", () => {
     const sessions = parseSessions("ghost|0|1", "", "claudes-world");
     expect(sessions[0].alive).toBe(false);

--- a/apps/server/src/routes/__tests__/terminal-sessions.test.ts
+++ b/apps/server/src/routes/__tests__/terminal-sessions.test.ts
@@ -28,20 +28,20 @@ const execFileMock = vi.fn((...fnArgs: any[]) => {
   let stdout = "";
   if (args[0] === "list-sessions") {
     stdout = [
-      "_tmux-server-keepalive\t0\t1751900000",
-      "claudes-world\t1\t1751900100",
-      "do-box--lane-a\t0\t1751900300",
-      "do-box--lane-b\t0\t1751900200",
-      "bad;name\t0\t1751900400",
+      "_tmux-server-keepalive|0|1751900000",
+      "claudes-world|1|1751900100",
+      "do-box--lane-a|0|1751900300",
+      "do-box--lane-b|0|1751900200",
+      "bad;name|0|1751900400",
     ].join("\n") + "\n";
   } else if (args[0] === "list-panes") {
     stdout = [
-      "_tmux-server-keepalive\tsh",
-      "claudes-world\tclaude",
+      "_tmux-server-keepalive|sh",
+      "claudes-world|claude",
       // Two panes for lane-a — the FIRST row must win.
-      "do-box--lane-a\tclaude",
-      "do-box--lane-a\tbash",
-      "do-box--lane-b\tbash",
+      "do-box--lane-a|claude",
+      "do-box--lane-a|bash",
+      "do-box--lane-b|bash",
     ].join("\n") + "\n";
   }
   callback?.(null, { stdout, stderr: "" });
@@ -69,14 +69,14 @@ beforeEach(() => {
 
 describe("parseSessions", () => {
   const LIST = [
-    "claudes-world\t1\t100",
-    "do-box--lane-a\t0\t300",
-    "do-box--lane-b\t0\t200",
+    "claudes-world|1|100",
+    "do-box--lane-a|0|300",
+    "do-box--lane-b|0|200",
   ].join("\n");
   const PANES = [
-    "claudes-world\tclaude",
-    "do-box--lane-a\tclaude",
-    "do-box--lane-b\tbash",
+    "claudes-world|claude",
+    "do-box--lane-a|claude",
+    "do-box--lane-b|bash",
   ].join("\n");
 
   it("maps fields, marks the default writable, sorts default-first then activity desc", () => {
@@ -106,8 +106,8 @@ describe("parseSessions", () => {
 
   it("uses the FIRST pane row per session (lowest window/pane index)", () => {
     const sessions = parseSessions(
-      "s1\t0\t1",
-      "s1\tclaude\ns1\tbash",
+      "s1|0|1",
+      "s1|claude\ns1|bash",
       "claudes-world",
     );
     expect(sessions[0].command).toBe("claude");
@@ -115,20 +115,27 @@ describe("parseSessions", () => {
   });
 
   it("hides _-prefixed infra sessions", () => {
-    const sessions = parseSessions("_keepalive\t0\t1\nreal\t0\t2", "", "claudes-world");
+    const sessions = parseSessions("_keepalive|0|1\nreal|0|2", "", "claudes-world");
     expect(sessions.map((s) => s.name)).toEqual(["real"]);
   });
 
   it("drops names that fail the session-name allowlist", () => {
     // A name we'd refuse to poll must never be offered to the client.
-    const sessions = parseSessions("bad;name\t0\t1\nok-name\t0\t2", "", "claudes-world");
+    const sessions = parseSessions("bad;name|0|1\nok-name|0|2", "", "claudes-world");
     expect(sessions.map((s) => s.name)).toEqual(["ok-name"]);
   });
 
   it("treats a session with no pane rows as not alive", () => {
-    const sessions = parseSessions("ghost\t0\t1", "", "claudes-world");
+    const sessions = parseSessions("ghost|0|1", "", "claudes-world");
     expect(sessions[0].alive).toBe(false);
     expect(sessions[0].command).toBe("");
+  });
+
+  it("uses a printable locale-safe separator and preserves separators in pane commands", () => {
+    // "|" is outside SESSION_NAME_RE's allowed charset, while pane commands
+    // are unconstrained and therefore must be split on the first "|" only.
+    const sessions = parseSessions("safe-name|0|1", "safe-name|command|with|pipes", "claudes-world");
+    expect(sessions[0].command).toBe("command|with|pipes");
   });
 });
 
@@ -149,6 +156,8 @@ describe("GET /sessions", () => {
     expect(body.sessions.map((s: any) => s.name)).not.toContain("_tmux-server-keepalive");
     // argv discipline: both tmux calls go through execFile with arrays.
     expect(execFileCalls.map((c) => c.args[0]).sort()).toEqual(["list-panes", "list-sessions"]);
+    const formats = execFileCalls.map((c) => c.args.at(-1));
+    expect(formats.every((format) => format?.includes("|") && !format.includes("\t"))).toBe(true);
   });
 
   it("returns 500 ok:false when tmux has no server running", async () => {

--- a/apps/server/src/routes/terminal/sessions.ts
+++ b/apps/server/src/routes/terminal/sessions.ts
@@ -14,6 +14,11 @@ const TMUX_TIMEOUT_MS = 5_000;
 // never useful to view from the mini app.
 const HIDDEN_SESSION_PREFIX = "_";
 
+// tmux replaces non-printable format characters (including tabs) with "_"
+// under a non-UTF-8 locale. "|" is printable and cannot occur in a session
+// name accepted by SESSION_NAME_RE, so its output is locale-independent.
+const TMUX_FIELD_SEPARATOR = "|";
+
 // A pane whose foreground process is a bare shell means the agent that was
 // running there has exited — same liveness heuristic as the fleet cockpit
 // collector (world-os apps/cpc/cockpit/lib/collector.mjs).
@@ -49,14 +54,16 @@ export function parseSessions(listOut: string, panesOut: string, defaultSession:
   const firstPaneCommand = new Map<string, string>();
   for (const line of panesOut.split("\n")) {
     if (!line) continue;
-    const [name, command = ""] = line.split("\t");
+    const separatorIndex = line.indexOf(TMUX_FIELD_SEPARATOR);
+    const name = separatorIndex === -1 ? line : line.slice(0, separatorIndex);
+    const command = separatorIndex === -1 ? "" : line.slice(separatorIndex + 1);
     if (name && !firstPaneCommand.has(name)) firstPaneCommand.set(name, command);
   }
 
   const sessions: TmuxSessionInfo[] = [];
   for (const line of listOut.split("\n")) {
     if (!line) continue;
-    const [name, attached = "0", activity = "0"] = line.split("\t");
+    const [name, attached = "0", activity = "0"] = line.split(TMUX_FIELD_SEPARATOR);
     if (!name || name.startsWith(HIDDEN_SESSION_PREFIX) || !SESSION_NAME_RE.test(name)) continue;
     const command = firstPaneCommand.get(name) ?? "";
     sessions.push({
@@ -92,12 +99,12 @@ app.get("/sessions", async (c) => {
     const [list, panes] = await Promise.all([
       execFileAsync(
         "tmux",
-        ["list-sessions", "-F", "#{session_name}\t#{session_attached}\t#{session_activity}"],
+        ["list-sessions", "-F", `#{session_name}${TMUX_FIELD_SEPARATOR}#{session_attached}${TMUX_FIELD_SEPARATOR}#{session_activity}`],
         { timeout: TMUX_TIMEOUT_MS },
       ),
       execFileAsync(
         "tmux",
-        ["list-panes", "-a", "-F", "#{session_name}\t#{pane_current_command}"],
+        ["list-panes", "-a", "-F", `#{session_name}${TMUX_FIELD_SEPARATOR}#{pane_current_command}`],
         { timeout: TMUX_TIMEOUT_MS },
       ),
     ]);

--- a/apps/server/src/routes/terminal/sessions.ts
+++ b/apps/server/src/routes/terminal/sessions.ts
@@ -57,13 +57,19 @@ export function parseSessions(listOut: string, panesOut: string, defaultSession:
     const separatorIndex = line.indexOf(TMUX_FIELD_SEPARATOR);
     const name = separatorIndex === -1 ? line : line.slice(0, separatorIndex);
     const command = separatorIndex === -1 ? "" : line.slice(separatorIndex + 1);
-    if (name && !firstPaneCommand.has(name)) firstPaneCommand.set(name, command);
+    // tmux sorts `list-panes -a` by session name. Every character allowed by
+    // SESSION_NAME_RE is below "|" (0x7c), so a real session's first pane row
+    // precedes rows from any `real|suffix` impostor; first-wins keeps the real
+    // command even though pane commands must preserve pipes after the first.
+    if (SESSION_NAME_RE.test(name) && !firstPaneCommand.has(name)) firstPaneCommand.set(name, command);
   }
 
   const sessions: TmuxSessionInfo[] = [];
   for (const line of listOut.split("\n")) {
     if (!line) continue;
-    const [name, attached = "0", activity = "0"] = line.split(TMUX_FIELD_SEPARATOR);
+    const fields = line.split(TMUX_FIELD_SEPARATOR);
+    if (fields.length !== 3) continue;
+    const [name, attached, activity] = fields;
     if (!name || name.startsWith(HIDDEN_SESSION_PREFIX) || !SESSION_NAME_RE.test(name)) continue;
     const command = firstPaneCommand.get(name) ?? "";
     sessions.push({


### PR DESCRIPTION
## Bug

`GET /api/terminal/sessions` (landed in PR #291) formats tmux output with literal TABs in the `-F` template. tmux sanitizes non-printable template characters to `_` when the client has **no UTF-8 locale** (C/POSIX), so under e.g. a systemd unit that doesn't set `LANG`, every line comes back fused: `claudes-world_1_1783694214`.

Consequences (all verified empirically on this box, tmux 3.5a):
- session names mangled → picker displays garbage
- `attached`/`activity`/`command` unparseable → `alive:false` everywhere
- no name matches the writable default → no writable session in the list
- tapping a pill feeds the fused name to `?session=` → attaches a nonexistent session

**Prod is currently safe by ambient luck only**: `cpc.service` sets just PORT/NODE_ENV/PATH; the process inherits `LANG=en_US.UTF-8` from the systemd user-manager environment, and prod is still v1.13.0 (pre-#291). This must not ship relying on that inheritance.

## Fix

- Field separator `\t` → `|` (printable ASCII, locale-independent, outside `SESSION_NAME_RE`'s `[A-Za-z0-9_.-]` charset — names containing `|` are already skipped defensively).
- `list-panes` lines split on the **first** `|` only, so `pane_current_command` values containing pipes survive intact (regression-tested).

## Verification

- `apps/server` full suite: **352/352 pass**; sessions file 9/9 incl. new regression tests (locale-safe format assertion + pipe-in-command).
- End-to-end: fixed server started with `env -i` (worst-case locale) returns clean names, correct `writable`/`alive`/`activity`.

Repro of the underlying tmux behavior:
```
env -i PATH="$PATH" HOME="$HOME" node -e '...execFile("tmux",["list-sessions","-F","#{session_name}\t..."]...)'
# → "claudes-world_1_1783694214"   (add LANG=en_US.UTF-8 → tabs preserved)
```

Part of the #246 group (dev-cpc-ui): the session switcher's acceptance criteria depend on this endpoint parsing correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)