### PR TITLE
feat(app): /pm_dobot route — pm-dobot terminal in the mini app (#241 phase 1)

### DIFF
--- a/apps/web/src/lib/__tests__/app-routing.test.ts
+++ b/apps/web/src/lib/__tests__/app-routing.test.ts
@@ -20,6 +20,15 @@ describe("resolveInitialAppState", () => {
     });
   });
 
+  it("resolves /pm_dobot to the pm-dobot terminal session without redirecting", () => {
+    expect(resolveInitialAppState("/pm_dobot", "")).toEqual({
+      tab: "terminal",
+      session: "pm-dobot",
+      file: null,
+      redirectPath: null,
+    });
+  });
+
   it("ignores a foreign Telegram hash when resolving the root redirect", () => {
     expect(resolveInitialAppState("/", "#tgWebAppData=abc&tgWebAppVersion=7")).toEqual({
       tab: "terminal",
@@ -43,6 +52,15 @@ describe("resolveInitialAppState", () => {
       tab: "files",
       session: null,
       file: "/tmp/notes.md",
+      redirectPath: null,
+    });
+  });
+
+  it("lets a hash deep link win over the pm-dobot alias", () => {
+    expect(resolveInitialAppState("/pm_dobot", "#terminal&session=another-session")).toEqual({
+      tab: "terminal",
+      session: "another-session",
+      file: null,
       redirectPath: null,
     });
   });

--- a/apps/web/src/lib/app-routing.ts
+++ b/apps/web/src/lib/app-routing.ts
@@ -7,6 +7,7 @@ type BotPathAlias = Readonly<{
 
 export const BOT_PATH_ALIASES: Readonly<Record<string, BotPathAlias>> = {
   "/claude_do_bot": { tab: "terminal", session: null },
+  "/pm_dobot": { tab: "terminal", session: "pm-dobot" },
 };
 
 const DEFAULT_BOT_PATH = "/claude_do_bot";


### PR DESCRIPTION
## What

Phase 1 (read-only inspection) of #241: `cpc.claude.do/pm_dobot` opens the terminal tab attached to the **pm-dobot** tmux session.

Nearly all of #241 phase 1 landed as infrastructure in PR #291 (multi-session terminal: view-only non-default sessions, restricted palette, server-side session validation) and PR #298 (`BOT_PATH_ALIASES` + landing redirect). This PR is the remaining delta:

- `/pm_dobot` → `{ tab: "terminal", session: "pm-dobot" }` in `BOT_PATH_ALIASES`
- Tests: alias resolution, no redirect for `/pm_dobot`, hash deep links still win over the alias

Auth: same Telegram auth middleware as every alias route (nothing bypasses it). Read-only: non-default sessions get no write palette (from #291). Phase 2 steering widgets are explicitly out of scope.

## Verification

- `apps/web`: 301/301 tests, typecheck + production build pass
- Rendered screenshot of `/pm_dobot` attached in the group thread (visual-proof gate)

Closes #241 phase 1 scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)