### PR TITLE
chore(links): glossary link → canonical world-os STT glossary (companion to world-os#427)

### DIFF
--- a/apps/web/src/components/Links.tsx
+++ b/apps/web/src/components/Links.tsx
@@ -69,7 +69,9 @@ const LINKS: LinkItem[] = [
   },
   {
     title: "Transcription Glossary",
-    url: "https://github.com/claudes-world/toolbox/blob/main/transcribe/glossary.txt",
+    // Canonical glossary moved to world-os (the file the live switchboard STT
+    // actually loads — Liam edits it on GitHub; world-os PR #427, 2026-07-10).
+    url: "https://github.com/claudes-world/world-os/blob/dev/apps/switchboard/src/switchboard/transcribe_glossary.txt",
     icon: "📝",
     description: "Tech terms for STT accuracy",
   },


### PR DESCRIPTION
One-line URL change. Rides v1.14.1 — no prod urgency. See world-os#427 for the canonical-glossary move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)