### PR TITLE
feat(reading-list): v2 UI — Links-tab section + Save action in file viewer (#149)

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -135,7 +135,7 @@ export function App() {
   // default explicitly by name is harmless (server resolves both to the
   // same session), so the pessimistic default is safe either way.
   const paletteSession = activeSession !== null && activeSession !== defaultSession ? activeSession : null;
-  const [initialFilePath] = useState<string | null>(initialFile);
+  const [fileOpenRequest, setFileOpenRequest] = useState({ path: initialFile, sequence: 0 });
   const [fileShowHidden, setFileShowHidden] = useState<boolean>(() => {
     try { return localStorage.getItem(HIDDEN_KEY) === "1"; } catch { return false; }
   });
@@ -157,6 +157,13 @@ export function App() {
   const [currentFolder, setCurrentFolder] = useState<string | null>(null);
   const [cpcBranch, setCpcBranch] = useState<string | null>(null);
   const [showHomeScreenPrompt, setShowHomeScreenPrompt] = useState(false);
+
+  const openFileFromReadingList = useCallback((path: string) => {
+    setViewingFile(null);
+    setFileOpenRequest((request) => ({ path, sequence: request.sequence + 1 }));
+    setIsAnimating(true);
+    setActiveTab("files");
+  }, []);
 
   const onConnectionChange = useCallback((c: boolean) => setConnected(c), []);
   const onReconnect = useCallback(() => {
@@ -556,10 +563,10 @@ export function App() {
             />
           </div>
           <div style={{ width: `${100 / TABS.length}%`, height: "100%", flexShrink: 0 }}>
-            <FileViewer onClose={() => setActiveTab("terminal")} initialFile={initialFilePath} showHidden={fileShowHidden} sortMode={fileSortMode} onSortModeChange={setFileSortMode} onViewChange={setViewingFile} onPathChange={setCurrentFolder} />
+            <FileViewer key={fileOpenRequest.sequence} onClose={() => setActiveTab("terminal")} initialFile={fileOpenRequest.path} showHidden={fileShowHidden} sortMode={fileSortMode} onSortModeChange={setFileSortMode} onViewChange={setViewingFile} onPathChange={setCurrentFolder} />
           </div>
           <div style={{ width: `${100 / TABS.length}%`, height: "100%", flexShrink: 0 }}>
-            <Links onClose={() => setActiveTab("terminal")} />
+            <Links onClose={() => setActiveTab("terminal")} onOpenFile={openFileFromReadingList} />
           </div>
           <div style={{ width: `${100 / TABS.length}%`, height: "100%", flexShrink: 0 }}>
             <VoiceRecorder />

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -136,6 +136,11 @@ export function App() {
   // same session), so the pessimistic default is safe either way.
   const paletteSession = activeSession !== null && activeSession !== defaultSession ? activeSession : null;
   const [fileOpenRequest, setFileOpenRequest] = useState({ path: initialFile, sequence: 0 });
+  // FileViewer is keyed by this request sequence. Keep the latest request in
+  // a ref so callbacks retained by an unmounted viewer cannot publish a late
+  // file/path result over the replacement viewer's state.
+  const fileOpenRequestRef = useRef(fileOpenRequest);
+  fileOpenRequestRef.current = fileOpenRequest;
   const [fileShowHidden, setFileShowHidden] = useState<boolean>(() => {
     try { return localStorage.getItem(HIDDEN_KEY) === "1"; } catch { return false; }
   });
@@ -157,6 +162,14 @@ export function App() {
   const [currentFolder, setCurrentFolder] = useState<string | null>(null);
   const [cpcBranch, setCpcBranch] = useState<string | null>(null);
   const [showHomeScreenPrompt, setShowHomeScreenPrompt] = useState(false);
+
+  const fileViewerSequence = fileOpenRequest.sequence;
+  const handleFileViewChange = useCallback((file: { path: string; name: string } | null) => {
+    if (fileViewerSequence === fileOpenRequestRef.current.sequence) setViewingFile(file);
+  }, [fileViewerSequence]);
+  const handleFilePathChange = useCallback((path: string) => {
+    if (fileViewerSequence === fileOpenRequestRef.current.sequence) setCurrentFolder(path);
+  }, [fileViewerSequence]);
 
   const openFileFromReadingList = useCallback((path: string) => {
     setViewingFile(null);
@@ -563,7 +576,7 @@ export function App() {
             />
           </div>
           <div style={{ width: `${100 / TABS.length}%`, height: "100%", flexShrink: 0 }}>
-            <FileViewer key={fileOpenRequest.sequence} onClose={() => setActiveTab("terminal")} initialFile={fileOpenRequest.path} showHidden={fileShowHidden} sortMode={fileSortMode} onSortModeChange={setFileSortMode} onViewChange={setViewingFile} onPathChange={setCurrentFolder} />
+            <FileViewer key={fileOpenRequest.sequence} onClose={() => setActiveTab("terminal")} initialFile={fileOpenRequest.path} showHidden={fileShowHidden} sortMode={fileSortMode} onSortModeChange={setFileSortMode} onViewChange={handleFileViewChange} onPathChange={handleFilePathChange} />
           </div>
           <div style={{ width: `${100 / TABS.length}%`, height: "100%", flexShrink: 0 }}>
             <Links onClose={() => setActiveTab("terminal")} onOpenFile={openFileFromReadingList} />

--- a/apps/web/src/__tests__/App.test.tsx
+++ b/apps/web/src/__tests__/App.test.tsx
@@ -1,0 +1,102 @@
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+interface MockFileViewerProps {
+  initialFile?: string | null;
+  onViewChange?: (file: { path: string; name: string } | null) => void;
+  onPathChange?: (path: string) => void;
+}
+
+const mockFileViewerPropsByPath = new Map<string | null, MockFileViewerProps>();
+
+vi.mock("../components/Terminal", () => ({
+  Terminal: () => <div>Terminal</div>,
+}));
+
+vi.mock("../components/FileViewer", () => ({
+  FileViewer: (props: MockFileViewerProps) => {
+    mockFileViewerPropsByPath.set(props.initialFile ?? null, props);
+    return <div>File viewer: {props.initialFile}</div>;
+  },
+}));
+
+vi.mock("../components/Links", () => ({
+  Links: ({ onOpenFile }: { onOpenFile: (path: string) => void }) => (
+    <button onClick={() => onOpenFile("/new.ts")}>Open new reading-list file</button>
+  ),
+}));
+
+vi.mock("../components/action-bar", () => ({
+  ActionBar: ({
+    viewingFile,
+    currentFolder,
+  }: {
+    viewingFile?: { path: string; name: string } | null;
+    currentFolder?: string | null;
+  }) => (
+    <div>
+      <span data-testid="action-file">{viewingFile?.path ?? "none"}</span>
+      <span data-testid="action-folder">{currentFolder ?? "none"}</span>
+    </div>
+  ),
+}));
+
+vi.mock("../components/VoiceRecorder", () => ({ VoiceRecorder: () => <div>Voice</div> }));
+vi.mock("../components/PrTicker", () => ({ PrTicker: () => <div>PRs</div> }));
+vi.mock("../components/HomeScreenPrompt", () => ({ HomeScreenPrompt: () => null }));
+vi.mock("../components/SessionPicker", () => ({ SessionPicker: () => null }));
+vi.mock("../debug/DebugOverlay", () => ({ DebugOverlay: () => null }));
+vi.mock("../lib/haptic", () => ({
+  haptic: { selection: vi.fn() },
+}));
+vi.mock("../lib/telegram", () => ({
+  getTelegramWebApp: () => null,
+  getAuthHeaders: () => ({}),
+  hasAuth: () => true,
+  setSessionToken: vi.fn(),
+}));
+
+import { App } from "../App";
+
+beforeEach(() => {
+  mockFileViewerPropsByPath.clear();
+  window.history.replaceState(null, "", "#files&file=%2Fold.ts");
+  localStorage.setItem("cpc:home-screen-prompted", "1");
+  vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+    json: async () => ({ ok: false }),
+  }));
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  localStorage.clear();
+  window.history.replaceState(null, "", "#");
+});
+
+describe("App FileViewer callback ownership", () => {
+  it("drops the old viewer's late callbacks after a reading-list open", async () => {
+    render(<App />);
+    const oldViewer = mockFileViewerPropsByPath.get("/old.ts");
+    expect(oldViewer).toBeDefined();
+
+    act(() => {
+      oldViewer?.onViewChange?.({ path: "/old.ts", name: "old.ts" });
+      oldViewer?.onPathChange?.("/old-folder");
+    });
+    expect(screen.getByTestId("action-file")).toHaveTextContent("/old.ts");
+
+    fireEvent.click(screen.getByText("Open new reading-list file"));
+    await waitFor(() => expect(mockFileViewerPropsByPath.has("/new.ts")).toBe(true));
+    const newViewer = mockFileViewerPropsByPath.get("/new.ts");
+
+    act(() => {
+      newViewer?.onViewChange?.({ path: "/new.ts", name: "new.ts" });
+      newViewer?.onPathChange?.("/new-folder");
+      oldViewer?.onViewChange?.({ path: "/stale.ts", name: "stale.ts" });
+      oldViewer?.onPathChange?.("/stale-folder");
+    });
+
+    expect(screen.getByTestId("action-file")).toHaveTextContent("/new.ts");
+    expect(screen.getByTestId("action-folder")).toHaveTextContent("/new-folder");
+  });
+});

--- a/apps/web/src/components/Links.tsx
+++ b/apps/web/src/components/Links.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { getTelegramWebApp } from "../lib/telegram";
+import { ReadingList } from "./ReadingList";
 import "./Links.css";
 
 interface LinkItem {
@@ -106,9 +107,10 @@ const APPS: AppItem[] = [
 
 interface LinksProps {
   onClose: () => void;
+  onOpenFile: (path: string) => void;
 }
 
-export function Links({ onClose }: LinksProps) {
+export function Links({ onClose, onOpenFile }: LinksProps) {
   return (
     <div style={{ display: "flex", flexDirection: "column", height: "100%" }}>
       <div
@@ -138,6 +140,7 @@ export function Links({ onClose }: LinksProps) {
       </div>
 
       <div style={{ flex: 1, overflow: "auto" }}>
+        <ReadingList onOpenFile={onOpenFile} />
         {LINKS.map((link) => (
           <a
             key={link.url}

--- a/apps/web/src/components/ReadingList.tsx
+++ b/apps/web/src/components/ReadingList.tsx
@@ -55,7 +55,6 @@ export function ReadingList({ onOpenFile }: ReadingListProps) {
   }, [loadItems]);
 
   const removeItem = async (item: ReadingListItem) => {
-    const originalIndex = items.findIndex((candidate) => candidate.id === item.id);
     haptic.impact("light");
     setError(null);
     setItems((current) => current.filter((candidate) => candidate.id !== item.id));
@@ -67,9 +66,7 @@ export function ReadingList({ onOpenFile }: ReadingListProps) {
       haptic.error();
       setItems((current) => {
         if (current.some((candidate) => candidate.id === item.id)) return current;
-        const restored = [...current];
-        restored.splice(Math.max(0, Math.min(originalIndex, restored.length)), 0, item);
-        return restored;
+        return [...current, item].sort((a, b) => b.created_at - a.created_at);
       });
       setError(err instanceof Error ? err.message : "Failed to remove item");
     }

--- a/apps/web/src/components/ReadingList.tsx
+++ b/apps/web/src/components/ReadingList.tsx
@@ -1,0 +1,199 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { deleteReadingListItem, fetchReadingList } from "./action-bar/api";
+import type { ReadingListItem } from "./action-bar/types";
+import { haptic } from "../lib/haptic";
+import { emitReadingListChanged, READING_LIST_CHANGED_EVENT } from "../lib/reading-list-events";
+
+interface ReadingListProps {
+  onOpenFile: (path: string) => void;
+}
+
+function fileName(item: ReadingListItem): string {
+  return item.title || item.path.split("/").pop() || item.path;
+}
+
+function timeAgo(timestamp: number): string {
+  const seconds = Math.max(0, Math.floor((Date.now() - timestamp) / 1000));
+  if (seconds < 60) return `${seconds}s ago`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  return `${Math.floor(hours / 24)}d ago`;
+}
+
+export function ReadingList({ onOpenFile }: ReadingListProps) {
+  const [items, setItems] = useState<ReadingListItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const loadSeqRef = useRef(0);
+
+  const loadItems = useCallback(async () => {
+    const seq = ++loadSeqRef.current;
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await fetchReadingList();
+      if (seq === loadSeqRef.current) setItems(data.items);
+    } catch (err) {
+      if (seq === loadSeqRef.current) {
+        setError(err instanceof Error ? err.message : "Failed to load reading list");
+      }
+    } finally {
+      if (seq === loadSeqRef.current) setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadItems();
+    const refresh = () => void loadItems();
+    window.addEventListener(READING_LIST_CHANGED_EVENT, refresh);
+    return () => {
+      ++loadSeqRef.current;
+      window.removeEventListener(READING_LIST_CHANGED_EVENT, refresh);
+    };
+  }, [loadItems]);
+
+  const removeItem = async (item: ReadingListItem) => {
+    const originalIndex = items.findIndex((candidate) => candidate.id === item.id);
+    haptic.impact("light");
+    setError(null);
+    setItems((current) => current.filter((candidate) => candidate.id !== item.id));
+    try {
+      await deleteReadingListItem({ id: item.id });
+      haptic.success();
+      emitReadingListChanged();
+    } catch (err) {
+      haptic.error();
+      setItems((current) => {
+        if (current.some((candidate) => candidate.id === item.id)) return current;
+        const restored = [...current];
+        restored.splice(Math.max(0, Math.min(originalIndex, restored.length)), 0, item);
+        return restored;
+      });
+      setError(err instanceof Error ? err.message : "Failed to remove item");
+    }
+  };
+
+  return (
+    <section
+      aria-label="Reading List"
+      style={{
+        borderBottom: "1px solid var(--color-border)",
+        background: "var(--color-bg)",
+      }}
+    >
+      <div
+        style={{
+          padding: "12px 16px 8px",
+          display: "flex",
+          alignItems: "baseline",
+          gap: 8,
+        }}
+      >
+        <span style={{ color: "var(--color-fg)", fontSize: 14, fontWeight: 600 }}>
+          Reading List
+        </span>
+        <span aria-label={`${items.length} items`} style={{ color: "var(--color-muted)", fontSize: 12 }}>
+          {items.length}
+        </span>
+      </div>
+
+      {loading && items.length === 0 ? (
+        <div style={{ padding: "4px 16px 14px", color: "var(--color-muted)", fontSize: 12 }}>
+          Loading…
+        </div>
+      ) : items.length === 0 && !error ? (
+        <div style={{ padding: "4px 16px 14px", color: "var(--color-muted)", fontSize: 12 }}>
+          Nothing saved yet — use 'Save to reading list' when viewing a file.
+        </div>
+      ) : (
+        items.map((item) => {
+          const name = fileName(item);
+          return (
+            <div
+              key={item.id}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 8,
+                padding: "9px 10px 9px 16px",
+                borderTop: "1px solid var(--color-separator)",
+              }}
+            >
+              <button
+                type="button"
+                onClick={() => {
+                  haptic.impact("light");
+                  onOpenFile(item.path);
+                }}
+                style={{
+                  minWidth: 0,
+                  flex: 1,
+                  padding: 0,
+                  border: "none",
+                  background: "none",
+                  textAlign: "left",
+                }}
+              >
+                <div
+                  style={{
+                    color: "var(--color-fg)",
+                    fontSize: 13,
+                    fontWeight: 600,
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                    whiteSpace: "nowrap",
+                  }}
+                >
+                  {name}
+                </div>
+                <div
+                  title={item.path}
+                  style={{
+                    color: "var(--color-muted)",
+                    fontSize: 11,
+                    marginTop: 2,
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                    whiteSpace: "nowrap",
+                  }}
+                >
+                  {item.path}
+                </div>
+                <div style={{ color: "var(--color-subtle)", fontSize: 10, marginTop: 2 }}>
+                  saved {timeAgo(item.created_at)}
+                </div>
+              </button>
+              <button
+                type="button"
+                aria-label={`Remove ${name}`}
+                title="Remove from reading list"
+                onClick={() => void removeItem(item)}
+                style={{
+                  width: 30,
+                  height: 30,
+                  flexShrink: 0,
+                  padding: 0,
+                  borderRadius: 6,
+                  border: "1px solid var(--color-border)",
+                  background: "var(--color-surface)",
+                  color: "var(--color-accent-red)",
+                  fontSize: 14,
+                }}
+              >
+                ✕
+              </button>
+            </div>
+          );
+        })
+      )}
+
+      {error && (
+        <div role="alert" style={{ padding: "4px 16px 10px", color: "var(--color-accent-red)", fontSize: 11 }}>
+          {error}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/components/__tests__/ActionBar.test.tsx
+++ b/apps/web/src/components/__tests__/ActionBar.test.tsx
@@ -208,6 +208,32 @@ describe("ActionBar", () => {
     expect(screen.getByRole("button", { name: "Save to reading list" })).toBeEnabled();
   });
 
+  it("does not lock the next file's Save button while a previous file's save is in flight", async () => {
+    let resolveSave!: (value: { ok: boolean }) => void;
+    mockSaveReadingListItem.mockImplementationOnce(() => new Promise((resolve) => { resolveSave = resolve; }));
+    mockCheckReadingListPaths.mockResolvedValue({ saved: {} });
+
+    const { rerender } = render(
+      <ActionBar activeTab="files" viewingFile={{ path: "/tmp/a.ts", name: "a.ts" }} />,
+    );
+    await waitFor(() => expect(screen.getByRole("button", { name: "Save to reading list" })).toBeEnabled());
+    fireEvent.click(screen.getByRole("button", { name: "Save to reading list" }));
+    expect(screen.getByRole("button", { name: "Saving…" })).toBeDisabled();
+
+    // Navigate to another file while A's save is still pending: B's button
+    // must be enabled and tappable, not stuck on "Saving…".
+    rerender(<ActionBar activeTab="files" viewingFile={{ path: "/tmp/b.ts", name: "b.ts" }} />);
+    await waitFor(() => expect(screen.getByRole("button", { name: "Save to reading list" })).toBeEnabled());
+    fireEvent.click(screen.getByRole("button", { name: "Save to reading list" }));
+    await waitFor(() => expect(mockSaveReadingListItem).toHaveBeenCalledWith("/tmp/b.ts", "b.ts"));
+
+    await act(async () => {
+      resolveSave({ ok: true });
+      await Promise.resolve();
+    });
+    expect(mockSaveReadingListItem).toHaveBeenCalledTimes(2);
+  });
+
   it("reports a reading-list save failure and leaves Save available", async () => {
     mockSaveReadingListItem.mockRejectedValue(new Error("Access denied"));
     render(<ActionBar activeTab="files" viewingFile={{ path: "/tmp/app.ts", name: "app.ts" }} />);

--- a/apps/web/src/components/__tests__/ActionBar.test.tsx
+++ b/apps/web/src/components/__tests__/ActionBar.test.tsx
@@ -264,9 +264,10 @@ describe("ActionBar", () => {
     fireEvent.click(screen.getByRole("button", { name: "Save to reading list" }));
     expect(mockSaveReadingListItem).toHaveBeenCalledTimes(2);
 
+    // Returning to A while its save is still pending must show "Saving…"
+    // (disabled), not an enabled button whose tap would silently no-op.
     rerender(<ActionBar activeTab="files" viewingFile={{ path: "/tmp/a.ts", name: "a.ts" }} />);
-    await waitFor(() => expect(screen.getByRole("button", { name: "Save to reading list" })).toBeEnabled());
-    fireEvent.click(screen.getByRole("button", { name: "Save to reading list" }));
+    await waitFor(() => expect(screen.getByRole("button", { name: "Saving…" })).toBeDisabled());
     expect(mockSaveReadingListItem).toHaveBeenCalledTimes(2);
 
     await act(async () => {

--- a/apps/web/src/components/__tests__/ActionBar.test.tsx
+++ b/apps/web/src/components/__tests__/ActionBar.test.tsx
@@ -208,9 +208,12 @@ describe("ActionBar", () => {
     expect(screen.getByRole("button", { name: "Save to reading list" })).toBeEnabled();
   });
 
-  it("does not lock the next file's Save button while a previous file's save is in flight", async () => {
-    let resolveSave!: (value: { ok: boolean }) => void;
-    mockSaveReadingListItem.mockImplementationOnce(() => new Promise((resolve) => { resolveSave = resolve; }));
+  it("keeps B saving through A's refresh and clears it when B settles", async () => {
+    let resolveSaveA!: (value: { ok: boolean }) => void;
+    let resolveSaveB!: (value: { ok: boolean }) => void;
+    mockSaveReadingListItem
+      .mockImplementationOnce(() => new Promise((resolve) => { resolveSaveA = resolve; }))
+      .mockImplementationOnce(() => new Promise((resolve) => { resolveSaveB = resolve; }));
     mockCheckReadingListPaths.mockResolvedValue({ saved: {} });
 
     const { rerender } = render(
@@ -225,13 +228,52 @@ describe("ActionBar", () => {
     rerender(<ActionBar activeTab="files" viewingFile={{ path: "/tmp/b.ts", name: "b.ts" }} />);
     await waitFor(() => expect(screen.getByRole("button", { name: "Save to reading list" })).toBeEnabled());
     fireEvent.click(screen.getByRole("button", { name: "Save to reading list" }));
-    await waitFor(() => expect(mockSaveReadingListItem).toHaveBeenCalledWith("/tmp/b.ts", "b.ts"));
+    expect(screen.getByRole("button", { name: "Saving…" })).toBeDisabled();
 
     await act(async () => {
-      resolveSave({ ok: true });
+      resolveSaveA({ ok: true });
       await Promise.resolve();
     });
+    await waitFor(() => expect(mockCheckReadingListPaths).toHaveBeenCalledTimes(3));
+    expect(screen.getByRole("button", { name: "Saving…" })).toBeDisabled();
+
+    await act(async () => {
+      resolveSaveB({ ok: true });
+      await Promise.resolve();
+    });
+    await waitFor(() => expect(screen.getByRole("button", { name: "Save to reading list" })).toBeEnabled());
     expect(mockSaveReadingListItem).toHaveBeenCalledTimes(2);
+  });
+
+  it("allows concurrent saves on A and B while blocking a second save on pending A", async () => {
+    let resolveSaveA!: (value: { ok: boolean }) => void;
+    let resolveSaveB!: (value: { ok: boolean }) => void;
+    mockSaveReadingListItem
+      .mockImplementationOnce(() => new Promise((resolve) => { resolveSaveA = resolve; }))
+      .mockImplementationOnce(() => new Promise((resolve) => { resolveSaveB = resolve; }));
+    mockCheckReadingListPaths.mockResolvedValue({ saved: {} });
+
+    const { rerender } = render(
+      <ActionBar activeTab="files" viewingFile={{ path: "/tmp/a.ts", name: "a.ts" }} />,
+    );
+    await waitFor(() => expect(screen.getByRole("button", { name: "Save to reading list" })).toBeEnabled());
+    fireEvent.click(screen.getByRole("button", { name: "Save to reading list" }));
+
+    rerender(<ActionBar activeTab="files" viewingFile={{ path: "/tmp/b.ts", name: "b.ts" }} />);
+    await waitFor(() => expect(screen.getByRole("button", { name: "Save to reading list" })).toBeEnabled());
+    fireEvent.click(screen.getByRole("button", { name: "Save to reading list" }));
+    expect(mockSaveReadingListItem).toHaveBeenCalledTimes(2);
+
+    rerender(<ActionBar activeTab="files" viewingFile={{ path: "/tmp/a.ts", name: "a.ts" }} />);
+    await waitFor(() => expect(screen.getByRole("button", { name: "Save to reading list" })).toBeEnabled());
+    fireEvent.click(screen.getByRole("button", { name: "Save to reading list" }));
+    expect(mockSaveReadingListItem).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      resolveSaveA({ ok: true });
+      resolveSaveB({ ok: true });
+      await Promise.resolve();
+    });
   });
 
   it("reports a reading-list save failure and leaves Save available", async () => {

--- a/apps/web/src/components/__tests__/ActionBar.test.tsx
+++ b/apps/web/src/components/__tests__/ActionBar.test.tsx
@@ -52,6 +52,8 @@ const mockSendAudioTelegram = vi.fn();
 const mockRestartSession = vi.fn();
 const mockSendFileToChat = vi.fn();
 const mockPublishShared = vi.fn();
+const mockCheckReadingListPaths = vi.fn();
+const mockSaveReadingListItem = vi.fn();
 
 vi.mock("../action-bar/api", () => ({
   postAction: (...args: unknown[]) => mockPostAction(...args),
@@ -71,6 +73,8 @@ vi.mock("../action-bar/api", () => ({
   restartSession: (...args: unknown[]) => mockRestartSession(...args),
   sendFileToChat: (...args: unknown[]) => mockSendFileToChat(...args),
   publishShared: (...args: unknown[]) => mockPublishShared(...args),
+  checkReadingListPaths: (...args: unknown[]) => mockCheckReadingListPaths(...args),
+  saveReadingListItem: (...args: unknown[]) => mockSaveReadingListItem(...args),
   summarizeMarkdown: vi.fn().mockResolvedValue({ ok: true, summary: "Test summary", cached: false, ms: 100 }),
 }));
 
@@ -96,6 +100,8 @@ beforeEach(() => {
   mockRestartSession.mockResolvedValue({ ok: true });
   mockSendFileToChat.mockResolvedValue({ ok: true });
   mockPublishShared.mockResolvedValue({ ok: true, url: "https://shared.claude.do/public/test-abc" });
+  mockCheckReadingListPaths.mockResolvedValue({ saved: {} });
+  mockSaveReadingListItem.mockResolvedValue({ ok: true, id: 1 });
   mockDeleteSessionName.mockResolvedValue(undefined);
 });
 
@@ -152,6 +158,67 @@ describe("ActionBar", () => {
   it("shows Share button when viewing any file", () => {
     render(<ActionBar activeTab="files" viewingFile={{ path: "/tmp/app.ts", name: "app.ts" }} />);
     expect(screen.getByText("Share")).toBeInTheDocument();
+  });
+
+  it("saves the viewed file and flips the button to Saved", async () => {
+    const file = { path: "/tmp/app.ts", name: "app.ts" };
+    mockCheckReadingListPaths
+      .mockResolvedValueOnce({ saved: { [file.path]: false } })
+      .mockResolvedValue({ saved: { [file.path]: true } });
+    render(<ActionBar activeTab="files" viewingFile={file} />);
+
+    await waitFor(() => expect(screen.getByRole("button", { name: "Save to reading list" })).toBeEnabled());
+    fireEvent.click(screen.getByRole("button", { name: "Save to reading list" }));
+
+    await waitFor(() => {
+      expect(mockSaveReadingListItem).toHaveBeenCalledWith(file.path, file.name);
+      expect(screen.getByRole("button", { name: "Saved ✓" })).toBeDisabled();
+      expect(screen.getByText("Saved to reading list")).toBeInTheDocument();
+    });
+  });
+
+  it("marks a pre-saved viewed file from the initial check", async () => {
+    mockCheckReadingListPaths.mockResolvedValue({ saved: { "/tmp/saved.ts": true } });
+    render(<ActionBar activeTab="files" viewingFile={{ path: "/tmp/saved.ts", name: "saved.ts" }} />);
+
+    await waitFor(() => expect(screen.getByRole("button", { name: "Saved ✓" })).toBeDisabled());
+    expect(mockCheckReadingListPaths).toHaveBeenCalledWith(["/tmp/saved.ts"]);
+  });
+
+  it("drops a stale saved check after the viewed file changes", async () => {
+    let resolveOld!: (value: { saved: Record<string, boolean> }) => void;
+    mockCheckReadingListPaths
+      .mockImplementationOnce(() => new Promise((resolve) => { resolveOld = resolve; }))
+      .mockResolvedValueOnce({ saved: { "/tmp/new.ts": false } });
+
+    const { rerender } = render(
+      <ActionBar activeTab="files" viewingFile={{ path: "/tmp/old.ts", name: "old.ts" }} />,
+    );
+    await waitFor(() => expect(mockCheckReadingListPaths).toHaveBeenCalledWith(["/tmp/old.ts"]));
+
+    rerender(<ActionBar activeTab="files" viewingFile={{ path: "/tmp/new.ts", name: "new.ts" }} />);
+    await waitFor(() => expect(screen.getByRole("button", { name: "Save to reading list" })).toBeEnabled());
+
+    await act(async () => {
+      resolveOld({ saved: { "/tmp/old.ts": true } });
+      await Promise.resolve();
+    });
+
+    expect(screen.queryByRole("button", { name: "Saved ✓" })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Save to reading list" })).toBeEnabled();
+  });
+
+  it("reports a reading-list save failure and leaves Save available", async () => {
+    mockSaveReadingListItem.mockRejectedValue(new Error("Access denied"));
+    render(<ActionBar activeTab="files" viewingFile={{ path: "/tmp/app.ts", name: "app.ts" }} />);
+
+    await waitFor(() => expect(screen.getByRole("button", { name: "Save to reading list" })).toBeEnabled());
+    fireEvent.click(screen.getByRole("button", { name: "Save to reading list" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Failed: Access denied")).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Save to reading list" })).toBeEnabled();
+    });
   });
 
   it("publishes with the selected share mode", async () => {

--- a/apps/web/src/components/__tests__/ReadingList.test.tsx
+++ b/apps/web/src/components/__tests__/ReadingList.test.tsx
@@ -103,4 +103,34 @@ describe("ReadingList", () => {
     expect(screen.getByRole("alert")).toHaveTextContent("Delete failed");
     expect(mockError).toHaveBeenCalled();
   });
+
+  it("restores concurrent failed deletes in newest-first order", async () => {
+    const concurrentItems: ReadingListItem[] = [
+      { id: 3, path: "/tmp/newest.ts", title: "newest.ts", created_at: 3_000 },
+      { id: 2, path: "/tmp/middle.ts", title: "middle.ts", created_at: 2_000 },
+      { id: 1, path: "/tmp/oldest.ts", title: "oldest.ts", created_at: 1_000 },
+    ];
+    let rejectNewest!: (error: Error) => void;
+    let rejectMiddle!: (error: Error) => void;
+    mockFetchReadingList.mockResolvedValue({ items: concurrentItems });
+    mockDeleteReadingListItem
+      .mockImplementationOnce(() => new Promise((_resolve, reject) => { rejectNewest = reject; }))
+      .mockImplementationOnce(() => new Promise((_resolve, reject) => { rejectMiddle = reject; }));
+
+    render(<ReadingList onOpenFile={() => {}} />);
+    await screen.findByText("newest.ts");
+    fireEvent.click(screen.getByRole("button", { name: "Remove newest.ts" }));
+    fireEvent.click(screen.getByRole("button", { name: "Remove middle.ts" }));
+
+    await act(async () => rejectNewest(new Error("Newest delete failed")));
+    await act(async () => rejectMiddle(new Error("Middle delete failed")));
+
+    const names = screen.getAllByRole("button").filter((button) =>
+      button.textContent?.includes(".ts") && !button.getAttribute("aria-label"),
+    );
+    expect(names).toHaveLength(3);
+    expect(names[0]).toHaveTextContent("newest.ts");
+    expect(names[1]).toHaveTextContent("middle.ts");
+    expect(names[2]).toHaveTextContent("oldest.ts");
+  });
 });

--- a/apps/web/src/components/__tests__/ReadingList.test.tsx
+++ b/apps/web/src/components/__tests__/ReadingList.test.tsx
@@ -1,0 +1,106 @@
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ReadingListItem } from "../action-bar/types";
+
+const mockFetchReadingList = vi.fn();
+const mockDeleteReadingListItem = vi.fn();
+const mockImpact = vi.fn();
+const mockSuccess = vi.fn();
+const mockError = vi.fn();
+
+vi.mock("../action-bar/api", () => ({
+  fetchReadingList: (...args: unknown[]) => mockFetchReadingList(...args),
+  deleteReadingListItem: (...args: unknown[]) => mockDeleteReadingListItem(...args),
+}));
+
+vi.mock("../../lib/haptic", () => ({
+  haptic: {
+    impact: (...args: unknown[]) => mockImpact(...args),
+    success: (...args: unknown[]) => mockSuccess(...args),
+    error: (...args: unknown[]) => mockError(...args),
+  },
+}));
+
+import { ReadingList } from "../ReadingList";
+
+const items: ReadingListItem[] = [
+  {
+    id: 2,
+    path: "/home/claude/code/new.ts",
+    title: "new.ts",
+    created_at: Date.now() - 60_000,
+  },
+  {
+    id: 1,
+    path: "/home/claude/code/old.ts",
+    title: "old.ts",
+    created_at: Date.now() - 3_600_000,
+  },
+];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockFetchReadingList.mockResolvedValue({ items });
+  mockDeleteReadingListItem.mockResolvedValue({ ok: true });
+});
+
+describe("ReadingList", () => {
+  it("renders the count, server order, file details, and opens a tapped file", async () => {
+    const onOpenFile = vi.fn();
+    render(<ReadingList onOpenFile={onOpenFile} />);
+
+    await waitFor(() => expect(screen.getByLabelText("2 items")).toBeInTheDocument());
+    const names = screen.getAllByRole("button").filter((button) =>
+      button.textContent?.includes(".ts") && !button.getAttribute("aria-label"),
+    );
+    expect(names[0]).toHaveTextContent("new.ts");
+    expect(names[1]).toHaveTextContent("old.ts");
+    expect(screen.getByText("/home/claude/code/new.ts")).toBeInTheDocument();
+    expect(screen.getByText("saved 1m ago")).toBeInTheDocument();
+
+    fireEvent.click(names[0]);
+    expect(onOpenFile).toHaveBeenCalledWith("/home/claude/code/new.ts");
+    expect(mockImpact).toHaveBeenCalledWith("light");
+  });
+
+  it("renders the locked empty state", async () => {
+    mockFetchReadingList.mockResolvedValue({ items: [] });
+    render(<ReadingList onOpenFile={() => {}} />);
+
+    expect(await screen.findByText("Nothing saved yet — use 'Save to reading list' when viewing a file.")).toBeInTheDocument();
+    expect(screen.getByLabelText("0 items")).toBeInTheDocument();
+  });
+
+  it("optimistically removes an item while delete is pending", async () => {
+    let resolveDelete!: (value: { ok: true }) => void;
+    mockDeleteReadingListItem.mockImplementationOnce(() => new Promise((resolve) => { resolveDelete = resolve; }));
+    mockFetchReadingList
+      .mockResolvedValueOnce({ items })
+      .mockResolvedValue({ items: [items[1]] });
+    render(<ReadingList onOpenFile={() => {}} />);
+    await screen.findByText("new.ts");
+
+    fireEvent.click(screen.getByRole("button", { name: "Remove new.ts" }));
+    expect(screen.queryByText("new.ts")).not.toBeInTheDocument();
+    expect(mockDeleteReadingListItem).toHaveBeenCalledWith({ id: 2 });
+
+    await act(async () => resolveDelete({ ok: true }));
+    await waitFor(() => expect(mockSuccess).toHaveBeenCalled());
+    expect(screen.queryByText("new.ts")).not.toBeInTheDocument();
+  });
+
+  it("restores an optimistically removed item when delete fails", async () => {
+    let rejectDelete!: (error: Error) => void;
+    mockDeleteReadingListItem.mockImplementationOnce(() => new Promise((_resolve, reject) => { rejectDelete = reject; }));
+    render(<ReadingList onOpenFile={() => {}} />);
+    await screen.findByText("new.ts");
+
+    fireEvent.click(screen.getByRole("button", { name: "Remove new.ts" }));
+    expect(screen.queryByText("new.ts")).not.toBeInTheDocument();
+
+    await act(async () => rejectDelete(new Error("Delete failed")));
+    await waitFor(() => expect(screen.getByText("new.ts")).toBeInTheDocument());
+    expect(screen.getByRole("alert")).toHaveTextContent("Delete failed");
+    expect(mockError).toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/action-bar/ActionBar.tsx
+++ b/apps/web/src/components/action-bar/ActionBar.tsx
@@ -83,7 +83,10 @@ export function ActionBar({ onReconnect, onFitScreen, fitResult, connected, acti
   const [readingListChecking, setReadingListChecking] = useState(false);
   const [readingListSaving, setReadingListSaving] = useState(false);
   const [readingListRefreshVersion, setReadingListRefreshVersion] = useState(0);
-  const readingListInFlightRef = useRef(false);
+  // Holds the path being saved (not a boolean): navigating to another file
+  // while a save is in flight must not lock that file's Save button — only
+  // a duplicate tap for the SAME path is a no-op.
+  const readingListInFlightRef = useRef<string | null>(null);
   // A check started for the previous file must never mark the newly viewed
   // file as saved. Saving also bumps this token so its success state owns
   // the button over any older GET still in flight.
@@ -142,8 +145,13 @@ export function ActionBar({ onReconnect, onFitScreen, fitResult, connected, acti
     readingListCheckedPathRef.current = path;
     // Clear the prior file's result immediately. A same-file refresh (for
     // example the event emitted by a successful save) keeps the confirmed
-    // Saved state visible while the authoritative re-check runs.
-    if (pathChanged) setReadingListSaved(false);
+    // Saved state visible while the authoritative re-check runs. Saving
+    // state is also per-file: a save still in flight for the previous file
+    // must not show the new file's button as "Saving…".
+    if (pathChanged) {
+      setReadingListSaved(false);
+      setReadingListSaving(false);
+    }
     if (!viewingFile) {
       setReadingListChecking(false);
       return;
@@ -163,6 +171,11 @@ export function ActionBar({ onReconnect, onFitScreen, fitResult, connected, acti
       .finally(() => {
         if (seq === readingListCheckSeqRef.current) setReadingListChecking(false);
       });
+    // Invalidate the in-flight check on unmount so it can't setState after
+    // teardown (same defensive bump ReadingList's loadSeqRef does).
+    return () => {
+      ++readingListCheckSeqRef.current;
+    };
   }, [viewingFile?.path, readingListRefreshVersion]);
 
   // Replace the optimistic "Fit screen requested" status (set the instant
@@ -485,9 +498,10 @@ export function ActionBar({ onReconnect, onFitScreen, fitResult, connected, acti
     }
   };
   const handleSaveToReadingList = async () => {
-    if (!viewingFile || readingListSaved || readingListInFlightRef.current) return;
-    readingListInFlightRef.current = true;
+    if (!viewingFile || readingListSaved) return;
     const path = viewingFile.path;
+    if (readingListInFlightRef.current === path) return;
+    readingListInFlightRef.current = path;
     const seq = ++readingListCheckSeqRef.current;
     setReadingListSaving(true);
     try {
@@ -501,8 +515,8 @@ export function ActionBar({ onReconnect, onFitScreen, fitResult, connected, acti
       haptic.error();
       setStatus(`Failed: ${err instanceof Error ? err.message : String(err)}`);
     } finally {
-      readingListInFlightRef.current = false;
-      setReadingListSaving(false);
+      if (readingListInFlightRef.current === path) readingListInFlightRef.current = null;
+      if (seq === readingListCheckSeqRef.current) setReadingListSaving(false);
     }
   };
   const handlePublishShared = async (scope: "public" | "private", tmp: boolean) => {

--- a/apps/web/src/components/action-bar/ActionBar.tsx
+++ b/apps/web/src/components/action-bar/ActionBar.tsx
@@ -16,13 +16,14 @@ import { ShareSheet } from "./ShareSheet";
 import { StatusLine } from "./StatusLine";
 import { btnStyle, type ActionBarProps, type AudioStatus, type GitBranch, type Modal, type SearchResult, type SessionName } from "./types";
 import {
-  checkAudio, deleteSessionName, fetchGitBranch, fetchGitStatus,
+  checkAudio, checkReadingListPaths, deleteSessionName, fetchGitBranch, fetchGitStatus,
   fetchSessionNames, fetchTodo, generateAudio, postAction,
   renameSession, restartSession, runGitCommand, searchFiles,
-  publishShared, sendAudioTelegram, sendCompactCommand, sendFileToChat, sendToTmux,
+  publishShared, saveReadingListItem, sendAudioTelegram, sendCompactCommand, sendFileToChat, sendToTmux,
 } from "./api";
 import { haptic } from "../../lib/haptic";
 import { usePreferences } from "../../hooks/usePreferences";
+import { emitReadingListChanged, READING_LIST_CHANGED_EVENT } from "../../lib/reading-list-events";
 
 // Preference key for the "current folder only" search toggle. Stored under
 // the unified cpc_dashboard_prefs aggregate via CloudStorage (Bot API 8.0+)
@@ -78,6 +79,16 @@ export function ActionBar({ onReconnect, onFitScreen, fitResult, connected, acti
   const [shareError, setShareError] = useState<string | null>(null);
   const shareInFlightRef = useRef(false);
   const shareSeqRef = useRef(0);
+  const [readingListSaved, setReadingListSaved] = useState(false);
+  const [readingListChecking, setReadingListChecking] = useState(false);
+  const [readingListSaving, setReadingListSaving] = useState(false);
+  const [readingListRefreshVersion, setReadingListRefreshVersion] = useState(0);
+  const readingListInFlightRef = useRef(false);
+  // A check started for the previous file must never mark the newly viewed
+  // file as saved. Saving also bumps this token so its success state owns
+  // the button over any older GET still in flight.
+  const readingListCheckSeqRef = useRef(0);
+  const readingListCheckedPathRef = useRef<string | null>(null);
   const [gitBranch, setGitBranch] = useState<GitBranch | null>(null);
   const searchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const searchAbortRef = useRef<AbortController | null>(null);
@@ -117,6 +128,42 @@ export function ActionBar({ onReconnect, onFitScreen, fitResult, connected, acti
     const timer = setTimeout(() => setStatus(null), 4000);
     return () => clearTimeout(timer);
   }, [status]);
+
+  useEffect(() => {
+    const refresh = () => setReadingListRefreshVersion((version) => version + 1);
+    window.addEventListener(READING_LIST_CHANGED_EVENT, refresh);
+    return () => window.removeEventListener(READING_LIST_CHANGED_EVENT, refresh);
+  }, []);
+
+  useEffect(() => {
+    const seq = ++readingListCheckSeqRef.current;
+    const path = viewingFile?.path ?? null;
+    const pathChanged = path !== readingListCheckedPathRef.current;
+    readingListCheckedPathRef.current = path;
+    // Clear the prior file's result immediately. A same-file refresh (for
+    // example the event emitted by a successful save) keeps the confirmed
+    // Saved state visible while the authoritative re-check runs.
+    if (pathChanged) setReadingListSaved(false);
+    if (!viewingFile) {
+      setReadingListChecking(false);
+      return;
+    }
+
+    setReadingListChecking(true);
+    void checkReadingListPaths([viewingFile.path])
+      .then((data) => {
+        if (seq === readingListCheckSeqRef.current) {
+          setReadingListSaved(data.saved[viewingFile.path] === true);
+        }
+      })
+      .catch(() => {
+        // A failed check leaves Save enabled; the POST remains authoritative.
+        if (seq === readingListCheckSeqRef.current) setReadingListSaved(false);
+      })
+      .finally(() => {
+        if (seq === readingListCheckSeqRef.current) setReadingListChecking(false);
+      });
+  }, [viewingFile?.path, readingListRefreshVersion]);
 
   // Replace the optimistic "Fit screen requested" status (set the instant
   // the button is tapped, in the reconnect-menu case below) with the real
@@ -435,6 +482,27 @@ export function ActionBar({ onReconnect, onFitScreen, fitResult, connected, acti
     } catch {
       haptic.error();
       setStatus("Failed");
+    }
+  };
+  const handleSaveToReadingList = async () => {
+    if (!viewingFile || readingListSaved || readingListInFlightRef.current) return;
+    readingListInFlightRef.current = true;
+    const path = viewingFile.path;
+    const seq = ++readingListCheckSeqRef.current;
+    setReadingListSaving(true);
+    try {
+      await saveReadingListItem(path, viewingFile.name);
+      if (seq === readingListCheckSeqRef.current) setReadingListSaved(true);
+      haptic.success();
+      setStatus("Saved to reading list");
+      emitReadingListChanged();
+    } catch (err) {
+      if (seq === readingListCheckSeqRef.current) setReadingListSaved(false);
+      haptic.error();
+      setStatus(`Failed: ${err instanceof Error ? err.message : String(err)}`);
+    } finally {
+      readingListInFlightRef.current = false;
+      setReadingListSaving(false);
     }
   };
   const handlePublishShared = async (scope: "public" | "private", tmp: boolean) => {
@@ -789,6 +857,19 @@ export function ActionBar({ onReconnect, onFitScreen, fitResult, connected, acti
                 style={{ ...btnStyle, background: "#1a2a3a", color: "var(--color-accent-cyan)", border: "1px solid #2d4a5a" }}
               >
                 Send to Chat
+              </button>
+              <button
+                disabled={readingListChecking || readingListSaving || readingListSaved}
+                onClick={() => { haptic.impact("light"); void handleSaveToReadingList(); }}
+                style={{
+                  ...btnStyle,
+                  background: "var(--color-surface)",
+                  color: readingListSaved ? "var(--color-accent-green)" : "var(--color-accent-blue)",
+                  border: "1px solid var(--color-border-alt)",
+                  opacity: readingListChecking || readingListSaving ? 0.65 : 1,
+                }}
+              >
+                {readingListSaved ? "Saved ✓" : readingListSaving ? "Saving…" : "Save to reading list"}
               </button>
               <button
                 onClick={() => {

--- a/apps/web/src/components/action-bar/ActionBar.tsx
+++ b/apps/web/src/components/action-bar/ActionBar.tsx
@@ -83,15 +83,15 @@ export function ActionBar({ onReconnect, onFitScreen, fitResult, connected, acti
   const [readingListChecking, setReadingListChecking] = useState(false);
   const [readingListSaving, setReadingListSaving] = useState(false);
   const [readingListRefreshVersion, setReadingListRefreshVersion] = useState(0);
-  // Holds the path being saved (not a boolean): navigating to another file
-  // while a save is in flight must not lock that file's Save button — only
-  // a duplicate tap for the SAME path is a no-op.
-  const readingListInFlightRef = useRef<string | null>(null);
+  // Track every path being saved. Navigating to another file must not lock
+  // that file's Save button, while returning to any pending path must still
+  // block a duplicate save.
+  const readingListInFlightRef = useRef(new Set<string>());
   // A check started for the previous file must never mark the newly viewed
   // file as saved. Saving also bumps this token so its success state owns
   // the button over any older GET still in flight.
   const readingListCheckSeqRef = useRef(0);
-  const readingListCheckedPathRef = useRef<string | null>(null);
+  const readingListViewedPathRef = useRef<string | null>(null);
   const [gitBranch, setGitBranch] = useState<GitBranch | null>(null);
   const searchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const searchAbortRef = useRef<AbortController | null>(null);
@@ -141,8 +141,8 @@ export function ActionBar({ onReconnect, onFitScreen, fitResult, connected, acti
   useEffect(() => {
     const seq = ++readingListCheckSeqRef.current;
     const path = viewingFile?.path ?? null;
-    const pathChanged = path !== readingListCheckedPathRef.current;
-    readingListCheckedPathRef.current = path;
+    const pathChanged = path !== readingListViewedPathRef.current;
+    readingListViewedPathRef.current = path;
     // Clear the prior file's result immediately. A same-file refresh (for
     // example the event emitted by a successful save) keeps the confirmed
     // Saved state visible while the authoritative re-check runs. Saving
@@ -500,8 +500,8 @@ export function ActionBar({ onReconnect, onFitScreen, fitResult, connected, acti
   const handleSaveToReadingList = async () => {
     if (!viewingFile || readingListSaved) return;
     const path = viewingFile.path;
-    if (readingListInFlightRef.current === path) return;
-    readingListInFlightRef.current = path;
+    if (readingListInFlightRef.current.has(path)) return;
+    readingListInFlightRef.current.add(path);
     const seq = ++readingListCheckSeqRef.current;
     setReadingListSaving(true);
     try {
@@ -515,8 +515,8 @@ export function ActionBar({ onReconnect, onFitScreen, fitResult, connected, acti
       haptic.error();
       setStatus(`Failed: ${err instanceof Error ? err.message : String(err)}`);
     } finally {
-      if (readingListInFlightRef.current === path) readingListInFlightRef.current = null;
-      if (seq === readingListCheckSeqRef.current) setReadingListSaving(false);
+      readingListInFlightRef.current.delete(path);
+      if (readingListViewedPathRef.current === path) setReadingListSaving(false);
     }
   };
   const handlePublishShared = async (scope: "public" | "private", tmp: boolean) => {

--- a/apps/web/src/components/action-bar/ActionBar.tsx
+++ b/apps/web/src/components/action-bar/ActionBar.tsx
@@ -146,11 +146,13 @@ export function ActionBar({ onReconnect, onFitScreen, fitResult, connected, acti
     // Clear the prior file's result immediately. A same-file refresh (for
     // example the event emitted by a successful save) keeps the confirmed
     // Saved state visible while the authoritative re-check runs. Saving
-    // state is also per-file: a save still in flight for the previous file
-    // must not show the new file's button as "Saving…".
+    // state is per-file: derive it from the in-flight set, so a save still
+    // pending for the PREVIOUS file doesn't label this one "Saving…", while
+    // returning to a file whose save is pending shows "Saving…" again
+    // instead of an enabled button whose tap would silently no-op.
     if (pathChanged) {
       setReadingListSaved(false);
-      setReadingListSaving(false);
+      setReadingListSaving(path !== null && readingListInFlightRef.current.has(path));
     }
     if (!viewingFile) {
       setReadingListChecking(false);

--- a/apps/web/src/components/action-bar/api.test.ts
+++ b/apps/web/src/components/action-bar/api.test.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../lib/telegram", () => ({
+  getAuthHeaders: () => ({ Authorization: "tma test" }),
+}));
+
+import {
+  checkReadingListPaths,
+  deleteReadingListItem,
+  fetchReadingList,
+  saveReadingListItem,
+} from "./api";
+
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+describe("reading-list API helpers", () => {
+  it("matches the save, list, check, and delete contracts", async () => {
+    fetchMock
+      .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true, id: 17 }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        items: [{ id: 17, path: "/tmp/a.ts", title: "a.ts", created_at: 123 }],
+      }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ saved: { "/tmp/a.ts": true, "/tmp/b.ts": false } }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true }), { status: 200 }));
+
+    await expect(saveReadingListItem("/tmp/a.ts", "a.ts")).resolves.toEqual({ ok: true, id: 17 });
+    await expect(fetchReadingList()).resolves.toEqual({
+      items: [{ id: 17, path: "/tmp/a.ts", title: "a.ts", created_at: 123 }],
+    });
+    await expect(checkReadingListPaths(["/tmp/a.ts", "/tmp/b.ts"])).resolves.toEqual({
+      saved: { "/tmp/a.ts": true, "/tmp/b.ts": false },
+    });
+    await expect(deleteReadingListItem({ id: 17 })).resolves.toEqual({ ok: true });
+
+    expect(fetchMock).toHaveBeenNthCalledWith(1, "/api/reading-list/save", expect.objectContaining({
+      method: "POST",
+      headers: { Authorization: "tma test", "Content-Type": "application/json" },
+      body: JSON.stringify({ path: "/tmp/a.ts", title: "a.ts" }),
+      signal: expect.any(AbortSignal),
+    }));
+    expect(fetchMock).toHaveBeenNthCalledWith(2, "/api/reading-list/list", expect.objectContaining({
+      headers: { Authorization: "tma test" },
+      signal: expect.any(AbortSignal),
+    }));
+    expect(fetchMock.mock.calls[2][0]).toBe("/api/reading-list/check?paths=%2Ftmp%2Fa.ts&paths=%2Ftmp%2Fb.ts");
+    expect(fetchMock).toHaveBeenNthCalledWith(4, "/api/reading-list/delete", expect.objectContaining({
+      method: "POST",
+      body: JSON.stringify({ id: 17 }),
+      signal: expect.any(AbortSignal),
+    }));
+  });
+
+  it("surfaces structured server errors", async () => {
+    fetchMock.mockResolvedValue(new Response(JSON.stringify({ error: "Access denied" }), {
+      status: 403,
+      statusText: "Forbidden",
+    }));
+
+    await expect(saveReadingListItem("/etc/passwd")).rejects.toThrow("Access denied");
+  });
+
+  it("falls back to HTTP status for non-JSON errors", async () => {
+    fetchMock.mockResolvedValue(new Response("bad gateway", { status: 502, statusText: "Bad Gateway" }));
+
+    await expect(fetchReadingList()).rejects.toThrow("Request failed: 502 Bad Gateway");
+  });
+});

--- a/apps/web/src/components/action-bar/api.ts
+++ b/apps/web/src/components/action-bar/api.ts
@@ -1,5 +1,7 @@
 import { getAuthHeaders } from "../../lib/telegram";
-import type { AudioStatus, GitBranch, SearchResult, SessionName } from "./types";
+import type { AudioStatus, GitBranch, ReadingListItem, SearchResult, SessionName } from "./types";
+
+const READING_LIST_TIMEOUT_MS = 10_000;
 
 async function jsonFetch<T>(input: RequestInfo | URL, init?: RequestInit): Promise<T> {
   const res = await fetch(input, init);
@@ -21,6 +23,17 @@ async function jsonFetch<T>(input: RequestInfo | URL, init?: RequestInit): Promi
     throw new Error(serverError ?? `Request failed: ${res.status} ${res.statusText}`);
   }
   return res.json() as Promise<T>;
+}
+
+/** Reading-list requests are short CRUD calls; do not leave the UI hanging indefinitely. */
+async function readingListJsonFetch<T>(input: RequestInfo | URL, init?: RequestInit): Promise<T> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), READING_LIST_TIMEOUT_MS);
+  try {
+    return await jsonFetch<T>(input, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timeout);
+  }
 }
 
 export async function postAction(endpoint: string, body?: Record<string, unknown>) {
@@ -220,5 +233,37 @@ export async function sendFileToChat(filePath: string) {
     method: "POST",
     headers: { "Content-Type": "application/json", ...getAuthHeaders() },
     body: JSON.stringify({ filePath }),
+  });
+}
+
+export async function saveReadingListItem(path: string, title?: string) {
+  return readingListJsonFetch<{ ok: true; id: number }>("/api/reading-list/save", {
+    method: "POST",
+    headers: { ...getAuthHeaders(), "Content-Type": "application/json" },
+    body: JSON.stringify({ path, ...(title !== undefined ? { title } : {}) }),
+  });
+}
+
+export async function fetchReadingList() {
+  return readingListJsonFetch<{ items: ReadingListItem[] }>("/api/reading-list/list", {
+    headers: getAuthHeaders(),
+  });
+}
+
+export async function checkReadingListPaths(paths: string[]) {
+  const params = new URLSearchParams();
+  for (const path of paths) params.append("paths", path);
+  const query = params.toString();
+  return readingListJsonFetch<{ saved: Record<string, boolean> }>(
+    `/api/reading-list/check${query ? `?${query}` : ""}`,
+    { headers: getAuthHeaders() },
+  );
+}
+
+export async function deleteReadingListItem(target: { id: number } | { path: string }) {
+  return readingListJsonFetch<{ ok: true }>("/api/reading-list/delete", {
+    method: "POST",
+    headers: { ...getAuthHeaders(), "Content-Type": "application/json" },
+    body: JSON.stringify(target),
   });
 }

--- a/apps/web/src/components/action-bar/types.ts
+++ b/apps/web/src/components/action-bar/types.ts
@@ -69,6 +69,13 @@ export interface AudioStatus {
   path?: string;
 }
 
+export interface ReadingListItem {
+  id: number;
+  path: string;
+  title: string | null;
+  created_at: number;
+}
+
 export interface GitBranch {
   branch: string;
   treeType: string;

--- a/apps/web/src/lib/reading-list-events.ts
+++ b/apps/web/src/lib/reading-list-events.ts
@@ -1,0 +1,5 @@
+export const READING_LIST_CHANGED_EVENT = "cpc:reading-list-changed";
+
+export function emitReadingListChanged() {
+  window.dispatchEvent(new Event(READING_LIST_CHANGED_EVENT));
+}


### PR DESCRIPTION
## Summary
- **Reading List section** at the top of the Links tab: most-recently-saved first, item rows show bold name + dimmed path + saved-timeAgo, tap opens the file in the Files viewer (App-level open-request with a sequence key), per-row ✕ with **optimistic removal** (restored if the API delete fails), muted empty state.
- **"Save to reading list"** joins the file-viewer action row: a seq-token-guarded `check` marks already-saved files (**Saved ✓**, disabled) — same stale-response guard class that review caught twice this week in ActionBar; in-flight ref prevents double-saves.
- Cross-tab refresh via a window event (`cpc:reading-list-changed`). Server (v1 backend from #134) untouched.

## Design decisions (posted in-thread, no override received)
Links-tab section instead of a 6th tab; most-recent-first, no reorder in v2; userId-required (backend enforces).

## Tests
Web 303/303 (+ActionBar save flow incl. stale-check drop; ReadingList list/delete/optimistic-restore; api helpers). Server 359/359 untouched. Typecheck + vite build clean.

## Visual proof
Live dev instance (port 38834), real signed initData: saved the proof doc from the viewer (**Saved ✓** flipped), Links tab showed **Reading List 1** with the item, tapping it reopened the doc in the viewer, ✕ deleted it → **Reading List 0** + empty state. Dev server killed after proof.

Fixes #149
Part of the dev-cpc-features integration group.

🤖 Generated with [Claude Code](https://claude.com/claude-code)