### PR TITLE
fix(db): tolerate unparseable legacy created_at during reading_list migration (M9, project-state release gate)

### DIFF
--- a/apps/server/src/__tests__/reading-list-migration.test.ts
+++ b/apps/server/src/__tests__/reading-list-migration.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import Database from "better-sqlite3";
 
 /**
@@ -35,6 +35,19 @@ function runMigration(db: Database.Database) {
     .all() as Array<{ name: string; type: string }>;
   const createdAtCol = cols.find((c) => c.name === "created_at");
   if (createdAtCol && createdAtCol.type.toUpperCase() !== "INTEGER") {
+    const invalidTimestampCount = (
+      db
+        .prepare(
+          "SELECT COUNT(*) AS count FROM reading_list WHERE strftime('%s', created_at) IS NULL",
+        )
+        .get() as { count: number }
+    ).count;
+    if (invalidTimestampCount > 0) {
+      console.warn(
+        `[reading_list migration] ${invalidTimestampCount} row(s) had unparseable created_at values; using the current time as a fallback`,
+      );
+    }
+
     // Retry-safe: mirrors db.ts — clean up any leftover reading_list_new from
     // a previous failed attempt, then wrap the rebuild in a try/catch that
     // rolls back + drops the scratch table if anything throws.
@@ -57,7 +70,10 @@ function runMigration(db: Database.Database) {
           user_id,
           path,
           title,
-          CAST(strftime('%s', created_at) AS INTEGER) * 1000
+          COALESCE(
+            CAST(strftime('%s', created_at) AS INTEGER) * 1000,
+            unixepoch() * 1000
+          )
         FROM reading_list;
         DROP INDEX IF EXISTS idx_reading_list_user;
         DROP INDEX IF EXISTS idx_reading_list_user_path;
@@ -80,6 +96,49 @@ function runMigration(db: Database.Database) {
 }
 
 describe("reading_list TEXT → INTEGER migration", () => {
+  it("preserves mixed valid and unparseable timestamps using a logged fallback", () => {
+    const db = new Database(":memory:");
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    db.exec(`
+      CREATE TABLE reading_list (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        user_id TEXT NOT NULL,
+        path TEXT NOT NULL,
+        title TEXT,
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        UNIQUE(user_id, path)
+      );
+      INSERT INTO reading_list (user_id, path, title, created_at)
+      VALUES
+        ('u1', '/valid-a', 'Valid A', '2025-01-01 00:00:00'),
+        ('u1', '/valid-b', 'Valid B', '2025-06-15 12:30:00'),
+        ('u1', '/invalid', 'Invalid', 'not-a-date');
+    `);
+
+    const beforeMigration = Date.now();
+    expect(() => runMigration(db)).not.toThrow();
+    const afterMigration = Date.now();
+
+    const rows = db
+      .prepare("SELECT path, created_at FROM reading_list ORDER BY path")
+      .all() as Array<{ path: string; created_at: number }>;
+    expect(rows).toHaveLength(3);
+    expect(rows.find((row) => row.path === "/valid-a")?.created_at).toBe(
+      Date.UTC(2025, 0, 1, 0, 0, 0),
+    );
+    expect(rows.find((row) => row.path === "/valid-b")?.created_at).toBe(
+      Date.UTC(2025, 5, 15, 12, 30, 0),
+    );
+    const fallback = rows.find((row) => row.path === "/invalid")?.created_at;
+    expect(fallback).toBeGreaterThanOrEqual(Math.floor(beforeMigration / 1000) * 1000);
+    expect(fallback).toBeLessThanOrEqual(Math.floor(afterMigration / 1000) * 1000);
+    expect(warn).toHaveBeenCalledOnce();
+    expect(warn).toHaveBeenCalledWith(
+      "[reading_list migration] 1 row(s) had unparseable created_at values; using the current time as a fallback",
+    );
+    warn.mockRestore();
+  });
+
   it("rebuilds the table and converts ISO timestamps to epoch-ms", () => {
     const db = new Database(":memory:");
     // Seed with the legacy schema (from #134).

--- a/apps/server/src/__tests__/reading-list-migration.test.ts
+++ b/apps/server/src/__tests__/reading-list-migration.test.ts
@@ -1,5 +1,14 @@
 import { describe, expect, it, vi } from "vitest";
 import Database from "better-sqlite3";
+import { execFile } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+
+const SERVER_DIR = join(dirname(fileURLToPath(import.meta.url)), "../..");
+const execFileAsync = promisify(execFile);
 
 /**
  * Regression test for the reading_list TEXT → INTEGER migration.
@@ -10,9 +19,9 @@ import Database from "better-sqlite3";
  * bootstrap in db.ts must detect the legacy column type and rebuild the
  * table in place.
  *
- * This test replays that bootstrap logic against an in-memory DB pre-seeded
- * with the legacy schema + a couple rows, and asserts that the rebuild
- * preserves data while converting timestamps.
+ * The primary regression test imports the real db.ts in a child process
+ * against a pre-seeded on-disk legacy database. The remaining tests replay
+ * the SQL against in-memory databases as fast checks of individual semantics.
  */
 
 function runMigration(db: Database.Database) {
@@ -96,6 +105,90 @@ function runMigration(db: Database.Database) {
 }
 
 describe("reading_list TEXT → INTEGER migration", () => {
+  it("boots the real db.ts migration and repairs malformed legacy timestamps", async () => {
+    const home = mkdtempSync(join(tmpdir(), "cpc-reading-list-migration-"));
+    const dbPath = join(home, "data", "cpc-voice.db");
+
+    try {
+      // Seed in a separate process before db.ts is imported. Its DATA_DIR,
+      // DB_PATH, schema bootstrap, and migration all execute at module load.
+      await execFileAsync(
+        process.execPath,
+        [
+          "-e",
+          `
+            const { mkdirSync } = require("node:fs");
+            const { dirname } = require("node:path");
+            const Database = require("better-sqlite3");
+            const dbPath = ${JSON.stringify(dbPath)};
+            mkdirSync(dirname(dbPath), { recursive: true });
+            const db = new Database(dbPath);
+            db.exec(\`
+              CREATE TABLE reading_list (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id TEXT NOT NULL,
+                path TEXT NOT NULL,
+                title TEXT,
+                created_at TEXT DEFAULT (datetime('now')),
+                UNIQUE(user_id, path)
+              );
+            \`);
+            const insert = db.prepare(
+              "INSERT INTO reading_list (user_id, path, title, created_at) VALUES (?, ?, ?, ?)",
+            );
+            insert.run("u1", "/valid", "Valid", "2026-07-01 12:00:00");
+            insert.run("u1", "/malformed", "Malformed", "not-a-timestamp");
+            insert.run("u1", "/empty", "Empty", "");
+            db.close();
+          `,
+        ],
+        { cwd: SERVER_DIR },
+      );
+
+      const beforeMigration = Date.now();
+      await expect(
+        execFileAsync(process.execPath, ["--import", "tsx", "-e", "import('./src/db.ts')"], {
+          cwd: SERVER_DIR,
+          env: { ...process.env, HOME: home },
+        }),
+      ).resolves.toBeDefined();
+      const afterMigration = Date.now();
+
+      const db = new Database(dbPath, { readonly: true });
+      try {
+        const columns = db.prepare("PRAGMA table_info(reading_list)").all() as Array<{
+          name: string;
+          type: string;
+        }>;
+        expect(columns.find((column) => column.name === "created_at")?.type.toUpperCase()).toBe(
+          "INTEGER",
+        );
+
+        const rows = db
+          .prepare("SELECT path, created_at FROM reading_list ORDER BY path")
+          .all() as Array<{ path: string; created_at: number }>;
+        expect(rows).toHaveLength(3);
+
+        const byPath = new Map(rows.map((row) => [row.path, row.created_at]));
+        expect(byPath.get("/valid")).toBe(Date.UTC(2026, 6, 1, 12, 0, 0));
+
+        const earliestFallback = Math.floor(beforeMigration / 1000) * 1000;
+        const latestFallback = Math.floor(afterMigration / 1000) * 1000;
+        for (const path of ["/malformed", "/empty"]) {
+          const fallback = byPath.get(path);
+          expect(typeof fallback).toBe("number");
+          expect(Number.isFinite(fallback)).toBe(true);
+          expect(fallback).toBeGreaterThanOrEqual(earliestFallback);
+          expect(fallback).toBeLessThanOrEqual(latestFallback);
+        }
+      } finally {
+        db.close();
+      }
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
   it("preserves mixed valid and unparseable timestamps using a logged fallback", () => {
     const db = new Database(":memory:");
     const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);

--- a/apps/server/src/db.ts
+++ b/apps/server/src/db.ts
@@ -287,6 +287,19 @@ db.exec(
     .all() as Array<{ name: string; type: string }>;
   const createdAtCol = cols.find((c) => c.name === "created_at");
   if (createdAtCol && createdAtCol.type.toUpperCase() !== "INTEGER") {
+    const invalidTimestampCount = (
+      db
+        .prepare(
+          "SELECT COUNT(*) AS count FROM reading_list WHERE strftime('%s', created_at) IS NULL",
+        )
+        .get() as { count: number }
+    ).count;
+    if (invalidTimestampCount > 0) {
+      console.warn(
+        `[reading_list migration] ${invalidTimestampCount} row(s) had unparseable created_at values; using the current time as a fallback`,
+      );
+    }
+
     // Retry-safe: drop any leftover `reading_list_new` from a previous failed
     // migration attempt before creating it fresh, and wrap the rebuild in a
     // try/catch with explicit ROLLBACK + cleanup so the next startup isn't
@@ -310,7 +323,10 @@ db.exec(
           user_id,
           path,
           title,
-          CAST(strftime('%s', created_at) AS INTEGER) * 1000
+          COALESCE(
+            CAST(strftime('%s', created_at) AS INTEGER) * 1000,
+            unixepoch() * 1000
+          )
         FROM reading_list;
         DROP INDEX IF EXISTS idx_reading_list_user;
         DROP INDEX IF EXISTS idx_reading_list_user_path;


### PR DESCRIPTION
Project-state release-gate MUST fix — verify-first item, empirically confirmed reproducible before implementation (1/10 reviewer flag, not independently pre-verified by the synthesis).

`reading_list`'s TEXT→INTEGER migration does `CAST(strftime('%s', created_at) AS INTEGER) * 1000` into an `INTEGER NOT NULL` column. `strftime` returns NULL for any legacy row it can't parse; the resulting NOT NULL violation rolled back the whole migration transaction and rethrew — any deployment with one malformed legacy row failed to boot. Reproduced directly: `strftime('%s', 'not-a-date')` → NULL → constraint violation → SQLite exit 1.

Fix: `COALESCE(..., unixepoch() * 1000)` so an unparseable row falls back to "now" instead of killing the migration; counts and loudly warns about affected rows first so an operator notices.

## Verification
404/404, new mixed-format test (well-formed + one malformed row in the same run) proves no throw, correct conversion of well-formed rows, and exactly one warning.

Not merging — cheap-first re-verification to follow, then held for the standing merge doctrine.