### PR TITLE
fix(auth): empty allowlist fails closed + JWT requires numeric exp (M1+M2, project-state release gate)

### DIFF
--- a/apps/server/src/auth.ts
+++ b/apps/server/src/auth.ts
@@ -98,6 +98,12 @@ export function getAllowedUsers(): Set<string> {
   return new Set(raw.split(",").map((s) => s.trim()).filter(Boolean));
 }
 
+/** Explicit dev-only opt-in for allowing all Telegram users. */
+export function allowAllTelegramUsers(): boolean {
+  const raw = process.env.ALLOW_ALL_TELEGRAM_USERS?.trim().toLowerCase();
+  return raw === "1" || raw === "true";
+}
+
 /**
  * Validate Telegram Login Widget data.
  * https://core.telegram.org/widgets/login#checking-authorization
@@ -160,8 +166,9 @@ export function validateJwtToken(
     // Decode payload
     const payload = JSON.parse(Buffer.from(parts[1], "base64url").toString());
 
-    // Check expiry
-    if (payload.exp && Date.now() / 1000 > payload.exp) return { valid: false };
+    // Tokens without a numeric expiry would otherwise remain valid forever.
+    if (typeof payload.exp !== "number") return { valid: false };
+    if (Date.now() / 1000 > payload.exp) return { valid: false };
 
     return {
       valid: true,
@@ -264,7 +271,9 @@ export function checkAuth(initData: string): { ok: boolean; user?: TelegramUser;
   if (!valid) return { ok: false, error: "Invalid auth" };
 
   const allowed = getAllowedUsers();
-  if (allowed.size > 0) {
+  if (allowed.size === 0) {
+    if (!allowAllTelegramUsers()) return { ok: false, error: "Not authorized" };
+  } else {
     if (!user) return { ok: false, error: "User identification required" };
     if (!allowed.has(String(user.id))) return { ok: false, error: "Not authorized" };
   }

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -9,7 +9,12 @@ import { serveStatic } from "@hono/node-server/serve-static";
 import { serve } from "@hono/node-server";
 import { createNodeWebSocket } from "@hono/node-ws";
 import { telegramAuth } from "./middleware.js";
-import { validateTelegramLoginWidget, createSession } from "./auth.js";
+import {
+  allowAllTelegramUsers,
+  createSession,
+  getAllowedUsers,
+  validateTelegramLoginWidget,
+} from "./auth.js";
 import { isAllowedUser } from "./lib/allowed-users.js";
 import { ALLOWED_ORIGINS } from "./lib/allowed-origins.js";
 import { registerDbSizeGauge, getTracer } from "./lib/otel.js";
@@ -50,6 +55,16 @@ function loadEnv(path: string) {
 }
 
 loadEnv(`${process.env.HOME}/.secrets/cpc.env`);
+
+if (getAllowedUsers().size === 0 && !allowAllTelegramUsers()) {
+  console.error([
+    "!!!!!!!!!!!!!!!!!!!! CPC AUTH WARNING !!!!!!!!!!!!!!!!!!!!",
+    "Allowlist admission is DISABLED: ALLOWED_TELEGRAM_USERS is empty or unset.",
+    "All Telegram users are BLOCKED until ALLOWED_TELEGRAM_USERS is populated",
+    "or ALLOW_ALL_TELEGRAM_USERS=1 is explicitly set for development.",
+    "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!",
+  ].join("\n"));
+}
 
 // Register DB size gauge after env is loaded so DB_PATH is stable
 registerDbSizeGauge(DB_PATH);

--- a/apps/server/src/lib/allowed-users.ts
+++ b/apps/server/src/lib/allowed-users.ts
@@ -1,13 +1,13 @@
-import { getAllowedUsers } from "../auth.js";
+import { allowAllTelegramUsers, getAllowedUsers } from "../auth.js";
 
 /**
  * Check if a user ID is in the allowlist.
  * Re-reads env on each call (matches existing getAllowedUsers behavior).
- * Empty allowlist = all users allowed (dev convenience).
+ * An empty allowlist fails closed unless explicitly opened for development.
  */
 export function isAllowedUser(userId: string | number | undefined | null): boolean {
   const allowed = getAllowedUsers();
-  if (allowed.size === 0) return true; // dev convenience: empty allowlist = open
+  if (allowed.size === 0) return allowAllTelegramUsers();
   if (userId == null) return false;    // no identity → block when allowlist is active
   return allowed.has(String(userId));
 }

--- a/apps/server/src/routes/__tests__/auth.test.ts
+++ b/apps/server/src/routes/__tests__/auth.test.ts
@@ -18,21 +18,32 @@ const TEST_USER = { id: 999111, first_name: "TestUser" };
 
 let savedBotToken: string | undefined;
 let savedAllowed: string | undefined;
+let savedAllowAll: string | undefined;
 
 beforeAll(() => {
   savedBotToken = process.env.TELEGRAM_BOT_TOKEN;
   savedAllowed = process.env.ALLOWED_TELEGRAM_USERS;
+  savedAllowAll = process.env.ALLOW_ALL_TELEGRAM_USERS;
   process.env.TELEGRAM_BOT_TOKEN = TEST_BOT_TOKEN;
   process.env.ALLOWED_TELEGRAM_USERS = TEST_USER_ID;
+  delete process.env.ALLOW_ALL_TELEGRAM_USERS;
 });
 
 afterAll(() => {
-  process.env.TELEGRAM_BOT_TOKEN = savedBotToken;
-  process.env.ALLOWED_TELEGRAM_USERS = savedAllowed;
+  restoreEnv("TELEGRAM_BOT_TOKEN", savedBotToken);
+  restoreEnv("ALLOWED_TELEGRAM_USERS", savedAllowed);
+  restoreEnv("ALLOW_ALL_TELEGRAM_USERS", savedAllowAll);
 });
 
 // Import after env setup so the module picks up our token.
 const { telegramAuth } = await import("../../middleware.js");
+const { checkAuth, validateJwtToken } = await import("../../auth.js");
+const { isAllowedUser } = await import("../../lib/allowed-users.js");
+
+function restoreEnv(name: string, value: string | undefined): void {
+  if (value === undefined) delete process.env[name];
+  else process.env[name] = value;
+}
 
 function buildApp(): Hono {
   const app = new Hono();
@@ -79,13 +90,15 @@ function makeInitData(
 /** Build a minimal JWT signed with the bot token. */
 function makeJwt(
   sub: string,
-  opts?: { exp?: number; botToken?: string },
+  opts?: { exp?: unknown; omitExp?: boolean; botToken?: string },
 ): string {
   const token = opts?.botToken ?? TEST_BOT_TOKEN;
   const header = Buffer.from(JSON.stringify({ alg: "HS256", typ: "JWT" })).toString("base64url");
-  const payload = Buffer.from(
-    JSON.stringify({ sub, exp: opts?.exp ?? Math.floor(Date.now() / 1000) + 3600 }),
-  ).toString("base64url");
+  const claims: Record<string, unknown> = { sub };
+  if (!opts?.omitExp) {
+    claims.exp = opts?.exp ?? Math.floor(Date.now() / 1000) + 3600;
+  }
+  const payload = Buffer.from(JSON.stringify(claims)).toString("base64url");
   const sig = createHmac("sha256", token)
     .update(`${header}.${payload}`)
     .digest("base64url");
@@ -183,6 +196,58 @@ describe("telegramAuth middleware", () => {
       const body = (await res.json()) as { error: string };
       expect(body.error).toBe("User not authorized");
     });
+
+    it("fails closed for isAllowedUser and checkAuth when the allowlist is empty", () => {
+      const originalAllowed = process.env.ALLOWED_TELEGRAM_USERS;
+      const originalAllowAll = process.env.ALLOW_ALL_TELEGRAM_USERS;
+      process.env.ALLOWED_TELEGRAM_USERS = "";
+      delete process.env.ALLOW_ALL_TELEGRAM_USERS;
+      try {
+        expect(isAllowedUser(TEST_USER_ID)).toBe(false);
+        expect(checkAuth(makeInitData(TEST_USER))).toEqual({
+          ok: false,
+          error: "Not authorized",
+        });
+      } finally {
+        restoreEnv("ALLOWED_TELEGRAM_USERS", originalAllowed);
+        restoreEnv("ALLOW_ALL_TELEGRAM_USERS", originalAllowAll);
+      }
+    });
+
+    it("allows isAllowedUser and checkAuth with the explicit empty-allowlist escape hatch", () => {
+      const originalAllowed = process.env.ALLOWED_TELEGRAM_USERS;
+      const originalAllowAll = process.env.ALLOW_ALL_TELEGRAM_USERS;
+      process.env.ALLOWED_TELEGRAM_USERS = "";
+      process.env.ALLOW_ALL_TELEGRAM_USERS = "true";
+      try {
+        expect(isAllowedUser(TEST_USER_ID)).toBe(true);
+        expect(checkAuth(makeInitData(TEST_USER))).toMatchObject({
+          ok: true,
+          user: TEST_USER,
+        });
+      } finally {
+        restoreEnv("ALLOWED_TELEGRAM_USERS", originalAllowed);
+        restoreEnv("ALLOW_ALL_TELEGRAM_USERS", originalAllowAll);
+      }
+    });
+
+    it("keeps a non-empty allowlist authoritative when the escape hatch is set", () => {
+      const originalAllowed = process.env.ALLOWED_TELEGRAM_USERS;
+      const originalAllowAll = process.env.ALLOW_ALL_TELEGRAM_USERS;
+      process.env.ALLOWED_TELEGRAM_USERS = TEST_USER_ID;
+      process.env.ALLOW_ALL_TELEGRAM_USERS = "1";
+      const nonAllowedUser = { id: 777888, first_name: "Intruder" };
+      try {
+        expect(isAllowedUser(nonAllowedUser.id)).toBe(false);
+        expect(checkAuth(makeInitData(nonAllowedUser))).toEqual({
+          ok: false,
+          error: "Not authorized",
+        });
+      } finally {
+        restoreEnv("ALLOWED_TELEGRAM_USERS", originalAllowed);
+        restoreEnv("ALLOW_ALL_TELEGRAM_USERS", originalAllowAll);
+      }
+    });
   });
 
   describe("Bearer JWT validation", () => {
@@ -202,6 +267,28 @@ describe("telegramAuth middleware", () => {
       expect(res.status).toBe(401);
       const body = (await res.json()) as { error: string };
       expect(body.error).toBe("Invalid or expired token");
+    });
+
+    it("rejects a signed JWT without an exp claim", () => {
+      expect(validateJwtToken(makeJwt(TEST_USER_ID, { omitExp: true }), TEST_BOT_TOKEN))
+        .toEqual({ valid: false });
+    });
+
+    it("rejects a signed JWT with a non-numeric exp claim", () => {
+      expect(validateJwtToken(makeJwt(TEST_USER_ID, { exp: "never" }), TEST_BOT_TOKEN))
+        .toEqual({ valid: false });
+    });
+
+    it("accepts a signed JWT with a future numeric exp claim", () => {
+      const exp = Math.floor(Date.now() / 1000) + 3600;
+      expect(validateJwtToken(makeJwt(TEST_USER_ID, { exp }), TEST_BOT_TOKEN))
+        .toMatchObject({ valid: true, user: { id: Number(TEST_USER_ID) } });
+    });
+
+    it("rejects a signed JWT with a past numeric exp claim", () => {
+      const exp = Math.floor(Date.now() / 1000) - 3600;
+      expect(validateJwtToken(makeJwt(TEST_USER_ID, { exp }), TEST_BOT_TOKEN))
+        .toEqual({ valid: false });
     });
 
     it("rejects a JWT signed with the wrong secret", async () => {


### PR DESCRIPTION
Project-state release-gate MUST fix (docs/reviews/project-state-20260710-synthesis.md in world-os, cpc dev@d84ab131e frozen pair). Mirrors the identical fix landing in world-os's `apps/cpc` (world-os PR #445).

## M1 — empty ALLOWED_TELEGRAM_USERS fails open (6/10 consensus)
`isAllowedUser()`/`checkAuth()` admitted any Telegram user when the allowlist was empty. A prior review (`docs/reviews/v0.10.0-pre-release-review.md` FP-2) marked this shape a false positive on the premise production always sets the var via the deploy script — an operational assumption, not a code guarantee. This fix stays compatible with that: dev convenience is preserved via an explicit `ALLOW_ALL_TELEGRAM_USERS=1` opt-in instead of silent absence.

## M2 — JWT exp optional (5/10 consensus)
`validateJwtToken()` treated `exp` as optional — a token minted without it never expired. Now requires a numeric `exp`.

## Verification
410/410 passing, run outside any sandbox restriction (2 codex-reported failures were sandbox artifacts — EPERM mkfifo, read-only host db path).

Not merging — cheap-first re-verification to follow, then held for the standing merge doctrine.