### PR TITLE
feat(prs): issues toggle + repo icons (#215, #216)

### DIFF
--- a/apps/server/src/routes/__tests__/prs-routes.test.ts
+++ b/apps/server/src/routes/__tests__/prs-routes.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { execFile, execFileSync } from "node:child_process";
-import { existsSync, readdirSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync, realpathSync, statSync } from "node:fs";
 import type { PrRow, RepoInfo } from "../prs.js";
 
 /**
@@ -65,7 +65,10 @@ vi.mock("node:fs", async () => {
   return {
     ...actual,
     existsSync: vi.fn(actual.existsSync),
+    readFileSync: vi.fn(actual.readFileSync),
     readdirSync: vi.fn(actual.readdirSync),
+    realpathSync: vi.fn(actual.realpathSync),
+    statSync: vi.fn(actual.statSync),
   };
 });
 
@@ -91,6 +94,7 @@ const {
   __setPollerForTests,
   __resetScopeCacheForTests,
   __resetRepoCacheForTests,
+  __resetPrAuxCachesForTests,
 } = await import("../prs.js");
 
 // ---------------------------------------------------------------------------
@@ -102,6 +106,14 @@ let mockPoller: InstanceType<typeof PrPoller>;
 beforeEach(() => {
   __resetScopeCacheForTests();
   __resetRepoCacheForTests();
+  __resetPrAuxCachesForTests();
+  vi.mocked(existsSync).mockImplementation(() => false);
+  vi.mocked(readdirSync).mockImplementation(() => [] as any);
+  vi.mocked(execFileSync).mockImplementation(() => { throw new Error("mocked"); });
+  vi.mocked(execFile).mockImplementation(((_cmd: string, _args: string[], _opts: any, cb?: any) => {
+    if (cb) cb(new Error("mocked"), "", "");
+    return { on: vi.fn() } as any;
+  }) as any);
   // Create a poller in static mode (empty repos = no network calls)
   mockPoller = new PrPoller([], 999_999);
   __setPollerForTests(mockPoller);
@@ -109,8 +121,22 @@ beforeEach(() => {
 
 afterEach(() => {
   __setPollerForTests(null);
+  vi.useRealTimers();
   vi.clearAllMocks();
 });
+
+function mockDiscoveredRepo(repo = makeRepoInfo()) {
+  vi.mocked(existsSync).mockImplementation((path) => {
+    const value = String(path);
+    return value === "/home/claude/code" || value === `${repo.path}/.git`;
+  });
+  vi.mocked(readdirSync).mockReturnValue([repo.name] as any);
+  vi.mocked(execFileSync).mockImplementation(((_cmd: string, args: string[]) => {
+    if (args.includes("get-url")) return `git@github.com:${repo.fullName}.git`;
+    if (args.includes("rev-parse")) return `${repo.branch}\n`;
+    throw new Error("unexpected git call");
+  }) as any);
+}
 
 // ---------------------------------------------------------------------------
 // GET /
@@ -243,6 +269,141 @@ describe("POST /refresh", () => {
     const res = await prsRoute.request("/refresh", { method: "POST" });
     const body = (await res.json()) as { repos: any[] };
     expect(Array.isArray(body.repos)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /issues
+// ---------------------------------------------------------------------------
+describe("GET /issues", () => {
+  it("rejects repositories outside discoverRepos without invoking gh", async () => {
+    mockDiscoveredRepo();
+
+    const res = await prsRoute.request("/issues?repo=attacker/unknown");
+
+    expect(res.status).toBe(400);
+    expect(execFile).not.toHaveBeenCalled();
+  });
+
+  it("maps gh issue output and invokes gh with literal argv", async () => {
+    mockDiscoveredRepo();
+    vi.mocked(execFile).mockImplementationOnce(((_cmd: string, _args: string[], _opts: any, cb: any) => {
+      cb(null, JSON.stringify([{
+        number: 215,
+        title: "Add issues mode",
+        state: "CLOSED",
+        author: { login: "octocat" },
+        updatedAt: "2026-07-10T12:00:00Z",
+        labels: [{ name: "enhancement" }, { name: "web" }],
+        url: "https://github.com/claudes-world/inbox/issues/215",
+      }]), "");
+      return { on: vi.fn() } as any;
+    }) as any);
+
+    const res = await prsRoute.request("/issues?repo=claudes-world%2Finbox");
+    const body = await res.json() as any;
+
+    expect(res.status).toBe(200);
+    expect(body).toEqual({
+      ok: true,
+      repo: "claudes-world/inbox",
+      issues: [{
+        key: "claudes-world/inbox#215",
+        repo: "claudes-world/inbox",
+        number: 215,
+        title: "Add issues mode",
+        state: "CLOSED",
+        author: "octocat",
+        updatedAt: "2026-07-10T12:00:00Z",
+        labels: ["enhancement", "web"],
+        url: "https://github.com/claudes-world/inbox/issues/215",
+      }],
+    });
+    expect(execFile).toHaveBeenCalledWith(
+      "gh",
+      [
+        "issue", "list",
+        "--repo", "claudes-world/inbox",
+        "--json", "number,title,state,author,updatedAt,labels,url",
+        "--limit", "30",
+      ],
+      { timeout: 10_000 },
+      expect.any(Function),
+    );
+  });
+
+  it("uses the five-minute per-repo cache, expires it, and honors force=1", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-10T12:00:00Z"));
+    mockDiscoveredRepo();
+    vi.mocked(execFile).mockImplementation(((_cmd: string, _args: string[], _opts: any, cb: any) => {
+      cb(null, "[]", "");
+      return { on: vi.fn() } as any;
+    }) as any);
+
+    await prsRoute.request("/issues?repo=claudes-world%2Finbox");
+    await prsRoute.request("/issues?repo=claudes-world%2Finbox");
+    expect(execFile).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(5 * 60_000 + 1);
+    await prsRoute.request("/issues?repo=claudes-world%2Finbox");
+    expect(execFile).toHaveBeenCalledTimes(2);
+
+    await prsRoute.request("/issues?repo=claudes-world%2Finbox&force=1");
+    expect(execFile).toHaveBeenCalledTimes(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /icons
+// ---------------------------------------------------------------------------
+describe("GET /icons", () => {
+  it("uses candidate order, skips files over 64KB, and returns the ico mime", async () => {
+    const repo = makeRepoInfo();
+    mockDiscoveredRepo(repo);
+    vi.mocked(existsSync).mockImplementation((path) => {
+      const value = String(path);
+      return value === "/home/claude/code"
+        || value === `${repo.path}/.git`
+        || value === `${repo.path}/favicon.svg`
+        || value === `${repo.path}/favicon.ico`;
+    });
+    vi.mocked(realpathSync).mockImplementation(((path: string) => path) as any);
+    vi.mocked(statSync).mockImplementation(((path: string) => ({
+      isFile: () => true,
+      size: path.endsWith("favicon.svg") ? 64 * 1024 + 1 : 4,
+    })) as any);
+    vi.mocked(readFileSync).mockReturnValue(Buffer.from("icon") as any);
+
+    const res = await prsRoute.request("/icons");
+    const body = await res.json() as any;
+
+    expect(body.icons[repo.fullName]).toBe(`data:image/x-icon;base64,${Buffer.from("icon").toString("base64")}`);
+    expect(statSync).toHaveBeenNthCalledWith(1, `${repo.path}/favicon.svg`);
+    expect(statSync).toHaveBeenNthCalledWith(2, `${repo.path}/favicon.ico`);
+    expect(readFileSync).toHaveBeenCalledTimes(1);
+    expect(readFileSync).toHaveBeenCalledWith(`${repo.path}/favicon.ico`);
+  });
+
+  it.each([
+    ["favicon.svg", "image/svg+xml"],
+    ["favicon.png", "image/png"],
+  ])("returns the correct data URI mime for %s", async (candidate, mime) => {
+    const repo = makeRepoInfo();
+    mockDiscoveredRepo(repo);
+    vi.mocked(existsSync).mockImplementation((path) => {
+      const value = String(path);
+      return value === "/home/claude/code"
+        || value === `${repo.path}/.git`
+        || value === `${repo.path}/${candidate}`;
+    });
+    vi.mocked(realpathSync).mockImplementation(((path: string) => path) as any);
+    vi.mocked(statSync).mockReturnValue({ isFile: () => true, size: 3 } as any);
+    vi.mocked(readFileSync).mockReturnValue(Buffer.from("img") as any);
+
+    const body = await (await prsRoute.request("/icons")).json() as any;
+
+    expect(body.icons[repo.fullName]).toBe(`data:${mime};base64,${Buffer.from("img").toString("base64")}`);
   });
 });
 

--- a/apps/server/src/routes/prs.ts
+++ b/apps/server/src/routes/prs.ts
@@ -1,7 +1,7 @@
 import { Hono } from "hono";
 import { execFile, execFileSync } from "node:child_process";
-import { existsSync, readdirSync } from "node:fs";
-import { join } from "node:path";
+import { existsSync, readFileSync, readdirSync, realpathSync, statSync } from "node:fs";
+import { isAbsolute, join, relative } from "node:path";
 
 const app = new Hono();
 
@@ -11,6 +11,9 @@ const GIT_TIMEOUT_MS = 5_000;
 const DEFAULT_POLL_INTERVAL_MS = 30_000;
 const SCOPE_CACHE_TTL_MS = 60_000;
 const REPO_DISCOVERY_TTL_MS = 5 * 60_000; // re-scan ~/code every 5 min
+const ISSUE_CACHE_TTL_MS = 5 * 60_000;
+const ICON_CACHE_TTL_MS = 30 * 60_000;
+const MAX_ICON_BYTES = 64 * 1024;
 
 // --- Types ---
 
@@ -35,6 +38,18 @@ export interface PrDiff {
   added: PrRow[];
   removed: PrRow[];
   changed: { pr: PrRow; fields: string[] }[];
+}
+
+export interface IssueRow {
+  key: string;
+  repo: string;
+  number: number;
+  title: string;
+  state: "OPEN" | "CLOSED";
+  author: string;
+  updatedAt: string;
+  labels: string[];
+  url: string;
 }
 
 // --- Repo discovery ---
@@ -204,6 +219,39 @@ function parseGhPrs(jsonStr: string, repoFullName: string, now: number): PrRow[]
     updatedAt: pr.updatedAt,
     firstSeen: now,
     lastChanged: now,
+  }));
+}
+
+interface GhIssueJson {
+  number: number;
+  title: string;
+  state: string;
+  author: { login: string } | null;
+  updatedAt: string;
+  labels: Array<{ name: string }>;
+  url: string;
+}
+
+function parseGhIssues(jsonStr: string, repoFullName: string): IssueRow[] {
+  let raw: GhIssueJson[];
+  try {
+    raw = JSON.parse(jsonStr);
+  } catch {
+    return [];
+  }
+  if (!Array.isArray(raw)) return [];
+  return raw.map((issue) => ({
+    key: `${repoFullName}#${issue.number}`,
+    repo: repoFullName,
+    number: issue.number,
+    title: issue.title,
+    state: issue.state?.toUpperCase() === "CLOSED" ? "CLOSED" : "OPEN",
+    author: issue.author?.login ?? "unknown",
+    updatedAt: issue.updatedAt,
+    labels: Array.isArray(issue.labels)
+      ? issue.labels.map((label) => label?.name).filter((name): name is string => typeof name === "string")
+      : [],
+    url: issue.url,
   }));
 }
 
@@ -438,6 +486,74 @@ export function __resetScopeCacheForTests() {
   scopeCache = null;
 }
 
+// --- On-demand issues and repository icons ---
+
+let issueCache = new Map<string, { issues: IssueRow[]; cachedAt: number }>();
+let iconCache: { icons: Record<string, string>; cachedAt: number } | null = null;
+
+const ICON_CANDIDATES = [
+  "favicon.svg",
+  "favicon.ico",
+  "favicon.png",
+  "public/favicon.svg",
+  "public/favicon.ico",
+  "public/favicon.png",
+  "app/favicon.ico",
+  "app/favicon.png",
+  "app/icon.svg",
+  "app/icon.png",
+  "assets/icon.svg",
+  "assets/icon.png",
+  "assets/logo.svg",
+  "assets/logo.png",
+] as const;
+
+const ICON_MIME: Record<string, string> = {
+  svg: "image/svg+xml",
+  ico: "image/x-icon",
+  png: "image/png",
+};
+
+function readRepoIcon(repoPath: string): string | null {
+  let realRepoPath: string;
+  try {
+    realRepoPath = realpathSync(repoPath);
+  } catch {
+    return null;
+  }
+
+  for (const candidate of ICON_CANDIDATES) {
+    const candidatePath = join(repoPath, candidate);
+    if (!existsSync(candidatePath)) continue;
+
+    try {
+      const realCandidatePath = realpathSync(candidatePath);
+      const relativePath = relative(realRepoPath, realCandidatePath);
+      if (relativePath.startsWith("..") || isAbsolute(relativePath)) continue;
+
+      const stat = statSync(realCandidatePath);
+      if (!stat.isFile() || stat.size > MAX_ICON_BYTES) continue;
+
+      const extension = candidate.slice(candidate.lastIndexOf(".") + 1);
+      const mime = ICON_MIME[extension];
+      if (!mime) continue;
+      const contents = readFileSync(realCandidatePath);
+      if (contents.length > MAX_ICON_BYTES) continue;
+      const encoded = contents.toString("base64");
+      return `data:${mime};base64,${encoded}`;
+    } catch {
+      // Unreadable/broken candidates are skipped in favor of the next one.
+    }
+  }
+
+  return null;
+}
+
+export function __resetPrAuxCachesForTests() {
+  issueCache = new Map();
+  iconCache = null;
+}
+
 // --- Singleton poller instance ---
 
 let pollerInstance: PrPoller | null = null;
@@ -517,6 +633,54 @@ app.post("/refresh", async (c) => {
       changed: diff.changed.length,
     },
   });
+});
+
+app.get("/issues", async (c) => {
+  const requestedRepo = c.req.query("repo");
+  const repos = discoverRepos();
+  const repo = repos.find((candidate) => candidate.fullName === requestedRepo);
+  if (!requestedRepo || !repo) {
+    return c.json({ ok: false, error: "Unknown repository" }, 400);
+  }
+
+  const force = c.req.query("force") === "1";
+  const now = Date.now();
+  const cached = issueCache.get(repo.fullName);
+  if (!force && cached && now - cached.cachedAt < ISSUE_CACHE_TTL_MS) {
+    return c.json({ ok: true, repo: repo.fullName, issues: cached.issues });
+  }
+
+  try {
+    const stdout = await execGh([
+      "issue", "list",
+      "--repo", repo.fullName,
+      "--json", "number,title,state,author,updatedAt,labels,url",
+      "--limit", "30",
+    ]);
+    const issues = parseGhIssues(stdout, repo.fullName);
+    issueCache.set(repo.fullName, { issues, cachedAt: now });
+    return c.json({ ok: true, repo: repo.fullName, issues });
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    return c.json({ ok: false, error }, 502);
+  }
+});
+
+app.get("/icons", (c) => {
+  const now = Date.now();
+  if (iconCache && now - iconCache.cachedAt < ICON_CACHE_TTL_MS) {
+    return c.json({ ok: true, icons: iconCache.icons });
+  }
+
+  const icons: Record<string, string> = Object.create(null) as Record<string, string>;
+  for (const repo of discoverRepos()) {
+    if (icons[repo.fullName]) continue;
+    const icon = readRepoIcon(repo.path);
+    if (icon) icons[repo.fullName] = icon;
+  }
+
+  iconCache = { icons, cachedAt: now };
+  return c.json({ ok: true, icons });
 });
 
 app.get("/current-branch-scope", async (c) => {

--- a/apps/web/src/components/PrTicker.tsx
+++ b/apps/web/src/components/PrTicker.tsx
@@ -55,6 +55,7 @@ interface RepoIssuesState {
   issues: IssueRow[];
   loading: boolean;
   loaded: boolean;
+  attempted: boolean;
   error: string | null;
 }
 
@@ -191,6 +192,25 @@ function saveCollapsedOrgs(collapsed: Set<string>) {
 // --- Main component ---
 
 const POLL_INTERVAL_MS = 10_000;
+const ISSUE_FETCH_CONCURRENCY = 4;
+
+async function runWithConcurrency<T>(
+  items: T[],
+  limit: number,
+  worker: (item: T) => Promise<void>,
+): Promise<void> {
+  let nextIndex = 0;
+  const workers = Array.from(
+    { length: Math.min(limit, items.length) },
+    async () => {
+      while (nextIndex < items.length) {
+        const item = items[nextIndex++];
+        await worker(item);
+      }
+    },
+  );
+  await Promise.all(workers);
+}
 
 export function PrTicker() {
   const [prs, setPrs] = useState<PrRow[]>([]);
@@ -208,6 +228,12 @@ export function PrTicker() {
   const [, setTick] = useState(0); // Force re-render for "last poll Xs ago"
   const mountedRef = useRef(true);
   const issuesRef = useRef<Record<string, RepoIssuesState>>({});
+  const issuesLoadSeqRef = useRef(0);
+  const issueFetchPoolRef = useRef<{ active: number; waiters: Array<() => void> }>({
+    active: 0,
+    waiters: [],
+  });
+  const previousViewModeRef = useRef<ViewMode>("prs");
 
   const toggleOrg = useCallback((org: string) => {
     haptic.impact("light");
@@ -267,55 +293,85 @@ export function PrTicker() {
   }, []);
 
   const updateRepoIssues = useCallback((repo: string, state: RepoIssuesState) => {
-    setIssuesByRepo((prev) => {
-      const next = { ...prev, [repo]: state };
-      issuesRef.current = next;
-      return next;
-    });
+    const next = { ...issuesRef.current, [repo]: state };
+    issuesRef.current = next;
+    setIssuesByRepo(next);
   }, []);
 
-  const fetchIssues = useCallback(async (repoNames: string[], force: boolean) => {
+  const withIssueFetchSlot = useCallback(async (task: () => Promise<void>) => {
+    const pool = issueFetchPoolRef.current;
+    if (pool.active < ISSUE_FETCH_CONCURRENCY) {
+      pool.active += 1;
+    } else {
+      await new Promise<void>((resolve) => pool.waiters.push(resolve));
+    }
+    try {
+      await task();
+    } finally {
+      const next = pool.waiters.shift();
+      if (next) {
+        next();
+      } else {
+        pool.active -= 1;
+      }
+    }
+  }, []);
+
+  const fetchIssues = useCallback(async (repoNames: string[], force: boolean, retryFailed = false) => {
+    const seq = ++issuesLoadSeqRef.current;
     const reposToFetch = repoNames.filter((repo) => {
       const current = issuesRef.current[repo];
-      return force || (!current?.loaded && !current?.loading);
+      return force || !current?.attempted || current.loading || (retryFailed && current.error !== null);
     });
 
-    await Promise.all(reposToFetch.map(async (repo) => {
-      const previous = issuesRef.current[repo];
+    const previousByRepo = new Map(reposToFetch.map((repo) => [repo, issuesRef.current[repo]]));
+    for (const repo of reposToFetch) {
+      const previous = previousByRepo.get(repo);
       updateRepoIssues(repo, {
         issues: previous?.issues ?? [],
         loading: true,
         loaded: previous?.loaded ?? false,
+        attempted: true,
         error: null,
       });
-      try {
-        const forceQuery = force ? "&force=1" : "";
-        const res = await fetch(`/api/prs/issues?repo=${encodeURIComponent(repo)}${forceQuery}`, {
-          headers: getAuthHeaders(),
-        });
-        if (!res.ok) throw new Error(`HTTP ${res.status}`);
-        const data = await res.json();
-        if (!data.ok) throw new Error(data.error ?? "Unknown error");
-        if (mountedRef.current) {
-          updateRepoIssues(repo, {
-            issues: data.issues ?? [],
-            loading: false,
-            loaded: true,
-            error: null,
+    }
+
+    await runWithConcurrency(reposToFetch, ISSUE_FETCH_CONCURRENCY, async (repo) => {
+      if (seq !== issuesLoadSeqRef.current) return;
+      const previous = previousByRepo.get(repo);
+      await withIssueFetchSlot(async () => {
+        if (seq !== issuesLoadSeqRef.current) return;
+        try {
+          const forceQuery = force ? "&force=1" : "";
+          const res = await fetch(`/api/prs/issues?repo=${encodeURIComponent(repo)}${forceQuery}`, {
+            headers: getAuthHeaders(),
           });
+          if (!res.ok) throw new Error(`HTTP ${res.status}`);
+          const data = await res.json();
+          if (!data.ok) throw new Error(data.error ?? "Unknown error");
+          if (mountedRef.current && seq === issuesLoadSeqRef.current) {
+            updateRepoIssues(repo, {
+              issues: data.issues ?? [],
+              loading: false,
+              loaded: true,
+              attempted: true,
+              error: null,
+            });
+          }
+        } catch (err) {
+          if (mountedRef.current && seq === issuesLoadSeqRef.current) {
+            updateRepoIssues(repo, {
+              issues: previous?.issues ?? [],
+              loading: false,
+              loaded: previous?.loaded ?? false,
+              attempted: true,
+              error: err instanceof Error ? err.message : String(err),
+            });
+          }
         }
-      } catch (err) {
-        if (mountedRef.current) {
-          updateRepoIssues(repo, {
-            issues: previous?.issues ?? [],
-            loading: false,
-            loaded: previous?.loaded ?? false,
-            error: err instanceof Error ? err.message : String(err),
-          });
-        }
-      }
-    }));
-  }, [updateRepoIssues]);
+      });
+    });
+  }, [updateRepoIssues, withIssueFetchSlot]);
 
   const handleRefresh = useCallback(async () => {
     setRefreshing(true);
@@ -379,11 +435,15 @@ export function PrTicker() {
   }, []);
 
   // Fetch only while Issues is selected; the PR polling interval never calls this.
+  const visibleIssueRepoSignature = visibleRepoNames(repos, prefs).sort().join("\n");
   useEffect(() => {
+    const enteredIssues = viewMode === "issues" && previousViewModeRef.current !== "issues";
+    previousViewModeRef.current = viewMode;
     if (viewMode === "issues") {
-      void fetchIssues(visibleRepoNames(repos, prefs), false);
+      const repoNames = visibleIssueRepoSignature ? visibleIssueRepoSignature.split("\n") : [];
+      void fetchIssues(repoNames, false, enteredIssues);
     }
-  }, [fetchIssues, prefs, repos, viewMode]);
+  }, [fetchIssues, viewMode, visibleIssueRepoSignature]);
 
   const grouped = groupPrs(prs, repos);
   const visibleGrouped = filterHidden(grouped, prefs);

--- a/apps/web/src/components/PrTicker.tsx
+++ b/apps/web/src/components/PrTicker.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef } from "react";
+import { useState, useEffect, useCallback, useRef, type ReactNode } from "react";
 import { getAuthHeaders } from "../lib/telegram";
 import { haptic } from "../lib/haptic";
 import { ManagePrsSheet } from "./ManagePrsSheet";
@@ -38,6 +38,27 @@ interface RepoSummary {
   branch: string;
   prCount: number;
 }
+
+interface IssueRow {
+  key: string;
+  repo: string;
+  number: number;
+  title: string;
+  state: "OPEN" | "CLOSED";
+  author: string;
+  updatedAt: string;
+  labels: string[];
+  url: string;
+}
+
+interface RepoIssuesState {
+  issues: IssueRow[];
+  loading: boolean;
+  loaded: boolean;
+  error: string | null;
+}
+
+type ViewMode = "prs" | "issues";
 
 // Grouped structure: org -> repo -> { branch, prs }
 type GroupedPrs = Record<string, Record<string, { branch: string; prs: PrRow[] }>>;
@@ -144,6 +165,11 @@ function groupPrs(prs: PrRow[], repos: RepoSummary[]): GroupedPrs {
   return grouped;
 }
 
+function visibleRepoNames(repos: RepoSummary[], prefs: PrViewPrefs): string[] {
+  const grouped = filterHidden(groupPrs([], repos), prefs);
+  return Object.values(grouped).flatMap((repoMap) => Object.keys(repoMap));
+}
+
 // --- Collapse state persistence ---
 
 const COLLAPSE_KEY = "cpc-pr-collapsed-orgs";
@@ -169,6 +195,9 @@ const POLL_INTERVAL_MS = 10_000;
 export function PrTicker() {
   const [prs, setPrs] = useState<PrRow[]>([]);
   const [repos, setRepos] = useState<RepoSummary[]>([]);
+  const [viewMode, setViewMode] = useState<ViewMode>("prs");
+  const [issuesByRepo, setIssuesByRepo] = useState<Record<string, RepoIssuesState>>({});
+  const [repoIcons, setRepoIcons] = useState<Record<string, string>>({});
   const [collapsedOrgs, setCollapsedOrgs] = useState<Set<string>>(loadCollapsedOrgs);
   const [prefs, setPrefs] = useState<PrViewPrefs>(loadPrViewPrefs);
   const [manageOpen, setManageOpen] = useState(false);
@@ -178,6 +207,7 @@ export function PrTicker() {
   const [refreshing, setRefreshing] = useState(false);
   const [, setTick] = useState(0); // Force re-render for "last poll Xs ago"
   const mountedRef = useRef(true);
+  const issuesRef = useRef<Record<string, RepoIssuesState>>({});
 
   const toggleOrg = useCallback((org: string) => {
     haptic.impact("light");
@@ -236,6 +266,57 @@ export function PrTicker() {
     }
   }, []);
 
+  const updateRepoIssues = useCallback((repo: string, state: RepoIssuesState) => {
+    setIssuesByRepo((prev) => {
+      const next = { ...prev, [repo]: state };
+      issuesRef.current = next;
+      return next;
+    });
+  }, []);
+
+  const fetchIssues = useCallback(async (repoNames: string[], force: boolean) => {
+    const reposToFetch = repoNames.filter((repo) => {
+      const current = issuesRef.current[repo];
+      return force || (!current?.loaded && !current?.loading);
+    });
+
+    await Promise.all(reposToFetch.map(async (repo) => {
+      const previous = issuesRef.current[repo];
+      updateRepoIssues(repo, {
+        issues: previous?.issues ?? [],
+        loading: true,
+        loaded: previous?.loaded ?? false,
+        error: null,
+      });
+      try {
+        const forceQuery = force ? "&force=1" : "";
+        const res = await fetch(`/api/prs/issues?repo=${encodeURIComponent(repo)}${forceQuery}`, {
+          headers: getAuthHeaders(),
+        });
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const data = await res.json();
+        if (!data.ok) throw new Error(data.error ?? "Unknown error");
+        if (mountedRef.current) {
+          updateRepoIssues(repo, {
+            issues: data.issues ?? [],
+            loading: false,
+            loaded: true,
+            error: null,
+          });
+        }
+      } catch (err) {
+        if (mountedRef.current) {
+          updateRepoIssues(repo, {
+            issues: previous?.issues ?? [],
+            loading: false,
+            loaded: previous?.loaded ?? false,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+      }
+    }));
+  }, [updateRepoIssues]);
+
   const handleRefresh = useCallback(async () => {
     setRefreshing(true);
     try {
@@ -260,6 +341,15 @@ export function PrTicker() {
     }
   }, []);
 
+  const handleIssueRefresh = useCallback(async () => {
+    setRefreshing(true);
+    try {
+      await fetchIssues(visibleRepoNames(repos, prefs), true);
+    } finally {
+      if (mountedRef.current) setRefreshing(false);
+    }
+  }, [fetchIssues, prefs, repos]);
+
   // Polling
   useEffect(() => {
     mountedRef.current = true;
@@ -274,11 +364,39 @@ export function PrTicker() {
     };
   }, [fetchPrs]);
 
+  // Icons are local, cached by the server, and only need one request per mount.
+  useEffect(() => {
+    void (async () => {
+      try {
+        const res = await fetch("/api/prs/icons", { headers: getAuthHeaders() });
+        if (!res.ok) return;
+        const data = await res.json();
+        if (mountedRef.current && data.ok) setRepoIcons(data.icons ?? {});
+      } catch {
+        // Icons are optional; retain the text-only repository rows on failure.
+      }
+    })();
+  }, []);
+
+  // Fetch only while Issues is selected; the PR polling interval never calls this.
+  useEffect(() => {
+    if (viewMode === "issues") {
+      void fetchIssues(visibleRepoNames(repos, prefs), false);
+    }
+  }, [fetchIssues, prefs, repos, viewMode]);
+
   const grouped = groupPrs(prs, repos);
   const visibleGrouped = filterHidden(grouped, prefs);
   const orgNames = applyOrder(Object.keys(visibleGrouped), prefs.orgOrder);
   const totalPrs = orgNames.reduce(
     (orgTotal, org) => orgTotal + Object.values(visibleGrouped[org]).reduce((repoTotal, repo) => repoTotal + repo.prs.length, 0),
+    0,
+  );
+  const totalIssues = orgNames.reduce(
+    (orgTotal, org) => orgTotal + Object.keys(visibleGrouped[org]).reduce(
+      (repoTotal, repo) => repoTotal + (issuesByRepo[repo]?.issues.length ?? 0),
+      0,
+    ),
     0,
   );
   const totalRepos = orgNames.reduce((total, org) => total + Object.keys(visibleGrouped[org]).length, 0);
@@ -299,6 +417,12 @@ export function PrTicker() {
       }
     } catch { /* fallback */ }
     window.open(url, "_blank");
+  };
+
+  const selectView = (mode: ViewMode) => {
+    if (mode === viewMode) return;
+    haptic.impact("light");
+    setViewMode(mode);
   };
 
   return (
@@ -327,6 +451,34 @@ export function PrTicker() {
             {hiddenCount} hidden
           </span>
         )}
+        <div style={{
+          display: "flex",
+          border: `1px solid ${COLORS.border}`,
+          borderRadius: 6,
+          overflow: "hidden",
+          marginLeft: 2,
+        }}>
+          {(["prs", "issues"] as const).map((mode) => (
+            <button
+              key={mode}
+              type="button"
+              aria-pressed={viewMode === mode}
+              onClick={() => selectView(mode)}
+              style={{
+                border: "none",
+                borderRight: mode === "prs" ? `1px solid ${COLORS.border}` : "none",
+                background: viewMode === mode ? COLORS.blue : "transparent",
+                color: viewMode === mode ? COLORS.bg : COLORS.textMuted,
+                fontSize: 11,
+                fontWeight: 600,
+                padding: "3px 7px",
+                cursor: "pointer",
+              }}
+            >
+              {mode === "prs" ? "PRs" : "Issues"}
+            </button>
+          ))}
+        </div>
         <div style={{ marginLeft: "auto", display: "flex", alignItems: "center", gap: 6 }}>
           <button
             type="button"
@@ -345,7 +497,11 @@ export function PrTicker() {
             ⚙
           </button>
           <button
-            onClick={() => { haptic.impact("light"); void handleRefresh(); }}
+            aria-label={`Refresh ${viewMode === "prs" ? "PRs" : "issues"}`}
+            onClick={() => {
+              haptic.impact("light");
+              void (viewMode === "prs" ? handleRefresh() : handleIssueRefresh());
+            }}
             disabled={refreshing}
             style={{
               background: "none",
@@ -356,7 +512,7 @@ export function PrTicker() {
               fontSize: 14,
               opacity: refreshing ? 0.5 : 1,
             }}
-            title="Force refresh"
+            title={`Refresh ${viewMode === "prs" ? "PRs" : "issues"}`}
           >
             {refreshing ? "..." : "\u21bb"}
           </button>
@@ -377,7 +533,7 @@ export function PrTicker() {
         </div>
       )}
 
-      {/* Grouped PR list */}
+      {/* Grouped PR/issue list */}
       <div style={{
         flex: 1,
         overflowY: "auto",
@@ -431,6 +587,9 @@ export function PrTicker() {
               repoOrder={getRepoOrder(prefs, org)}
               collapsed={collapsedOrgs.has(org)}
               collapsedRepos={prefs.collapsedRepos}
+              viewMode={viewMode}
+              issuesByRepo={issuesByRepo}
+              repoIcons={repoIcons}
               onToggle={() => toggleOrg(org)}
               onToggleRepo={toggleRepo}
               onTapPr={openPr}
@@ -450,20 +609,24 @@ export function PrTicker() {
         justifyContent: "space-between",
         flexShrink: 0,
       }}>
-        <span>{totalPrs} open</span>
-        <span>
-          last poll {pollAgoSec}s ago
-          <span style={{
-            display: "inline-block",
-            width: 6,
-            height: 6,
-            borderRadius: "50%",
-            background: pollError ? COLORS.red : COLORS.green,
-            marginLeft: 6,
-            verticalAlign: "middle",
-          }} />
-          {" "}{pollError ? "degraded" : "live"}
-        </span>
+        <span>{viewMode === "prs" ? `${totalPrs} open` : `${totalIssues} issues`}</span>
+        {viewMode === "prs" ? (
+          <span>
+            last poll {pollAgoSec}s ago
+            <span style={{
+              display: "inline-block",
+              width: 6,
+              height: 6,
+              borderRadius: "50%",
+              background: pollError ? COLORS.red : COLORS.green,
+              marginLeft: 6,
+              verticalAlign: "middle",
+            }} />
+            {" "}{pollError ? "degraded" : "live"}
+          </span>
+        ) : (
+          <span>on demand</span>
+        )}
       </div>
 
       {manageOpen && (
@@ -486,6 +649,9 @@ function OrgSection({
   repoOrder,
   collapsed,
   collapsedRepos,
+  viewMode,
+  issuesByRepo,
+  repoIcons,
   onToggle,
   onToggleRepo,
   onTapPr,
@@ -495,12 +661,20 @@ function OrgSection({
   repoOrder: string[];
   collapsed: boolean;
   collapsedRepos: string[];
+  viewMode: ViewMode;
+  issuesByRepo: Record<string, RepoIssuesState>;
+  repoIcons: Record<string, string>;
   onToggle: () => void;
   onToggleRepo: (repo: string) => void;
   onTapPr: (url: string) => void;
 }) {
   const repoNames = applyOrder(Object.keys(repoMap), repoOrder);
-  const totalPrs = repoNames.reduce((sum, r) => sum + repoMap[r].prs.length, 0);
+  const totalItems = repoNames.reduce(
+    (sum, repo) => sum + (viewMode === "prs"
+      ? repoMap[repo].prs.length
+      : issuesByRepo[repo]?.issues.length ?? 0),
+    0,
+  );
 
   return (
     <div>
@@ -521,11 +695,19 @@ function OrgSection({
         <span style={{ fontSize: 11, color: COLORS.textMuted, width: 12, textAlign: "center" }}>
           {collapsed ? "\u25b6" : "\u25bc"}
         </span>
+        <img
+          src={`https://avatars.githubusercontent.com/${encodeURIComponent(org)}?s=32`}
+          alt={`${org} avatar`}
+          onError={(event) => { event.currentTarget.style.display = "none"; }}
+          style={{ width: 16, height: 16, borderRadius: "50%", flexShrink: 0 }}
+        />
         <span style={{ fontWeight: 700, fontSize: 13, color: COLORS.text }}>
           {org}
         </span>
         <span style={{ fontSize: 11, color: COLORS.textMuted }}>
-          {totalPrs} PR{totalPrs !== 1 ? "s" : ""}
+          {totalItems} {viewMode === "prs"
+            ? `PR${totalItems !== 1 ? "s" : ""}`
+            : `issue${totalItems !== 1 ? "s" : ""}`}
         </span>
       </div>
 
@@ -534,6 +716,8 @@ function OrgSection({
         const { branch, prs } = repoMap[repoFullName];
         const repoShort = repoFullName.split("/")[1] || repoFullName;
         const repoCollapsed = collapsedRepos.includes(repoFullName);
+        const issueState = issuesByRepo[repoFullName];
+        const itemCount = viewMode === "prs" ? prs.length : issueState?.issues.length ?? 0;
 
         return (
           <div key={repoFullName}>
@@ -554,6 +738,14 @@ function OrgSection({
               <span style={{ fontSize: 10, color: COLORS.textMuted, width: 10, textAlign: "center" }}>
                 {repoCollapsed ? "\u25b6" : "\u25bc"}
               </span>
+              {repoIcons[repoFullName] && (
+                <img
+                  src={repoIcons[repoFullName]}
+                  alt={`${repoShort} icon`}
+                  onError={(event) => { event.currentTarget.style.display = "none"; }}
+                  style={{ width: 16, height: 16, objectFit: "contain", flexShrink: 0 }}
+                />
+              )}
               <span style={{ fontWeight: 600, color: COLORS.text }}>
                 {repoShort}
               </span>
@@ -574,12 +766,24 @@ function OrgSection({
                 </span>
               )}
               <span style={{ fontSize: 11, color: COLORS.textMuted, marginLeft: "auto" }}>
-                {prs.length} open
+                {viewMode === "issues" && issueState?.loading
+                  ? "..."
+                  : `${itemCount} ${viewMode === "prs" ? "open" : "issues"}`}
               </span>
             </div>
 
-            {/* PR rows or empty state */}
-            {!repoCollapsed && (prs.length === 0 ? (
+            {/* PR/issue rows or per-repo state */}
+            {!repoCollapsed && (viewMode === "issues" && issueState?.loading ? (
+              <RepoMessage>loading issues...</RepoMessage>
+            ) : viewMode === "issues" && issueState?.error ? (
+              <RepoMessage color={COLORS.red}>issues failed: {issueState.error}</RepoMessage>
+            ) : viewMode === "issues" ? (
+              (issueState?.issues.length ?? 0) === 0
+                ? <RepoMessage>no issues</RepoMessage>
+                : issueState!.issues.map((issue) => (
+                  <IssueRowItem key={issue.key} issue={issue} onTap={onTapPr} />
+                ))
+            ) : prs.length === 0 ? (
               <div style={{
                 padding: "8px 12px 8px 36px",
                 fontSize: 12,
@@ -597,6 +801,20 @@ function OrgSection({
           </div>
         );
       })}
+    </div>
+  );
+}
+
+function RepoMessage({ children, color = COLORS.textMuted }: { children: ReactNode; color?: string }) {
+  return (
+    <div style={{
+      padding: "8px 12px 8px 36px",
+      fontSize: 12,
+      color,
+      fontStyle: "italic",
+      borderBottom: `1px solid ${COLORS.border}`,
+    }}>
+      {children}
     </div>
   );
 }
@@ -672,6 +890,74 @@ function PrRowItem({
         <span style={{ color: statusColor }}>{review}</span>
         {ci && <span style={{ color: statusColor }}>{ci}</span>}
         <span style={{ marginLeft: "auto" }}>{timeAgo(pr.updatedAt)}</span>
+      </div>
+    </div>
+  );
+}
+
+function IssueRowItem({
+  issue,
+  onTap,
+}: {
+  issue: IssueRow;
+  onTap: (url: string) => void;
+}) {
+  const statusColor = issue.state === "CLOSED" ? "var(--color-accent-purple)" : COLORS.green;
+
+  return (
+    <div
+      onClick={() => { haptic.impact("light"); onTap(issue.url); }}
+      style={{
+        padding: "10px 12px 10px 36px",
+        borderBottom: `1px solid ${COLORS.border}`,
+        cursor: "pointer",
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 2 }}>
+        <span style={{
+          width: 8,
+          height: 8,
+          borderRadius: "50%",
+          background: statusColor,
+          flexShrink: 0,
+        }} />
+        <span style={{ fontWeight: 600, color: COLORS.text }}>#{issue.number}</span>
+        <span style={{
+          color: COLORS.text,
+          fontSize: 12,
+          overflow: "hidden",
+          textOverflow: "ellipsis",
+          whiteSpace: "nowrap",
+        }}>
+          {issue.title}
+        </span>
+      </div>
+      <div style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 6,
+        minWidth: 0,
+        marginLeft: 14,
+        fontSize: 11,
+        color: COLORS.textMuted,
+      }}>
+        <span>{issue.author}</span>
+        {issue.labels.slice(0, 3).map((label) => (
+          <span key={label} style={{
+            padding: "1px 5px",
+            borderRadius: 8,
+            background: COLORS.surface,
+            border: `1px solid ${COLORS.border}`,
+            color: COLORS.textMuted,
+            maxWidth: 80,
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+          }}>
+            {label}
+          </span>
+        ))}
+        <span style={{ marginLeft: "auto", flexShrink: 0 }}>{timeAgo(issue.updatedAt)}</span>
       </div>
     </div>
   );

--- a/apps/web/src/components/__tests__/PrTicker.test.tsx
+++ b/apps/web/src/components/__tests__/PrTicker.test.tsx
@@ -531,6 +531,134 @@ describe("PrTicker", () => {
     });
   });
 
+  it("does not retry a failed issues fetch when PR polling returns a fresh repos array", async () => {
+    const repo = makeRepo();
+    fetchMock.mockImplementation(async (url: string) => {
+      if (url === "/api/prs") {
+        return {
+          ok: true,
+          json: async () => ({ ok: true, prs: [], repos: [{ ...repo }], lastPollOk: Date.now() }),
+        };
+      }
+      if (url === "/api/prs/icons") {
+        return { ok: true, json: async () => ({ ok: true, icons: {} }) };
+      }
+      if (url.startsWith("/api/prs/issues?")) {
+        return { ok: false, status: 503, json: async () => ({}) };
+      }
+      return { ok: false, status: 404, json: async () => ({}) };
+    });
+
+    render(<PrTicker />);
+    await waitFor(() => expect(screen.getByText("inbox")).toBeInTheDocument());
+    fireEvent.click(screen.getByRole("button", { name: "Issues" }));
+    await waitFor(() => expect(screen.getByText("issues failed: HTTP 503")).toBeInTheDocument());
+
+    await vi.advanceTimersByTimeAsync(20_000);
+
+    expect(fetchMock.mock.calls.filter(([url]) => String(url).startsWith("/api/prs/issues?"))).toHaveLength(1);
+    expect(fetchMock.mock.calls.filter(([url]) => url === "/api/prs").length).toBeGreaterThanOrEqual(3);
+
+    fireEvent.click(screen.getByRole("button", { name: "PRs" }));
+    fireEvent.click(screen.getByRole("button", { name: "Issues" }));
+    await waitFor(() => {
+      expect(fetchMock.mock.calls.filter(([url]) => String(url).startsWith("/api/prs/issues?"))).toHaveLength(2);
+    });
+  });
+
+  it("limits issue fetches to four in flight", async () => {
+    const repos = Array.from({ length: 7 }, (_, index) => makeRepo({
+      name: `repo-${index}`,
+      fullName: `claudes-world/repo-${index}`,
+    }));
+    let inFlight = 0;
+    let maxInFlight = 0;
+    let releaseFetches: (() => void) | undefined;
+    const fetchGate = new Promise<void>((resolve) => { releaseFetches = resolve; });
+
+    fetchMock.mockImplementation(async (url: string) => {
+      if (url === "/api/prs") {
+        return {
+          ok: true,
+          json: async () => ({ ok: true, prs: [], repos, lastPollOk: Date.now() }),
+        };
+      }
+      if (url === "/api/prs/icons") {
+        return { ok: true, json: async () => ({ ok: true, icons: {} }) };
+      }
+      if (url.startsWith("/api/prs/issues?")) {
+        inFlight += 1;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        await fetchGate;
+        inFlight -= 1;
+        return { ok: true, json: async () => ({ ok: true, issues: [] }) };
+      }
+      return { ok: false, status: 404, json: async () => ({}) };
+    });
+
+    render(<PrTicker />);
+    await waitFor(() => expect(screen.getByText("7 repos")).toBeInTheDocument());
+    fireEvent.click(screen.getByRole("button", { name: "Issues" }));
+
+    await waitFor(() => {
+      expect(fetchMock.mock.calls.filter(([url]) => String(url).startsWith("/api/prs/issues?"))).toHaveLength(4);
+    });
+    expect(maxInFlight).toBe(4);
+
+    releaseFetches?.();
+    await waitFor(() => {
+      expect(fetchMock.mock.calls.filter(([url]) => String(url).startsWith("/api/prs/issues?"))).toHaveLength(7);
+    });
+    expect(maxInFlight).toBe(4);
+  });
+
+  it("drops stale issue responses after a force refresh starts", async () => {
+    const repo = makeRepo();
+    const staleIssue = makeIssue({ number: 1, key: "claudes-world/inbox#1", title: "Stale issue" });
+    const freshIssue = makeIssue({ number: 2, key: "claudes-world/inbox#2", title: "Fresh issue" });
+    let resolveStale: ((response: unknown) => void) | undefined;
+    const staleResponse = new Promise<unknown>((resolve) => { resolveStale = resolve; });
+    let staleResponseRead = false;
+    let issueFetchCount = 0;
+
+    fetchMock.mockImplementation(async (url: string) => {
+      if (url === "/api/prs") {
+        return {
+          ok: true,
+          json: async () => ({ ok: true, prs: [], repos: [repo], lastPollOk: Date.now() }),
+        };
+      }
+      if (url === "/api/prs/icons") {
+        return { ok: true, json: async () => ({ ok: true, icons: {} }) };
+      }
+      if (url.startsWith("/api/prs/issues?")) {
+        issueFetchCount += 1;
+        if (issueFetchCount === 1) return staleResponse;
+        return { ok: true, json: async () => ({ ok: true, issues: [freshIssue] }) };
+      }
+      return { ok: false, status: 404, json: async () => ({}) };
+    });
+
+    render(<PrTicker />);
+    await waitFor(() => expect(screen.getByText("inbox")).toBeInTheDocument());
+    fireEvent.click(screen.getByRole("button", { name: "Issues" }));
+    await waitFor(() => expect(issueFetchCount).toBe(1));
+
+    fireEvent.click(screen.getByRole("button", { name: "Refresh issues" }));
+    await waitFor(() => expect(screen.getByText("Fresh issue")).toBeInTheDocument());
+
+    resolveStale?.({
+      ok: true,
+      json: async () => {
+        staleResponseRead = true;
+        return { ok: true, issues: [staleIssue] };
+      },
+    });
+    await waitFor(() => expect(staleResponseRead).toBe(true));
+    expect(screen.getByText("Fresh issue")).toBeInTheDocument();
+    expect(screen.queryByText("Stale issue")).not.toBeInTheDocument();
+  });
+
   it("renders repo icons once with org-avatar and text-only fallbacks", async () => {
     const inbox = makeRepo();
     const cpc = makeRepo({ name: "cpc", fullName: "claudes-world/cpc" });

--- a/apps/web/src/components/__tests__/PrTicker.test.tsx
+++ b/apps/web/src/components/__tests__/PrTicker.test.tsx
@@ -55,6 +55,21 @@ function makeRepo(overrides: Record<string, unknown> = {}) {
   };
 }
 
+function makeIssue(overrides: Record<string, unknown> = {}) {
+  return {
+    key: "claudes-world/inbox#215",
+    repo: "claudes-world/inbox",
+    number: 215,
+    title: "Add issues mode",
+    state: "OPEN",
+    author: "octocat",
+    updatedAt: new Date().toISOString(),
+    labels: ["enhancement", "web", "mobile", "fourth-hidden"],
+    url: "https://github.com/claudes-world/inbox/issues/215",
+    ...overrides,
+  };
+}
+
 let fetchMock: ReturnType<typeof vi.fn>;
 
 beforeEach(() => {
@@ -438,5 +453,114 @@ describe("PrTicker", () => {
     render(<PrTicker />);
     await waitFor(() => expect(screen.getByText("inbox")).toBeInTheDocument());
     expect(screen.queryByText("Persisted collapse")).not.toBeInTheDocument();
+  });
+
+  it("switches between PRs and Issues and force-refreshes visible repo issues", async () => {
+    const pr = makePr({ title: "PR-only title" });
+    const issue = makeIssue();
+    const repo = makeRepo({ prCount: 1 });
+    fetchMock.mockImplementation(async (url: string) => {
+      if (url === "/api/prs") {
+        return {
+          ok: true,
+          json: async () => ({ ok: true, prs: [pr], repos: [repo], lastPollOk: Date.now() }),
+        };
+      }
+      if (url === "/api/prs/icons") {
+        return { ok: true, json: async () => ({ ok: true, icons: {} }) };
+      }
+      if (url.startsWith("/api/prs/issues?")) {
+        return { ok: true, json: async () => ({ ok: true, issues: [issue] }) };
+      }
+      return { ok: false, status: 404, json: async () => ({}) };
+    });
+
+    render(<PrTicker />);
+    await waitFor(() => expect(screen.getByText("PR-only title")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole("button", { name: "Issues" }));
+    await waitFor(() => {
+      expect(screen.getByText("Add issues mode")).toBeInTheDocument();
+      expect(screen.queryByText("PR-only title")).not.toBeInTheDocument();
+    });
+    expect(screen.getByText("enhancement")).toBeInTheDocument();
+    expect(screen.getByText("web")).toBeInTheDocument();
+    expect(screen.getByText("mobile")).toBeInTheDocument();
+    expect(screen.queryByText("fourth-hidden")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Refresh issues" }));
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/prs/issues?repo=claudes-world%2Finbox&force=1",
+        expect.objectContaining({ headers: { Authorization: "tma test-init-data" } }),
+      );
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "PRs" }));
+    expect(screen.getByText("PR-only title")).toBeInTheDocument();
+  });
+
+  it("does not fetch issues during the 10-second PR polling interval", async () => {
+    const repo = makeRepo();
+    fetchMock.mockImplementation(async (url: string) => {
+      if (url === "/api/prs") {
+        return {
+          ok: true,
+          json: async () => ({ ok: true, prs: [], repos: [repo], lastPollOk: Date.now() }),
+        };
+      }
+      if (url === "/api/prs/icons") {
+        return { ok: true, json: async () => ({ ok: true, icons: {} }) };
+      }
+      if (url.startsWith("/api/prs/issues?")) {
+        return { ok: true, json: async () => ({ ok: true, issues: [] }) };
+      }
+      return { ok: false, status: 404, json: async () => ({}) };
+    });
+
+    render(<PrTicker />);
+    await waitFor(() => expect(screen.getByText("inbox")).toBeInTheDocument());
+    await vi.advanceTimersByTimeAsync(20_000);
+
+    expect(fetchMock.mock.calls.filter(([url]) => String(url).startsWith("/api/prs/issues?"))).toHaveLength(0);
+    expect(fetchMock.mock.calls.filter(([url]) => url === "/api/prs").length).toBeGreaterThanOrEqual(3);
+
+    fireEvent.click(screen.getByRole("button", { name: "Issues" }));
+    await waitFor(() => {
+      expect(fetchMock.mock.calls.filter(([url]) => String(url).startsWith("/api/prs/issues?"))).toHaveLength(1);
+    });
+  });
+
+  it("renders repo icons once with org-avatar and text-only fallbacks", async () => {
+    const inbox = makeRepo();
+    const cpc = makeRepo({ name: "cpc", fullName: "claudes-world/cpc" });
+    const icon = "data:image/png;base64,aWNvbg==";
+    fetchMock.mockImplementation(async (url: string) => {
+      if (url === "/api/prs") {
+        return {
+          ok: true,
+          json: async () => ({ ok: true, prs: [], repos: [inbox, cpc], lastPollOk: Date.now() }),
+        };
+      }
+      if (url === "/api/prs/icons") {
+        return {
+          ok: true,
+          json: async () => ({ ok: true, icons: { "claudes-world/inbox": icon } }),
+        };
+      }
+      return { ok: false, status: 404, json: async () => ({}) };
+    });
+
+    render(<PrTicker />);
+    const repoIcon = await screen.findByAltText("inbox icon");
+    const orgAvatar = screen.getByAltText("claudes-world avatar");
+
+    expect(repoIcon).toHaveAttribute("src", icon);
+    expect(orgAvatar).toHaveAttribute("src", "https://avatars.githubusercontent.com/claudes-world?s=32");
+    expect(screen.queryByAltText("cpc icon")).not.toBeInTheDocument();
+    expect(fetchMock.mock.calls.filter(([url]) => url === "/api/prs/icons")).toHaveLength(1);
+
+    fireEvent.error(repoIcon);
+    expect(repoIcon).toHaveStyle({ display: "none" });
   });
 });


### PR DESCRIPTION
## Summary
- **PRs | Issues segmented toggle** in the PRs-tab header. Issues are fetched **on demand only** — on toggle switch or manual ↻ — never in the 10s poll (the poller already exhausts GitHub API quota; this was a deliberate design constraint). Server: `GET /api/prs/issues?repo=<fullName>`, validated against discovered repos (400 otherwise), `gh` via execFile with literal argv, per-repo 5-min cache with `?force=1` bypass. Rows reuse the org/repo grouping + visibility prefs from #305: state dot, #number, title, author, label pills (max 3), timeAgo.
- **Repo icons** (t3code-style): one authenticated `GET /api/prs/icons` returns data URIs from a well-known-path scan of each local checkout (realpath-contained, ≤64 KB, svg/ico/png only, 30-min cache) — a raw image endpoint would have to be unauthenticated since `<img>` can't send the `tma` header. Org headers fall back to GitHub's public avatar CDN; broken images hide via `onError`.

## Tests
Server 365/365 (+repo validation, gh mapping, cache TTL + force, icon candidate order/size/mime). Web 295/295 (+toggle switching, issues fetched only on demand — asserts no issues fetch during interval polling — icon render + fallback). Typechecks + vite build clean.

## Visual proof
Live dev instance (port 38833), real signed initData, 24 real repos: PRs view renders org avatars + a repo favicon; toggling **Issues** fetched on demand (footer shows "218 issues · on demand") and rendered real issues with state dots, label pills, and timestamps across orgs; toggling back to PRs intact. Dev server killed after proof.

Fixes #215
Fixes #216
Part of the dev-cpc-features integration group.

🤖 Generated with [Claude Code](https://claude.com/claude-code)