### PR TITLE
fix(links): Fleet Cockpit link opens externally — stop one-way webview navigation stranding mini-app auth

### DIFF
--- a/apps/web/src/components/Links.tsx
+++ b/apps/web/src/components/Links.tsx
@@ -61,11 +61,14 @@ const LINKS: LinkItem[] = [
     url: "https://cockpit.claude.do",
     icon: "🛩️",
     description: "Fleet grid + live lane terminals",
-    // Stays inside the Mini App (Liam voice msg 1185). NOTE: cockpit.claude.do
-    // currently sits behind Cloudflare Access, which a Telegram WebView cannot
-    // pass — the link hits the Access wall until the cockpit auth lift lands
-    // (world-os#218 plan addendum). Shipped anyway per Liam.
-    inApp: true,
+    // In-app navigation (Liam voice msg 1185) is DISABLED until two blockers
+    // clear: (1) cockpit.claude.do sits behind Cloudflare Access, which a
+    // Telegram WebView cannot pass — the link dead-ends at the Access wall;
+    // (2) window.location.assign is a one-way trip — any return to CPC that
+    // isn't a fresh Telegram launch leaves the webview without initData,
+    // stranding the user on the login screen (live incident 2026-07-10,
+    // voice 1565). Re-enable inApp only with the Access lift + BackButton
+    // return wiring (world-os#218 plan addendum).
   },
   {
     title: "Transcription Glossary",


### PR DESCRIPTION
## What
One-line behavior revert: the Fleet Cockpit link no longer navigates the Telegram webview in-place (`inApp: true` removed); it opens an external tab like every other link. Comment documents the two re-enable blockers.

## Why (live prod incident, 2026-07-10)
`window.location.assign` inside the mini-app is a one-way trip: cockpit.claude.do dead-ends at Cloudflare Access (webviews can't pass it), and any non-fresh-launch return to CPC has no `tgWebAppData` fragment → `initData` empty → user stranded on the Login-with-Telegram screen. Reported by Liam (voice 1565), recovered only by full close+reopen (voice 1580). The v1.13→v1.14 audit confirmed this is the only top-level navigation path added in the release; the shipping commit had already documented the one-way risk as accepted.

Defense-in-depth also landed host-side: prod HTML/API now `Cache-Control: no-store` via Caddy (assets keep immutable cache) — closes the stale-WKWebView class for future deploys.

## Re-enable path (world-os#218 plan addendum)
1. Cloudflare Access lift (or service-token bypass) for Telegram webviews on cockpit.claude.do
2. BackButton return wiring so in-app navigation has a session-preserving way back

## Verification
- `tsc --noEmit` clean, web build green
- Hotfix cherry-picked to prod (deploy pattern) — see deploy note in thread

🤖 Generated with [Claude Code](https://claude.com/claude-code)