### PR TITLE
feat(prs): manage sheet — hide/show, manual reorder, repo collapse persistence (#217, #218)

### DIFF
--- a/apps/web/src/components/ManagePrsSheet.tsx
+++ b/apps/web/src/components/ManagePrsSheet.tsx
@@ -1,6 +1,6 @@
 import { BottomSheet } from "./BottomSheet";
 import { haptic } from "../lib/haptic";
-import { applyOrder, type PrViewPrefs } from "../lib/prViewPrefs";
+import { applyOrder, getRepoOrder, type PrViewPrefs } from "../lib/prViewPrefs";
 
 interface ManagePrsSheetProps {
   orgRepos: Record<string, string[]>;
@@ -47,7 +47,7 @@ export function ManagePrsSheet({ orgRepos, prefs, onChange, onClose }: ManagePrs
       <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
         {orgs.map((org, orgIndex) => {
           const orgHidden = prefs.hiddenOrgs.includes(org);
-          const repos = applyOrder(orgRepos[org] ?? [], prefs.repoOrder[org] ?? []);
+          const repos = applyOrder(orgRepos[org] ?? [], getRepoOrder(prefs, org));
 
           return (
             <div

--- a/apps/web/src/components/ManagePrsSheet.tsx
+++ b/apps/web/src/components/ManagePrsSheet.tsx
@@ -1,0 +1,155 @@
+import { BottomSheet } from "./BottomSheet";
+import { haptic } from "../lib/haptic";
+import { applyOrder, type PrViewPrefs } from "../lib/prViewPrefs";
+
+interface ManagePrsSheetProps {
+  orgRepos: Record<string, string[]>;
+  prefs: PrViewPrefs;
+  onChange: (prefs: PrViewPrefs) => void;
+  onClose: () => void;
+}
+
+function toggleValue(items: string[], value: string): string[] {
+  return items.includes(value) ? items.filter((item) => item !== value) : [...items, value];
+}
+
+function moveValue(items: string[], value: string, offset: -1 | 1): string[] {
+  const index = items.indexOf(value);
+  const nextIndex = index + offset;
+  if (index < 0 || nextIndex < 0 || nextIndex >= items.length) return items;
+  const next = [...items];
+  [next[index], next[nextIndex]] = [next[nextIndex], next[index]];
+  return next;
+}
+
+const iconButtonStyle = {
+  width: 34,
+  height: 30,
+  border: "1px solid var(--color-border)",
+  borderRadius: 7,
+  background: "var(--color-surface)",
+  color: "var(--color-fg)",
+  fontSize: 15,
+  cursor: "pointer",
+  flexShrink: 0,
+};
+
+export function ManagePrsSheet({ orgRepos, prefs, onChange, onClose }: ManagePrsSheetProps) {
+  const orgs = applyOrder(Object.keys(orgRepos), prefs.orgOrder);
+
+  const update = (next: PrViewPrefs) => {
+    haptic.impact("light");
+    onChange(next);
+  };
+
+  return (
+    <BottomSheet onClose={onClose} title="Manage PRs">
+      <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+        {orgs.map((org, orgIndex) => {
+          const orgHidden = prefs.hiddenOrgs.includes(org);
+          const repos = applyOrder(orgRepos[org] ?? [], prefs.repoOrder[org] ?? []);
+
+          return (
+            <div
+              key={org}
+              style={{
+                border: "1px solid var(--color-border)",
+                borderRadius: 10,
+                overflow: "hidden",
+                opacity: orgHidden ? 0.5 : 1,
+              }}
+            >
+              <div style={{ display: "flex", alignItems: "center", gap: 6, padding: "8px 8px 8px 10px", background: "var(--color-surface)" }}>
+                <span style={{ minWidth: 0, flex: 1, fontWeight: 700, color: "var(--color-fg)", overflow: "hidden", textOverflow: "ellipsis" }}>
+                  {org}
+                </span>
+                <button
+                  type="button"
+                  aria-label={`${orgHidden ? "Show" : "Hide"} org ${org}`}
+                  title={`${orgHidden ? "Show" : "Hide"} ${org}`}
+                  onClick={() => update({ ...prefs, hiddenOrgs: toggleValue(prefs.hiddenOrgs, org) })}
+                  style={iconButtonStyle}
+                >
+                  {orgHidden ? "◌" : "👁"}
+                </button>
+                <button
+                  type="button"
+                  aria-label={`Move org ${org} up`}
+                  disabled={orgIndex === 0}
+                  onClick={() => update({ ...prefs, orgOrder: moveValue(orgs, org, -1) })}
+                  style={{ ...iconButtonStyle, opacity: orgIndex === 0 ? 0.3 : 1, cursor: orgIndex === 0 ? "default" : "pointer" }}
+                >
+                  ↑
+                </button>
+                <button
+                  type="button"
+                  aria-label={`Move org ${org} down`}
+                  disabled={orgIndex === orgs.length - 1}
+                  onClick={() => update({ ...prefs, orgOrder: moveValue(orgs, org, 1) })}
+                  style={{ ...iconButtonStyle, opacity: orgIndex === orgs.length - 1 ? 0.3 : 1, cursor: orgIndex === orgs.length - 1 ? "default" : "pointer" }}
+                >
+                  ↓
+                </button>
+              </div>
+
+              {repos.map((repo, repoIndex) => {
+                const repoHidden = prefs.hiddenRepos.includes(repo);
+                const repoShort = repo.split("/")[1] || repo;
+                return (
+                  <div
+                    key={repo}
+                    style={{
+                      display: "flex",
+                      alignItems: "center",
+                      gap: 6,
+                      padding: "7px 8px 7px 20px",
+                      borderTop: "1px solid var(--color-border)",
+                      opacity: repoHidden ? 0.5 : 1,
+                    }}
+                  >
+                    <span style={{ minWidth: 0, flex: 1, color: "var(--color-fg)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                      {repoShort}
+                    </span>
+                    <button
+                      type="button"
+                      aria-label={`${repoHidden ? "Show" : "Hide"} repo ${repo}`}
+                      title={`${repoHidden ? "Show" : "Hide"} ${repoShort}`}
+                      onClick={() => update({ ...prefs, hiddenRepos: toggleValue(prefs.hiddenRepos, repo) })}
+                      style={iconButtonStyle}
+                    >
+                      {repoHidden ? "◌" : "👁"}
+                    </button>
+                    <button
+                      type="button"
+                      aria-label={`Move repo ${repo} up`}
+                      disabled={repoIndex === 0}
+                      onClick={() => update({
+                        ...prefs,
+                        repoOrder: { ...prefs.repoOrder, [org]: moveValue(repos, repo, -1) },
+                      })}
+                      style={{ ...iconButtonStyle, opacity: repoIndex === 0 ? 0.3 : 1, cursor: repoIndex === 0 ? "default" : "pointer" }}
+                    >
+                      ↑
+                    </button>
+                    <button
+                      type="button"
+                      aria-label={`Move repo ${repo} down`}
+                      disabled={repoIndex === repos.length - 1}
+                      onClick={() => update({
+                        ...prefs,
+                        repoOrder: { ...prefs.repoOrder, [org]: moveValue(repos, repo, 1) },
+                      })}
+                      style={{ ...iconButtonStyle, opacity: repoIndex === repos.length - 1 ? 0.3 : 1, cursor: repoIndex === repos.length - 1 ? "default" : "pointer" }}
+                    >
+                      ↓
+                    </button>
+                  </div>
+                );
+              })}
+            </div>
+          );
+        })}
+      </div>
+    </BottomSheet>
+  );
+}

--- a/apps/web/src/components/PrTicker.tsx
+++ b/apps/web/src/components/PrTicker.tsx
@@ -1,6 +1,14 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import { getAuthHeaders } from "../lib/telegram";
 import { haptic } from "../lib/haptic";
+import { ManagePrsSheet } from "./ManagePrsSheet";
+import {
+  applyOrder,
+  filterHidden,
+  loadPrViewPrefs,
+  savePrViewPrefs,
+  type PrViewPrefs,
+} from "../lib/prViewPrefs";
 
 // --- Types matching server PrRow ---
 
@@ -161,6 +169,8 @@ export function PrTicker() {
   const [prs, setPrs] = useState<PrRow[]>([]);
   const [repos, setRepos] = useState<RepoSummary[]>([]);
   const [collapsedOrgs, setCollapsedOrgs] = useState<Set<string>>(loadCollapsedOrgs);
+  const [prefs, setPrefs] = useState<PrViewPrefs>(loadPrViewPrefs);
+  const [manageOpen, setManageOpen] = useState(false);
   const [loading, setLoading] = useState(true);
   const [lastPollAt, setLastPollAt] = useState<number>(0);
   const [pollError, setPollError] = useState<string | null>(null);
@@ -169,6 +179,7 @@ export function PrTicker() {
   const mountedRef = useRef(true);
 
   const toggleOrg = useCallback((org: string) => {
+    haptic.impact("light");
     setCollapsedOrgs((prev) => {
       const next = new Set(prev);
       if (next.has(org)) {
@@ -179,6 +190,23 @@ export function PrTicker() {
       saveCollapsedOrgs(next);
       return next;
     });
+  }, []);
+
+  const toggleRepo = useCallback((repo: string) => {
+    haptic.impact("light");
+    setPrefs((prev) => {
+      const collapsedRepos = prev.collapsedRepos.includes(repo)
+        ? prev.collapsedRepos.filter((item) => item !== repo)
+        : [...prev.collapsedRepos, repo];
+      const next = { ...prev, collapsedRepos };
+      savePrViewPrefs(next);
+      return next;
+    });
+  }, []);
+
+  const handlePrefsChange = useCallback((next: PrViewPrefs) => {
+    savePrViewPrefs(next);
+    setPrefs(next);
   }, []);
 
   const fetchPrs = useCallback(async () => {
@@ -246,9 +274,17 @@ export function PrTicker() {
   }, [fetchPrs]);
 
   const grouped = groupPrs(prs, repos);
-  const orgNames = Object.keys(grouped).sort();
-  const totalPrs = prs.length;
-  const totalRepos = repos.length;
+  const visibleGrouped = filterHidden(grouped, prefs);
+  const orgNames = applyOrder(Object.keys(visibleGrouped), prefs.orgOrder);
+  const totalPrs = orgNames.reduce(
+    (orgTotal, org) => orgTotal + Object.values(visibleGrouped[org]).reduce((repoTotal, repo) => repoTotal + repo.prs.length, 0),
+    0,
+  );
+  const totalRepos = orgNames.reduce((total, org) => total + Object.keys(visibleGrouped[org]).length, 0);
+  const hiddenCount = prefs.hiddenOrgs.length + prefs.hiddenRepos.length;
+  const manageOrgRepos = Object.fromEntries(
+    Object.entries(grouped).map(([org, repoMap]) => [org, Object.keys(repoMap)]),
+  );
 
   const pollAgoSec = lastPollAt ? Math.floor((Date.now() - lastPollAt) / 1000) : 0;
 
@@ -285,9 +321,30 @@ export function PrTicker() {
         <span style={{ fontSize: 12, color: COLORS.textMuted }}>
           {totalRepos} repos
         </span>
+        {hiddenCount > 0 && (
+          <span style={{ fontSize: 10, color: COLORS.textMuted }}>
+            {hiddenCount} hidden
+          </span>
+        )}
         <div style={{ marginLeft: "auto", display: "flex", alignItems: "center", gap: 6 }}>
           <button
-            onClick={() => void handleRefresh()}
+            type="button"
+            aria-label="Manage PR view"
+            onClick={() => { haptic.impact("light"); setManageOpen(true); }}
+            style={{
+              background: "none",
+              border: "none",
+              color: COLORS.textMuted,
+              cursor: "pointer",
+              padding: "2px 4px",
+              fontSize: 14,
+            }}
+            title="Manage PR view"
+          >
+            ⚙
+          </button>
+          <button
+            onClick={() => { haptic.impact("light"); void handleRefresh(); }}
             disabled={refreshing}
             style={{
               background: "none",
@@ -338,7 +395,7 @@ export function PrTicker() {
           }}>
             Loading PRs...
           </div>
-        ) : orgNames.length === 0 ? (
+        ) : Object.keys(grouped).length === 0 ? (
           <div style={{
             display: "flex",
             alignItems: "center",
@@ -351,14 +408,30 @@ export function PrTicker() {
           }}>
             No repos discovered
           </div>
+        ) : orgNames.length === 0 ? (
+          <div style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            height: "100%",
+            color: COLORS.textMuted,
+            fontSize: 14,
+            padding: 20,
+            textAlign: "center",
+          }}>
+            No repos visible
+          </div>
         ) : (
           orgNames.map((org) => (
             <OrgSection
               key={org}
               org={org}
-              repoMap={grouped[org]}
+              repoMap={visibleGrouped[org]}
+              repoOrder={prefs.repoOrder[org] ?? []}
               collapsed={collapsedOrgs.has(org)}
+              collapsedRepos={prefs.collapsedRepos}
               onToggle={() => toggleOrg(org)}
+              onToggleRepo={toggleRepo}
               onTapPr={openPr}
             />
           ))
@@ -391,6 +464,15 @@ export function PrTicker() {
           {" "}{pollError ? "degraded" : "live"}
         </span>
       </div>
+
+      {manageOpen && (
+        <ManagePrsSheet
+          orgRepos={manageOrgRepos}
+          prefs={prefs}
+          onChange={handlePrefsChange}
+          onClose={() => setManageOpen(false)}
+        />
+      )}
     </div>
   );
 }
@@ -400,17 +482,23 @@ export function PrTicker() {
 function OrgSection({
   org,
   repoMap,
+  repoOrder,
   collapsed,
+  collapsedRepos,
   onToggle,
+  onToggleRepo,
   onTapPr,
 }: {
   org: string;
   repoMap: Record<string, { branch: string; prs: PrRow[] }>;
+  repoOrder: string[];
   collapsed: boolean;
+  collapsedRepos: string[];
   onToggle: () => void;
+  onToggleRepo: (repo: string) => void;
   onTapPr: (url: string) => void;
 }) {
-  const repoNames = Object.keys(repoMap).sort();
+  const repoNames = applyOrder(Object.keys(repoMap), repoOrder);
   const totalPrs = repoNames.reduce((sum, r) => sum + repoMap[r].prs.length, 0);
 
   return (
@@ -444,18 +532,27 @@ function OrgSection({
       {!collapsed && repoNames.map((repoFullName) => {
         const { branch, prs } = repoMap[repoFullName];
         const repoShort = repoFullName.split("/")[1] || repoFullName;
+        const repoCollapsed = collapsedRepos.includes(repoFullName);
 
         return (
           <div key={repoFullName}>
             {/* Repo subheading */}
-            <div style={{
-              display: "flex",
-              alignItems: "center",
-              gap: 6,
-              padding: "6px 12px 6px 24px",
-              borderBottom: `1px solid ${COLORS.border}`,
-              fontSize: 12,
-            }}>
+            <div
+              onClick={() => onToggleRepo(repoFullName)}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 6,
+                padding: "6px 12px 6px 24px",
+                borderBottom: `1px solid ${COLORS.border}`,
+                fontSize: 12,
+                cursor: "pointer",
+                userSelect: "none",
+              }}
+            >
+              <span style={{ fontSize: 10, color: COLORS.textMuted, width: 10, textAlign: "center" }}>
+                {repoCollapsed ? "\u25b6" : "\u25bc"}
+              </span>
               <span style={{ fontWeight: 600, color: COLORS.text }}>
                 {repoShort}
               </span>
@@ -481,7 +578,7 @@ function OrgSection({
             </div>
 
             {/* PR rows or empty state */}
-            {prs.length === 0 ? (
+            {!repoCollapsed && (prs.length === 0 ? (
               <div style={{
                 padding: "8px 12px 8px 36px",
                 fontSize: 12,
@@ -495,7 +592,7 @@ function OrgSection({
               prs.map((pr) => (
                 <PrRowItem key={pr.key} pr={pr} onTap={onTapPr} />
               ))
-            )}
+            ))}
           </div>
         );
       })}

--- a/apps/web/src/components/PrTicker.tsx
+++ b/apps/web/src/components/PrTicker.tsx
@@ -5,6 +5,7 @@ import { ManagePrsSheet } from "./ManagePrsSheet";
 import {
   applyOrder,
   filterHidden,
+  getRepoOrder,
   loadPrViewPrefs,
   savePrViewPrefs,
   type PrViewPrefs,
@@ -427,7 +428,7 @@ export function PrTicker() {
               key={org}
               org={org}
               repoMap={visibleGrouped[org]}
-              repoOrder={prefs.repoOrder[org] ?? []}
+              repoOrder={getRepoOrder(prefs, org)}
               collapsed={collapsedOrgs.has(org)}
               collapsedRepos={prefs.collapsedRepos}
               onToggle={() => toggleOrg(org)}

--- a/apps/web/src/components/__tests__/ManagePrsSheet.test.tsx
+++ b/apps/web/src/components/__tests__/ManagePrsSheet.test.tsx
@@ -1,0 +1,57 @@
+import { useState } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { ManagePrsSheet } from "../ManagePrsSheet";
+import type { PrViewPrefs } from "../../lib/prViewPrefs";
+
+const initialPrefs: PrViewPrefs = {
+  orgOrder: [],
+  repoOrder: {},
+  hiddenOrgs: [],
+  hiddenRepos: [],
+  collapsedRepos: [],
+};
+
+function Harness({ onChange = () => {} }: { onChange?: (prefs: PrViewPrefs) => void }) {
+  const [prefs, setPrefs] = useState(initialPrefs);
+  return (
+    <ManagePrsSheet
+      orgRepos={{
+        alpha: ["alpha/one", "alpha/two"],
+        beta: ["beta/one"],
+      }}
+      prefs={prefs}
+      onChange={(next) => {
+        onChange(next);
+        setPrefs(next);
+      }}
+      onClose={() => {}}
+    />
+  );
+}
+
+describe("ManagePrsSheet", () => {
+  it("toggles visibility and renders hidden rows dimmed", () => {
+    const onChange = vi.fn();
+    render(<Harness onChange={onChange} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Hide repo alpha/two" }));
+
+    expect(onChange).toHaveBeenLastCalledWith(expect.objectContaining({ hiddenRepos: ["alpha/two"] }));
+    expect(screen.getByRole("button", { name: "Show repo alpha/two" })).toBeInTheDocument();
+    expect(screen.getByText("two").parentElement).toHaveStyle({ opacity: "0.5" });
+  });
+
+  it("moves orgs and repos with arrow buttons", () => {
+    const onChange = vi.fn();
+    render(<Harness onChange={onChange} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Move org beta up" }));
+    expect(onChange).toHaveBeenLastCalledWith(expect.objectContaining({ orgOrder: ["beta", "alpha"] }));
+
+    fireEvent.click(screen.getByRole("button", { name: "Move repo alpha/two up" }));
+    expect(onChange).toHaveBeenLastCalledWith(expect.objectContaining({
+      repoOrder: { alpha: ["alpha/two", "alpha/one"] },
+    }));
+  });
+});

--- a/apps/web/src/components/__tests__/PrTicker.test.tsx
+++ b/apps/web/src/components/__tests__/PrTicker.test.tsx
@@ -7,6 +7,7 @@ import { PrTicker } from "../PrTicker";
 // Mock the telegram auth module
 vi.mock("../../lib/telegram", () => ({
   getAuthHeaders: () => ({ Authorization: "tma test-init-data" }),
+  getTelegramWebApp: () => null,
 }));
 
 // Mock localStorage
@@ -326,5 +327,91 @@ describe("PrTicker", () => {
       expect(screen.getByText("#1")).toBeInTheDocument();
       expect(screen.getByText("#2")).toBeInTheDocument();
     });
+  });
+
+  it("hides a repo from the main list through the manage sheet", async () => {
+    const inboxPr = makePr({ number: 1, title: "Inbox PR", key: "claudes-world/inbox#1" });
+    const cpcPr = makePr({
+      number: 2,
+      title: "CPC PR",
+      repo: "claudes-world/claude-pocket-console",
+      key: "claudes-world/claude-pocket-console#2",
+    });
+    const inbox = makeRepo({ prCount: 1 });
+    const cpc = makeRepo({ name: "claude-pocket-console", fullName: "claudes-world/claude-pocket-console", prCount: 1 });
+
+    fetchMock.mockImplementation(async (url: string) => {
+      if (url === "/api/prs") {
+        return {
+          ok: true,
+          json: async () => ({ ok: true, prs: [inboxPr, cpcPr], repos: [inbox, cpc], lastPollOk: Date.now() }),
+        };
+      }
+      return { ok: true, json: async () => ({}) };
+    });
+
+    render(<PrTicker />);
+    await waitFor(() => expect(screen.getByText("CPC PR")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole("button", { name: "Manage PR view" }));
+    fireEvent.click(screen.getByRole("button", { name: "Hide repo claudes-world/claude-pocket-console" }));
+
+    await waitFor(() => {
+      expect(screen.queryByText("CPC PR")).not.toBeInTheDocument();
+      expect(screen.getByText("Inbox PR")).toBeInTheDocument();
+      expect(screen.getByText("1 hidden")).toBeInTheDocument();
+      expect(screen.getByText("1 repos")).toBeInTheDocument();
+    });
+  });
+
+  it("applies org reordering from the manage sheet to the main list", async () => {
+    const alphaRepo = makeRepo({ name: "one", org: "alpha", fullName: "alpha/one" });
+    const zetaRepo = makeRepo({ name: "two", org: "zeta", fullName: "zeta/two" });
+
+    fetchMock.mockImplementation(async (url: string) => {
+      if (url === "/api/prs") {
+        return {
+          ok: true,
+          json: async () => ({ ok: true, prs: [], repos: [alphaRepo, zetaRepo], lastPollOk: Date.now() }),
+        };
+      }
+      return { ok: true, json: async () => ({}) };
+    });
+
+    render(<PrTicker />);
+    await waitFor(() => expect(screen.getByText("alpha")).toBeInTheDocument());
+    fireEvent.click(screen.getByRole("button", { name: "Manage PR view" }));
+    fireEvent.click(screen.getByRole("button", { name: "Move org zeta up" }));
+
+    const mainAlpha = screen.getAllByText("alpha")[0];
+    const mainZeta = screen.getAllByText("zeta")[0];
+    expect(mainZeta.compareDocumentPosition(mainAlpha) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it("persists repo collapse across remounts", async () => {
+    const pr = makePr({ number: 7, title: "Persisted collapse", key: "claudes-world/inbox#7" });
+    const repo = makeRepo({ prCount: 1 });
+    fetchMock.mockImplementation(async (url: string) => {
+      if (url === "/api/prs") {
+        return {
+          ok: true,
+          json: async () => ({ ok: true, prs: [pr], repos: [repo], lastPollOk: Date.now() }),
+        };
+      }
+      return { ok: true, json: async () => ({}) };
+    });
+
+    const first = render(<PrTicker />);
+    await waitFor(() => expect(screen.getByText("Persisted collapse")).toBeInTheDocument());
+    fireEvent.click(screen.getByText("inbox"));
+    await waitFor(() => expect(screen.queryByText("Persisted collapse")).not.toBeInTheDocument());
+
+    expect(JSON.parse(localStorageMock.getItem("cpc-pr-view-prefs") ?? "{}").collapsedRepos)
+      .toEqual(["claudes-world/inbox"]);
+
+    first.unmount();
+    render(<PrTicker />);
+    await waitFor(() => expect(screen.getByText("inbox")).toBeInTheDocument());
+    expect(screen.queryByText("Persisted collapse")).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/__tests__/PrTicker.test.tsx
+++ b/apps/web/src/components/__tests__/PrTicker.test.tsx
@@ -115,6 +115,31 @@ describe("PrTicker", () => {
     });
   });
 
+  it("renders an org named constructor without a saved repo order", async () => {
+    const repo = makeRepo({
+      name: "repo",
+      org: "constructor",
+      fullName: "constructor/repo",
+      prCount: 0,
+    });
+    fetchMock.mockImplementation(async (url: string) => {
+      if (url === "/api/prs") {
+        return {
+          ok: true,
+          json: async () => ({ ok: true, prs: [], repos: [repo], lastPollOk: Date.now() }),
+        };
+      }
+      return { ok: true, json: async () => ({}) };
+    });
+
+    render(<PrTicker />);
+
+    await waitFor(() => {
+      expect(screen.getByText("constructor")).toBeInTheDocument();
+      expect(screen.getByText("repo")).toBeInTheDocument();
+    });
+  });
+
   it("renders PR rows grouped by org and repo", async () => {
     const pr1 = makePr({ number: 42, title: "Fix the widget", headRefName: "fix/widget", repo: "claudes-world/inbox", key: "claudes-world/inbox#42" });
     const pr2 = makePr({ number: 43, title: "Add feature X", headRefName: "feat/x", repo: "claudes-world/claude-pocket-console", key: "claudes-world/claude-pocket-console#43" });

--- a/apps/web/src/lib/__tests__/prViewPrefs.test.ts
+++ b/apps/web/src/lib/__tests__/prViewPrefs.test.ts
@@ -3,6 +3,7 @@ import {
   PR_VIEW_PREFS_KEY,
   applyOrder,
   filterHidden,
+  getRepoOrder,
   loadPrViewPrefs,
   savePrViewPrefs,
   type PrViewPrefs,
@@ -24,6 +25,17 @@ describe("PR view preference helpers", () => {
   it("applies saved values first and appends unknown values alphabetically", () => {
     expect(applyOrder(["gamma", "alpha", "delta", "beta"], ["beta", "missing", "beta"]))
       .toEqual(["beta", "alpha", "delta", "gamma"]);
+  });
+
+  it("treats a malformed saved order as empty", () => {
+    expect(applyOrder(["beta", "alpha"], "constructor" as unknown as string[]))
+      .toEqual(["alpha", "beta"]);
+  });
+
+  it("ignores inherited repo-order properties for adversarial org names", () => {
+    expect(getRepoOrder(emptyPrefs, "constructor")).toEqual([]);
+    expect(getRepoOrder(emptyPrefs, "toString")).toEqual([]);
+    expect(getRepoOrder(emptyPrefs, "__proto__")).toEqual([]);
   });
 
   it("filters hidden repos and orgs, including newly empty orgs", () => {
@@ -76,5 +88,18 @@ describe("PR view preference helpers", () => {
       hiddenRepos: [],
       collapsedRepos: ["alpha/one"],
     });
+  });
+
+  it("filters __proto__ while loading repo orders", () => {
+    localStorage.setItem(
+      PR_VIEW_PREFS_KEY,
+      '{"repoOrder":{"__proto__":["__proto__/repo"],"constructor":["constructor/repo"]}}',
+    );
+
+    const prefs = loadPrViewPrefs();
+
+    expect(Object.keys(prefs.repoOrder)).toEqual(["constructor"]);
+    expect(getRepoOrder(prefs, "__proto__")).toEqual([]);
+    expect(getRepoOrder(prefs, "constructor")).toEqual(["constructor/repo"]);
   });
 });

--- a/apps/web/src/lib/__tests__/prViewPrefs.test.ts
+++ b/apps/web/src/lib/__tests__/prViewPrefs.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  PR_VIEW_PREFS_KEY,
+  applyOrder,
+  filterHidden,
+  loadPrViewPrefs,
+  savePrViewPrefs,
+  type PrViewPrefs,
+} from "../prViewPrefs";
+
+const emptyPrefs: PrViewPrefs = {
+  orgOrder: [],
+  repoOrder: {},
+  hiddenOrgs: [],
+  hiddenRepos: [],
+  collapsedRepos: [],
+};
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe("PR view preference helpers", () => {
+  it("applies saved values first and appends unknown values alphabetically", () => {
+    expect(applyOrder(["gamma", "alpha", "delta", "beta"], ["beta", "missing", "beta"]))
+      .toEqual(["beta", "alpha", "delta", "gamma"]);
+  });
+
+  it("filters hidden repos and orgs, including newly empty orgs", () => {
+    const grouped = {
+      alpha: { "alpha/one": 1, "alpha/two": 2 },
+      beta: { "beta/one": 3 },
+      gamma: { "gamma/one": 4 },
+    };
+
+    const visible = filterHidden(grouped, {
+      hiddenOrgs: ["beta"],
+      hiddenRepos: ["alpha/two", "gamma/one"],
+    });
+
+    expect(Object.keys(visible)).toEqual(["alpha"]);
+    expect(Object.keys(visible.alpha)).toEqual(["alpha/one"]);
+  });
+
+  it("round-trips the versionless preferences object", () => {
+    const prefs: PrViewPrefs = {
+      ...emptyPrefs,
+      orgOrder: ["beta", "alpha"],
+      repoOrder: { alpha: ["alpha/two", "alpha/one"] },
+      hiddenRepos: ["alpha/three"],
+      collapsedRepos: ["alpha/one"],
+    };
+
+    savePrViewPrefs(prefs);
+
+    expect(JSON.parse(localStorage.getItem(PR_VIEW_PREFS_KEY) ?? "null")).toEqual(prefs);
+    expect(loadPrViewPrefs()).toEqual(prefs);
+  });
+
+  it("tolerates malformed and partially invalid JSON", () => {
+    localStorage.setItem(PR_VIEW_PREFS_KEY, "{not-json");
+    expect(loadPrViewPrefs()).toEqual(emptyPrefs);
+
+    localStorage.setItem(PR_VIEW_PREFS_KEY, JSON.stringify({
+      orgOrder: "wrong",
+      repoOrder: { alpha: ["alpha/one", 12], beta: "wrong" },
+      hiddenOrgs: ["alpha", null],
+      hiddenRepos: null,
+      collapsedRepos: ["alpha/one", false],
+    }));
+
+    expect(loadPrViewPrefs()).toEqual({
+      orgOrder: [],
+      repoOrder: { alpha: ["alpha/one"], beta: [] },
+      hiddenOrgs: ["alpha"],
+      hiddenRepos: [],
+      collapsedRepos: ["alpha/one"],
+    });
+  });
+});

--- a/apps/web/src/lib/prViewPrefs.ts
+++ b/apps/web/src/lib/prViewPrefs.ts
@@ -35,6 +35,7 @@ export function loadPrViewPrefs(): PrViewPrefs {
     const repoOrder: Record<string, string[]> = {};
     if (value.repoOrder && typeof value.repoOrder === "object" && !Array.isArray(value.repoOrder)) {
       for (const [org, repos] of Object.entries(value.repoOrder as Record<string, unknown>)) {
+        if (org === "__proto__") continue;
         repoOrder[org] = stringArray(repos);
       }
     }
@@ -49,6 +50,14 @@ export function loadPrViewPrefs(): PrViewPrefs {
   } catch {
     return { ...DEFAULT_PREFS, repoOrder: {} };
   }
+}
+
+/** Read an org's saved repo order without falling through to Object.prototype. */
+export function getRepoOrder(prefs: PrViewPrefs, org: string): string[] {
+  const value = Object.prototype.hasOwnProperty.call(prefs.repoOrder, org)
+    ? prefs.repoOrder[org]
+    : undefined;
+  return Array.isArray(value) ? value : [];
 }
 
 /** Persist the complete, versionless PR view preferences object. */
@@ -66,7 +75,7 @@ export function applyOrder(items: string[], savedOrder: string[]): string[] {
   const seen = new Set<string>();
   const ordered: string[] = [];
 
-  for (const item of savedOrder) {
+  for (const item of Array.isArray(savedOrder) ? savedOrder : []) {
     if (available.has(item) && !seen.has(item)) {
       ordered.push(item);
       seen.add(item);

--- a/apps/web/src/lib/prViewPrefs.ts
+++ b/apps/web/src/lib/prViewPrefs.ts
@@ -1,0 +1,99 @@
+export interface PrViewPrefs {
+  orgOrder: string[];
+  repoOrder: Record<string, string[]>;
+  hiddenOrgs: string[];
+  hiddenRepos: string[];
+  collapsedRepos: string[];
+}
+
+export const PR_VIEW_PREFS_KEY = "cpc-pr-view-prefs";
+
+const DEFAULT_PREFS: PrViewPrefs = {
+  orgOrder: [],
+  repoOrder: {},
+  hiddenOrgs: [],
+  hiddenRepos: [],
+  collapsedRepos: [],
+};
+
+function stringArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((item): item is string => typeof item === "string") : [];
+}
+
+/** Load persisted PR view preferences, safely ignoring malformed or partial data. */
+export function loadPrViewPrefs(): PrViewPrefs {
+  try {
+    const saved = localStorage.getItem(PR_VIEW_PREFS_KEY);
+    if (!saved) return { ...DEFAULT_PREFS, repoOrder: {} };
+
+    const parsed: unknown = JSON.parse(saved);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return { ...DEFAULT_PREFS, repoOrder: {} };
+    }
+
+    const value = parsed as Record<string, unknown>;
+    const repoOrder: Record<string, string[]> = {};
+    if (value.repoOrder && typeof value.repoOrder === "object" && !Array.isArray(value.repoOrder)) {
+      for (const [org, repos] of Object.entries(value.repoOrder as Record<string, unknown>)) {
+        repoOrder[org] = stringArray(repos);
+      }
+    }
+
+    return {
+      orgOrder: stringArray(value.orgOrder),
+      repoOrder,
+      hiddenOrgs: stringArray(value.hiddenOrgs),
+      hiddenRepos: stringArray(value.hiddenRepos),
+      collapsedRepos: stringArray(value.collapsedRepos),
+    };
+  } catch {
+    return { ...DEFAULT_PREFS, repoOrder: {} };
+  }
+}
+
+/** Persist the complete, versionless PR view preferences object. */
+export function savePrViewPrefs(prefs: PrViewPrefs): void {
+  try {
+    localStorage.setItem(PR_VIEW_PREFS_KEY, JSON.stringify(prefs));
+  } catch {
+    // Storage can be unavailable in private/restricted WebViews.
+  }
+}
+
+/** Apply saved order first, then append unknown/new values alphabetically. */
+export function applyOrder(items: string[], savedOrder: string[]): string[] {
+  const available = new Set(items);
+  const seen = new Set<string>();
+  const ordered: string[] = [];
+
+  for (const item of savedOrder) {
+    if (available.has(item) && !seen.has(item)) {
+      ordered.push(item);
+      seen.add(item);
+    }
+  }
+
+  ordered.push(...items.filter((item) => !seen.has(item)).sort((a, b) => a.localeCompare(b)));
+  return ordered;
+}
+
+/** Remove hidden orgs/repos and omit orgs left empty by repo filtering. */
+export function filterHidden<T>(
+  grouped: Record<string, Record<string, T>>,
+  prefs: Pick<PrViewPrefs, "hiddenOrgs" | "hiddenRepos">,
+): Record<string, Record<string, T>> {
+  const hiddenOrgs = new Set(prefs.hiddenOrgs);
+  const hiddenRepos = new Set(prefs.hiddenRepos);
+  const visible = Object.create(null) as Record<string, Record<string, T>>;
+
+  for (const [org, repoMap] of Object.entries(grouped)) {
+    if (hiddenOrgs.has(org)) continue;
+    const visibleRepos = Object.create(null) as Record<string, T>;
+    for (const [repo, value] of Object.entries(repoMap)) {
+      if (!hiddenRepos.has(repo)) visibleRepos[repo] = value;
+    }
+    if (Object.keys(visibleRepos).length > 0) visible[org] = visibleRepos;
+  }
+
+  return visible;
+}


### PR DESCRIPTION
## Summary
- New **⚙ Manage** button on the PRs tab header opens a **Manage PRs** BottomSheet listing every org and repo with an eye (hide/show) toggle and **↑/↓ reorder arrows** per row (deliberately arrows, not drag — Telegram WebView touch rules make drag gestures hazardous; flagged in-thread).
- Hidden repos/orgs are filtered from the main list; an org left empty by repo-hiding disappears too; header shows a subtle **N hidden** count. Hidden rows render dimmed in the sheet.
- **Repo rows now collapse** like orgs (▶/▼), and collapse state persists.
- All prefs in one tolerant localStorage key `cpc-pr-view-prefs` (`orgOrder`, per-org `repoOrder`, `hiddenOrgs`, `hiddenRepos`, `collapsedRepos`) via pure exported helpers (`loadPrViewPrefs`/`savePrViewPrefs`/`applyOrder`/`filterHidden`); saved order first, new items appended alphabetically; malformed JSON falls back safely.
- Client-only — no server changes.

## Tests
276/276 web (new: prViewPrefs helpers incl. malformed-JSON tolerance; ManagePrsSheet hide/reorder; PrTicker hide-filters-main-list, org reorder applies, repo collapse persists across remount). Typecheck + vite build clean.

## Visual proof
Live dev instance (wt-prs, port 38833), real signed initData, 24 real repos: opened Manage sheet → hid `0xPulsePlay/nitrolite` (dimmed in sheet, header flipped to "23 repos · 1 hidden") → moved org `0xPulsePlay` down (main list reordered live behind the sheet) → **full page reload** → hidden + order persisted; org with its only repo hidden vanished from the main list as designed.

Fixes #217
Fixes #218
Part of the dev-cpc-features integration group.

🤖 Generated with [Claude Code](https://claude.com/claude-code)