### PR TITLE
fix(server): drain HTTP+WS connections before telemetry shutdown on SIGTERM/SIGINT (M11, project-state release gate)

### DIFF
--- a/apps/server/src/__tests__/graceful-shutdown.test.ts
+++ b/apps/server/src/__tests__/graceful-shutdown.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  drainServer,
+  type CloseableHttpServer,
+  type CloseableWebSocketServer,
+} from "../lib/graceful-shutdown.js";
+
+describe("drainServer", () => {
+  it("waits for HTTP and WS drains before flushing telemetry", async () => {
+    const events: string[] = [];
+    let finishHttpDrain!: () => void;
+    const server = {
+      close: vi.fn((callback: () => void) => {
+        finishHttpDrain = () => {
+          events.push("http");
+          callback();
+        };
+      }),
+    } as CloseableHttpServer;
+
+    const wsClient = { close: vi.fn() };
+    let finishWebSocketDrain!: () => void;
+    const wss = {
+      clients: new Set([wsClient]),
+      close: vi.fn((callback: (error?: Error) => void) => {
+        finishWebSocketDrain = () => {
+          events.push("ws");
+          callback();
+        };
+      }),
+    } as unknown as CloseableWebSocketServer;
+    const flushTelemetry = vi.fn(async () => {
+      events.push("telemetry");
+    });
+
+    const draining = drainServer(server, wss, flushTelemetry);
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(flushTelemetry).not.toHaveBeenCalled();
+    expect(wsClient.close).toHaveBeenCalledWith(1001, "Server shutting down");
+
+    // Models Node's Server.close callback: it fires only after the held-open
+    // request has completed. Telemetry must remain live until that point.
+    finishHttpDrain();
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(flushTelemetry).not.toHaveBeenCalled();
+
+    finishWebSocketDrain();
+    await draining;
+
+    expect(events).toEqual(["http", "ws", "telemetry"]);
+    expect(flushTelemetry).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -1,4 +1,4 @@
-import './lib/otel.js';
+import { registerDbSizeGauge, getTracer, shutdownTelemetry } from "./lib/otel.js";
 import { readFileSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -12,7 +12,7 @@ import { telegramAuth } from "./middleware.js";
 import { validateTelegramLoginWidget, createSession } from "./auth.js";
 import { isAllowedUser } from "./lib/allowed-users.js";
 import { ALLOWED_ORIGINS } from "./lib/allowed-origins.js";
-import { registerDbSizeGauge, getTracer } from "./lib/otel.js";
+import { drainServer } from "./lib/graceful-shutdown.js";
 import { propagation, context as otelContext, trace, SpanStatusCode } from "@opentelemetry/api";
 import { DB_PATH } from "./db.js";
 import { terminalRoute } from "./routes/terminal/index.js";
@@ -55,7 +55,7 @@ loadEnv(`${process.env.HOME}/.secrets/cpc.env`);
 registerDbSizeGauge(DB_PATH);
 
 const app = new Hono<{ Bindings: HttpBindings }>();
-const { injectWebSocket, upgradeWebSocket } = createNodeWebSocket({ app });
+const { injectWebSocket, upgradeWebSocket, wss } = createNodeWebSocket({ app });
 
 app.use("*", cors({
   origin: [...ALLOWED_ORIGINS],
@@ -235,3 +235,29 @@ const server = serve({ fetch: app.fetch, port }, (info) => {
 });
 
 injectWebSocket(server);
+
+let shuttingDown = false;
+const shutdown = async (signal: NodeJS.Signals) => {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  console.log(`[shutdown] ${signal} received; draining HTTP and WebSocket connections`);
+
+  // Covers both connection draining and the subsequent telemetry flush.
+  const hardKill = setTimeout(() => process.exit(1), 15_000);
+  hardKill.unref();
+
+  try {
+    await drainServer(server, wss, shutdownTelemetry);
+  } catch (error) {
+    console.error("[shutdown] graceful drain failed:", error);
+    // A close error must not prevent the telemetry providers from releasing
+    // their handles. This still occurs after the drain attempt has settled.
+    await shutdownTelemetry();
+  } finally {
+    clearTimeout(hardKill);
+    process.exit(0);
+  }
+};
+
+process.on("SIGTERM", () => { void shutdown("SIGTERM"); });
+process.on("SIGINT", () => { void shutdown("SIGINT"); });

--- a/apps/server/src/lib/graceful-shutdown.ts
+++ b/apps/server/src/lib/graceful-shutdown.ts
@@ -1,0 +1,52 @@
+export interface CloseableHttpServer {
+  close(callback: () => void): unknown;
+}
+
+export interface CloseableWebSocketServer {
+  clients: Iterable<{ close(code: number, reason: string): void }>;
+  close(callback: (error?: Error) => void): void;
+}
+
+function closeHttpServer(server: CloseableHttpServer): Promise<void> {
+  return new Promise((resolve) => {
+    server.close(resolve);
+  });
+}
+
+function closeWebSocketServer(wss: CloseableWebSocketServer): Promise<void> {
+  // HTTP Server.close() does not close sockets that have already upgraded.
+  // Start a normal WS close handshake for every client; wss.close() resolves
+  // after those clients have disconnected. The process-level hard timeout in
+  // index.ts remains the backstop for a client that never completes it.
+  for (const client of wss.clients) {
+    client.close(1001, "Server shutting down");
+  }
+
+  return new Promise((resolve, reject) => {
+    wss.close((error) => {
+      if (error) reject(error);
+      else resolve();
+    });
+  });
+}
+
+/** Stop new traffic, drain HTTP and WS, then flush final telemetry. */
+export async function drainServer(
+  server: CloseableHttpServer,
+  wss: CloseableWebSocketServer,
+  shutdownTelemetry: () => Promise<void>,
+): Promise<void> {
+  // Begin both drains together: upgraded sockets can otherwise keep the HTTP
+  // server's close callback pending, depending on Node/server adapter details.
+  const results = await Promise.allSettled([
+    closeHttpServer(server),
+    closeWebSocketServer(wss),
+  ]);
+  const errors = results
+    .filter((result): result is PromiseRejectedResult => result.status === "rejected")
+    .map((result) => result.reason);
+  if (errors.length > 0) {
+    throw new AggregateError(errors, "one or more server drains failed");
+  }
+  await shutdownTelemetry();
+}

--- a/apps/server/src/lib/otel.ts
+++ b/apps/server/src/lib/otel.ts
@@ -67,23 +67,11 @@ const meterProvider = new MeterProvider({
 metrics.setGlobalMeterProvider(meterProvider);
 
 // ── Graceful shutdown ─────────────────────────────────────────────────────────
-// Flush buffered spans/metrics on process termination, then exit so the process
-// doesn't hang on live handles (HTTP server socket, keep-alive connections).
-// process.exit(0) is in `finally` so it runs even if a provider rejects (e.g.
-// collector unavailable), preventing unhandled-rejection hangs on SIGTERM.
-const shutdown = async (signal: string) => {
-  // Hard-kill backstop: if flush stalls (e.g. collector network hang),
-  // force-exit after 10s. unref() so it doesn't prevent normal exit itself.
-  const hardKill = setTimeout(() => process.exit(1), 10_000);
-  hardKill.unref();
-  try {
-    await Promise.allSettled([provider.shutdown(), meterProvider.shutdown()]);
-  } finally {
-    process.exit(0);
-  }
-};
-process.on('SIGTERM', () => { void shutdown('SIGTERM'); });
-process.on('SIGINT', () => { void shutdown('SIGINT'); });
+// Signal ownership belongs to index.ts, which can drain its HTTP and WebSocket
+// servers before flushing the final request-completion telemetry.
+export async function shutdownTelemetry(): Promise<void> {
+  await Promise.allSettled([provider.shutdown(), meterProvider.shutdown()]);
+}
 
 export function getTracer(name: string): Tracer {
   return trace.getTracer(name);


### PR DESCRIPTION
Project-state release-gate MUST fix — verify-first item, confirmed by direct trace before implementation.

`otel.ts` installed the process's ONLY SIGTERM/SIGINT handlers and unconditionally `process.exit(0)`'d after flushing telemetry — `index.ts` never referenced its own `server` in any shutdown path, no `server.close()` anywhere. Every deploy restart killed in-flight requests' sockets immediately instead of draining them.

Fix: signal ownership moves to `index.ts` (the only place with the server + WebSocket references). `otel.ts` now exports a pure `shutdownTelemetry()` (flush only). New `lib/graceful-shutdown.ts` drains HTTP (`server.close()`) and WS (per-client 1001 close + `wss.close()`, since HTTP close alone doesn't close already-upgraded sockets) concurrently, THEN flushes telemetry — so request-completion spans from draining requests still get flushed. Idempotent shutdown handler, 15s hard-kill backstop.

## Verification
404/404, typecheck clean. Call-order unit test (ephemeral port binding unavailable in the sandbox) proves telemetry flush fires strictly after both drains resolve, not concurrently.

Not merging — cheap-first re-verification to follow, then held for the standing merge doctrine.