### PR TITLE
Release v1.16.0 — in-app Fleet Cockpit via same-origin authenticated proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,40 @@
 
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.16.0] — 2026-07-13
+
+### Highlights
+
+- **Fleet Cockpit now opens inside the mini-app** — no more external-Safari hop, no more
+  cockpit `401 unauthorized`.
+
+### Added
+
+- Same-origin authenticated cockpit proxy: `/api/cockpit-proxy/*` forwards to the
+  co-located cockpit service with the auth token attached server-side (never
+  client-visible). Iframe subresources authenticate via a signed HttpOnly, path-scoped
+  session cookie (1h TTL) minted only for Telegram-authenticated callers. (#323)
+- `#/cockpit` SPA route rendering the proxied cockpit in a same-origin iframe with
+  Telegram BackButton wiring — closes the #315 login-stranding class. Links entry falls
+  back to the external tab when the server proxy is unconfigured.
+
+### Security
+
+- Proxy hardening from the review round: absolute/protocol-relative/encoded upstream
+  paths rejected before URL construction + resolved-origin assertion (token
+  exfiltration guard); session cookie cannot self-renew; cross-origin upstream
+  redirects blocked; root-relative redirects rewritten under the proxy prefix;
+  Connection-nominated headers stripped.
+
+### Deploy
+
+- New server env: `COCKPIT_AUTH_TOKEN` (required for in-app cockpit; must match the
+  cockpit service) and optional `COCKPIT_INTERNAL_URL` (default
+  `http://127.0.0.1:38847`). See docs/guides/deploying.md.
+
+> Note: entries for v1.13.0–v1.15.0 were not stamped at release time; backfill tracked
+> by the Director.
+
 ## [1.12.0] — 2026-04-18
 
 ### Highlights

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this p
 - `#/cockpit` SPA route rendering the proxied cockpit in a same-origin iframe with
   Telegram BackButton wiring — closes the #315 login-stranding class. Links entry falls
   back to the external tab when the server proxy is unconfigured.
+- Fit Screen is available on every terminal session view and resizes only the session
+  carried by that view's validated WebSocket connection; Restart and git remain
+  default-session-only.
 
 ### Security
 

--- a/apps/server/AGENTS.md
+++ b/apps/server/AGENTS.md
@@ -88,6 +88,8 @@ WebSocket auth is handled separately in `auth.ts` via `checkAuth()`.
 | `OPENAI_API_KEY`          | `~/.secrets/openai.env`   | TTS, transcribe|
 | `BOTTOKEN`                | `common.sh` (via shell)   | Telegram sends |
 | `TELEGRAM_CHAT_ID`        | `common.sh` (via shell)   | Telegram sends |
+| `COCKPIT_AUTH_TOKEN`      | `~/.secrets/cpc.env`      | Cockpit proxy auth |
+| `COCKPIT_INTERNAL_URL`    | `~/.secrets/cpc.env`      | Cockpit loopback URL |
 
 The server loads `~/.secrets/cpc.env` at startup via `loadEnv()`. OpenAI key
 is loaded separately in `actions.ts` and `voice.ts`.

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -32,6 +32,7 @@ import { markdownRoute } from "./routes/markdown.js";
 import { readingListRoute } from "./routes/reading-list.js";
 import { prsRoute } from "./routes/prs.js";
 import { shareRoute } from "./routes/share.js";
+import { cockpitProxyRoute } from "./routes/cockpit-proxy.js";
 import { isAssetLikePath } from "./lib/spa-fallback.js";
 
 // Load env from secrets file if not already set
@@ -160,6 +161,11 @@ app.post("/api/auth/telegram-widget", async (c) => {
   const token = createSession(user);
   return c.json({ ok: true, token, user: { id: user.id, first_name: user.first_name } });
 });
+
+// The cockpit iframe/EventSource use a proxy-scoped HttpOnly session derived
+// from normal CPC auth, so this self-protected route must be mounted before the
+// generic /api/* middleware. See routes/cockpit-proxy.ts.
+app.route("/api/cockpit-proxy", cockpitProxyRoute);
 
 // Auth middleware for all other /api/* routes
 app.use("/api/*", telegramAuth);

--- a/apps/server/src/routes/__tests__/cockpit-proxy.test.ts
+++ b/apps/server/src/routes/__tests__/cockpit-proxy.test.ts
@@ -60,11 +60,11 @@ function makeInitData(): string {
   return params.toString();
 }
 
-function buildApp(): Hono {
+function buildApp(overrides: { internalUrl?: string } = {}): Hono {
   const app = new Hono();
   app.route("/api/cockpit-proxy", createCockpitProxyRoute({
     fetchImpl: fetchImpl as unknown as typeof fetch,
-    getConfig: () => config,
+    getConfig: () => ({ ...config, ...overrides }),
     now: () => Date.parse("2026-07-13T12:00:00Z"),
   }));
   return app;
@@ -183,6 +183,30 @@ describe("cockpit proxy", () => {
     expect(response.status).toBeGreaterThanOrEqual(400);
     expect(response.status).toBeLessThan(500);
     expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("rejects dot-segment traversal escaping a subpath internal URL", async () => {
+    const app = buildApp({ internalUrl: "http://127.0.0.1:38847/cockpit" });
+    const cookie = await proxyCookie(app);
+    fetchImpl.mockClear();
+
+    const response = await app.request("/api/cockpit-proxy/../admin/secrets", {
+      headers: { Cookie: cookie },
+    });
+
+    expect(response.status).toBeGreaterThanOrEqual(400);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("still proxies normally when the internal URL carries a subpath", async () => {
+    const app = buildApp({ internalUrl: "http://127.0.0.1:38847/cockpit" });
+    const cookie = await proxyCookie(app);
+    await app.request("/api/cockpit-proxy/api/fleet", {
+      headers: { Cookie: cookie },
+    });
+
+    const [target] = fetchImpl.mock.calls[0] as [URL];
+    expect(String(target)).toBe("http://127.0.0.1:38847/cockpit/api/fleet");
   });
 
   it("strips headers nominated by the incoming Connection header", async () => {

--- a/apps/server/src/routes/__tests__/cockpit-proxy.test.ts
+++ b/apps/server/src/routes/__tests__/cockpit-proxy.test.ts
@@ -115,6 +115,18 @@ describe("cockpit proxy", () => {
     expect(cookie).toContain("Path=/api/cockpit-proxy");
   });
 
+  it("does not renew a session authenticated only by its existing cookie", async () => {
+    const app = buildApp();
+    const cookie = await proxyCookie(app);
+    const response = await app.request("/api/cockpit-proxy/health", {
+      headers: { Cookie: cookie },
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ configured: true });
+    expect(response.headers.get("set-cookie")).toBeNull();
+  });
+
   it("forwards method, path, query and body with only the server Bearer credential", async () => {
     let receivedBody = "";
     fetchImpl.mockImplementation(async (input: URL | RequestInfo, init?: RequestInit) => {
@@ -154,6 +166,91 @@ describe("cockpit proxy", () => {
     expect(headers.get("x-cockpit-intent")).toBe("compact");
     expect(receivedBody).toBe('{"request":"compact"}');
     expect(responseBody).not.toContain(COCKPIT_TOKEN);
+  });
+
+  it.each([
+    "/api/cockpit-proxy/http://attacker.example/",
+    "/api/cockpit-proxy//attacker.example/",
+    "/api/cockpit-proxy/http:%5C%5Cattacker.example/",
+    "/api/cockpit-proxy/%2F%2Fattacker.example/",
+  ])("rejects unsafe upstream path %s without fetching", async (path) => {
+    const app = buildApp();
+    const cookie = await proxyCookie(app);
+    fetchImpl.mockClear();
+
+    const response = await app.request(path, { headers: { Cookie: cookie } });
+
+    expect(response.status).toBeGreaterThanOrEqual(400);
+    expect(response.status).toBeLessThan(500);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("strips headers nominated by the incoming Connection header", async () => {
+    const app = buildApp();
+    const cookie = await proxyCookie(app);
+    await app.request("/api/cockpit-proxy/api/fleet", {
+      headers: {
+        Cookie: cookie,
+        Connection: "X-Remove-Me, X-Also-Remove",
+        "X-Also-Remove": "private",
+        "X-Keep-Me": "public",
+        "X-Remove-Me": "private",
+      },
+    });
+
+    const [, init] = fetchImpl.mock.calls[0] as [URL, RequestInit];
+    const headers = new Headers(init.headers);
+    expect(headers.get("connection")).toBeNull();
+    expect(headers.get("x-remove-me")).toBeNull();
+    expect(headers.get("x-also-remove")).toBeNull();
+    expect(headers.get("x-keep-me")).toBe("public");
+  });
+
+  it("rewrites same-origin absolute redirects beneath the proxy prefix", async () => {
+    fetchImpl.mockResolvedValue(new Response(null, {
+      status: 302,
+      headers: { Location: "http://127.0.0.1:38847/login?next=%2Ffleet#auth" },
+    }));
+    const app = buildApp();
+    const cookie = await proxyCookie(app);
+    const response = await app.request("/api/cockpit-proxy/api/fleet", {
+      headers: { Cookie: cookie },
+    });
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toBe(
+      "/api/cockpit-proxy/login?next=%2Ffleet#auth",
+    );
+  });
+
+  it("passes relative upstream redirects through unchanged", async () => {
+    fetchImpl.mockResolvedValue(new Response(null, {
+      status: 307,
+      headers: { Location: "../login?next=fleet" },
+    }));
+    const app = buildApp();
+    const cookie = await proxyCookie(app);
+    const response = await app.request("/api/cockpit-proxy/api/fleet", {
+      headers: { Cookie: cookie },
+    });
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toBe("../login?next=fleet");
+  });
+
+  it("rejects absolute upstream redirects to another origin", async () => {
+    fetchImpl.mockResolvedValue(new Response(null, {
+      status: 302,
+      headers: { Location: "https://attacker.example/collect" },
+    }));
+    const app = buildApp();
+    const cookie = await proxyCookie(app);
+    const response = await app.request("/api/cockpit-proxy/api/fleet", {
+      headers: { Cookie: cookie },
+    });
+
+    expect(response.status).toBe(502);
+    expect(response.headers.get("location")).toBeNull();
   });
 
   it("rewrites root-absolute cockpit API paths beneath the proxy prefix", async () => {

--- a/apps/server/src/routes/__tests__/cockpit-proxy.test.ts
+++ b/apps/server/src/routes/__tests__/cockpit-proxy.test.ts
@@ -1,0 +1,199 @@
+import { createHmac } from "node:crypto";
+import { Hono } from "hono";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { createCockpitProxyRoute } from "../cockpit-proxy.js";
+
+const TEST_BOT_TOKEN = "123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11";
+const TEST_USER = { id: 999111, first_name: "TestUser" };
+const COCKPIT_TOKEN = "cockpit-server-secret";
+
+const savedEnv = {
+  botToken: process.env.TELEGRAM_BOT_TOKEN,
+  allowedUsers: process.env.ALLOWED_TELEGRAM_USERS,
+  nodeEnv: process.env.NODE_ENV,
+};
+
+let config = {
+  internalUrl: "http://127.0.0.1:38847",
+  authToken: COCKPIT_TOKEN,
+};
+let fetchImpl: ReturnType<typeof vi.fn>;
+
+beforeAll(() => {
+  process.env.TELEGRAM_BOT_TOKEN = TEST_BOT_TOKEN;
+  process.env.ALLOWED_TELEGRAM_USERS = String(TEST_USER.id);
+  process.env.NODE_ENV = "test";
+});
+
+afterAll(() => {
+  restoreEnv("TELEGRAM_BOT_TOKEN", savedEnv.botToken);
+  restoreEnv("ALLOWED_TELEGRAM_USERS", savedEnv.allowedUsers);
+  restoreEnv("NODE_ENV", savedEnv.nodeEnv);
+});
+
+beforeEach(() => {
+  config = {
+    internalUrl: "http://127.0.0.1:38847",
+    authToken: COCKPIT_TOKEN,
+  };
+  fetchImpl = vi.fn(async () => new Response(JSON.stringify({ ok: true }), {
+    headers: { "content-type": "application/json" },
+  }));
+});
+
+function restoreEnv(name: string, value: string | undefined): void {
+  if (value === undefined) delete process.env[name];
+  else process.env[name] = value;
+}
+
+function makeInitData(): string {
+  const params = new URLSearchParams({
+    auth_date: String(Math.floor(Date.now() / 1000)),
+    user: JSON.stringify(TEST_USER),
+  });
+  const dataCheckString = Array.from(params.entries())
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([key, value]) => `${key}=${value}`)
+    .join("\n");
+  const secretKey = createHmac("sha256", "WebAppData").update(TEST_BOT_TOKEN).digest();
+  params.set("hash", createHmac("sha256", secretKey).update(dataCheckString).digest("hex"));
+  return params.toString();
+}
+
+function buildApp(): Hono {
+  const app = new Hono();
+  app.route("/api/cockpit-proxy", createCockpitProxyRoute({
+    fetchImpl: fetchImpl as unknown as typeof fetch,
+    getConfig: () => config,
+    now: () => Date.parse("2026-07-13T12:00:00Z"),
+  }));
+  return app;
+}
+
+function cpcAuthHeaders(): HeadersInit {
+  return { Authorization: `tma ${makeInitData()}` };
+}
+
+async function proxyCookie(app: Hono): Promise<string> {
+  const response = await app.request("/api/cockpit-proxy/health", { headers: cpcAuthHeaders() });
+  const setCookie = response.headers.get("set-cookie");
+  expect(setCookie).toContain("cpc_cockpit_proxy=");
+  return setCookie!.split(";", 1)[0];
+}
+
+describe("cockpit proxy", () => {
+  it("requires CPC auth before disclosing capability or proxying", async () => {
+    const app = buildApp();
+    expect((await app.request("/api/cockpit-proxy/health")).status).toBe(401);
+    expect((await app.request("/api/cockpit-proxy/")).status).toBe(401);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("reports an authenticated disabled capability without setting a cookie", async () => {
+    config.authToken = "";
+    const response = await buildApp().request("/api/cockpit-proxy/health", {
+      headers: cpcAuthHeaders(),
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ configured: false });
+    expect(response.headers.get("set-cookie")).toBeNull();
+  });
+
+  it("bootstraps a scoped HttpOnly session without exposing the cockpit token", async () => {
+    const response = await buildApp().request("/api/cockpit-proxy/health", {
+      headers: cpcAuthHeaders(),
+    });
+    const body = await response.text();
+    const cookie = response.headers.get("set-cookie") || "";
+
+    expect(response.status).toBe(200);
+    expect(body).toBe('{"configured":true}');
+    expect(`${body}${cookie}`).not.toContain(COCKPIT_TOKEN);
+    expect(cookie).toContain("HttpOnly");
+    expect(cookie).toContain("SameSite=Strict");
+    expect(cookie).toContain("Path=/api/cockpit-proxy");
+  });
+
+  it("forwards method, path, query and body with only the server Bearer credential", async () => {
+    let receivedBody = "";
+    fetchImpl.mockImplementation(async (input: URL | RequestInfo, init?: RequestInit) => {
+      receivedBody = await new Response(init?.body).text();
+      return new Response('{"accepted":true}', {
+        headers: { "content-type": "application/json" },
+      });
+    });
+    const app = buildApp();
+    const cookie = await proxyCookie(app);
+    const response = await app.request(
+      "/api/cockpit-proxy/api/sessions/agent-1/compact?detail=full",
+      {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer client-credential-that-must-be-replaced",
+          Cookie: `${cookie}; unrelated=client-cookie`,
+          "Content-Type": "application/json",
+          "X-Cockpit-Intent": "compact",
+        },
+        body: '{"request":"compact"}',
+      },
+    );
+
+    expect(response.status).toBe(200);
+    const responseBody = await response.text();
+    expect(responseBody).toBe('{"accepted":true}');
+    expect(fetchImpl).toHaveBeenCalledOnce();
+    const [target, init] = fetchImpl.mock.calls[0] as [URL, RequestInit];
+    expect(target.toString()).toBe(
+      "http://127.0.0.1:38847/api/sessions/agent-1/compact?detail=full",
+    );
+    const headers = new Headers(init.headers);
+    expect(init.method).toBe("POST");
+    expect(headers.get("authorization")).toBe(`Bearer ${COCKPIT_TOKEN}`);
+    expect(headers.get("cookie")).toBeNull();
+    expect(headers.get("x-cockpit-intent")).toBe("compact");
+    expect(receivedBody).toBe('{"request":"compact"}');
+    expect(responseBody).not.toContain(COCKPIT_TOKEN);
+  });
+
+  it("rewrites root-absolute cockpit API paths beneath the proxy prefix", async () => {
+    fetchImpl.mockResolvedValue(new Response(
+      '<script>fetch("/api/fleet");new EventSource("/api/fleet/stream")</script>',
+      { headers: { "content-type": "text/html; charset=utf-8" } },
+    ));
+    const app = buildApp();
+    const cookie = await proxyCookie(app);
+    const response = await app.request("/api/cockpit-proxy/", {
+      headers: { Cookie: cookie },
+    });
+
+    expect(response.headers.get("content-type")).toContain("text/html");
+    expect(await response.text()).toContain(
+      'fetch("/api/cockpit-proxy/api/fleet")',
+    );
+  });
+
+  it("passes SSE through as a streamed response with its content type", async () => {
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode("data: one\n\n"));
+        controller.close();
+      },
+    });
+    fetchImpl.mockResolvedValue(new Response(stream, {
+      headers: {
+        "cache-control": "no-cache",
+        "content-type": "text/event-stream",
+      },
+    }));
+    const app = buildApp();
+    const cookie = await proxyCookie(app);
+    const response = await app.request("/api/cockpit-proxy/api/fleet/stream", {
+      headers: { Cookie: cookie },
+    });
+
+    expect(response.headers.get("content-type")).toBe("text/event-stream");
+    expect(response.headers.get("cache-control")).toBe("no-cache");
+    expect(await response.text()).toBe("data: one\n\n");
+  });
+});

--- a/apps/server/src/routes/__tests__/cockpit-proxy.test.ts
+++ b/apps/server/src/routes/__tests__/cockpit-proxy.test.ts
@@ -223,6 +223,23 @@ describe("cockpit proxy", () => {
     );
   });
 
+  it("rewrites root-relative upstream redirects beneath the proxy prefix", async () => {
+    fetchImpl.mockResolvedValue(new Response(null, {
+      status: 302,
+      headers: { Location: "/login?next=%2Ffleet" },
+    }));
+    const app = buildApp();
+    const cookie = await proxyCookie(app);
+    const response = await app.request("/api/cockpit-proxy/api/fleet", {
+      headers: { Cookie: cookie },
+    });
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toBe(
+      "/api/cockpit-proxy/login?next=%2Ffleet",
+    );
+  });
+
   it("passes relative upstream redirects through unchanged", async () => {
     fetchImpl.mockResolvedValue(new Response(null, {
       status: 307,

--- a/apps/server/src/routes/__tests__/terminal-ws-fit.test.ts
+++ b/apps/server/src/routes/__tests__/terminal-ws-fit.test.ts
@@ -9,7 +9,7 @@ import { createSession } from "../../auth.js";
  *   1. `validateFitDimensions` — bounds/type checks in isolation (no tmux
  *      involved), since this is the untrusted input surface (WebView).
  *   2. `onMessage` wiring — a valid `{ type: "fit", cols, rows }` message
- *      calls `tmux resize-window -t <session> -x <cols> -y <rows>` via
+ *      calls `tmux resize-window -t =<session>: -x <cols> -y <rows>` via
  *      `execFile` (argv array, no shell) and acks over the socket; an
  *      invalid message never reaches `execFile` and gets a `fit-error`
  *      reply instead; the legacy `resize` message type remains a no-op.
@@ -224,7 +224,7 @@ describe("terminalWsRoute onMessage: fit", () => {
 
     expect(execFileCalls[0].cmd).toBe("tmux");
     expect(execFileCalls[0].args).toEqual([
-      "resize-window", "-t", "test-session", "-x", "92", "-y", "40",
+      "resize-window", "-t", "=test-session:", "-x", "92", "-y", "40",
     ]);
 
     (ws as any)._cleanup?.();
@@ -241,7 +241,7 @@ describe("terminalWsRoute onMessage: fit", () => {
     expect(execFileCalls).toHaveLength(2);
     expect(execFileCalls[1].cmd).toBe("tmux");
     expect(execFileCalls[1].args).toEqual([
-      "set-option", "-t", "test-session", "window-size", "latest",
+      "set-option", "-t", "=test-session:", "window-size", "latest",
     ]);
 
     (ws as any)._cleanup?.();

--- a/apps/server/src/routes/__tests__/terminal-ws-session.test.ts
+++ b/apps/server/src/routes/__tests__/terminal-ws-session.test.ts
@@ -13,9 +13,9 @@ import { createSession } from "../../auth.js";
  *      exact-match `=<name>`; an unknown session closes 4004 after the
  *      probe; the default session starts polling with no probe (legacy
  *      restart-tolerance).
- *   3. onMessage "fit" — a view-only (non-default) session gets fit-error
- *      and `tmux resize-window` is NEVER reached; the default session
- *      keeps its existing fit behavior.
+ *   3. onMessage "fit" — the single sanctioned session-scoped write
+ *      resizes the viewed session; the default session keeps its existing
+ *      behavior. Every other WS write-shaped message remains inert.
  */
 
 const TEST_USER_ID = "999222";
@@ -272,8 +272,8 @@ describe("terminalWsRoute capture-pane poll: null (timeout) exit code is transie
   });
 });
 
-describe("terminalWsRoute onMessage: fit is default-session-only", () => {
-  it("rejects fit on a non-default session with fit-error and never reaches resize-window", async () => {
+describe("terminalWsRoute onMessage: fit targets the viewed session", () => {
+  it("applies fit to a non-default session with an exact-match target", async () => {
     existingSessions.add("do-box--lane-a");
     const { handlers, ws } = connectWs("do-box--lane-a");
     await flush();
@@ -282,10 +282,11 @@ describe("terminalWsRoute onMessage: fit is default-session-only", () => {
       ws as any,
     );
     await flush();
-    const fitError = ws._sent.map((m) => JSON.parse(m)).find((m) => m.type === "fit-error");
-    expect(fitError).toBeTruthy();
-    expect(fitError.message).toMatch(/view-only/i);
-    expect(execFileCalls.find((c) => c.args[0] === "resize-window")).toBeUndefined();
+    const resize = execFileCalls.find((c) => c.args[0] === "resize-window");
+    expect(resize?.args).toEqual(["resize-window", "-t", "=do-box--lane-a:", "-x", "100", "-y", "40"]);
+    const release = execFileCalls.find((c) => c.args[0] === "set-option");
+    expect(release?.args).toEqual(["set-option", "-t", "=do-box--lane-a:", "window-size", "latest"]);
+    expect(ws._sent.map((m) => JSON.parse(m)).some((m) => m.type === "fit-ack")).toBe(true);
     handlers.onClose(new Event("close"), ws as any);
   });
 
@@ -298,8 +299,39 @@ describe("terminalWsRoute onMessage: fit is default-session-only", () => {
     );
     await flush();
     const resize = execFileCalls.find((c) => c.args[0] === "resize-window");
-    expect(resize?.args).toEqual(["resize-window", "-t", "test-session", "-x", "100", "-y", "40"]);
+    expect(resize?.args).toEqual(["resize-window", "-t", "=test-session:", "-x", "100", "-y", "40"]);
     expect(ws._sent.map((m) => JSON.parse(m)).some((m) => m.type === "fit-ack")).toBe(true);
+    handlers.onClose(new Event("close"), ws as any);
+  });
+
+  it("still rejects malformed fit dimensions on a non-default session without a tmux write", async () => {
+    existingSessions.add("do-box--lane-a");
+    const { handlers, ws } = connectWs("do-box--lane-a");
+    await flush();
+    handlers.onMessage(
+      { data: JSON.stringify({ type: "fit", cols: 100, rows: "40" }) } as unknown as MessageEvent,
+      ws as any,
+    );
+    await flush();
+    expect(execFileCalls.some((c) => c.args[0] === "resize-window" || c.args[0] === "set-option")).toBe(false);
+    expect(ws._sent.map((m) => JSON.parse(m)).some((m) => m.type === "fit-error")).toBe(true);
+    handlers.onClose(new Event("close"), ws as any);
+  });
+
+  it("keeps every other WS write path inert for a non-default session", async () => {
+    existingSessions.add("do-box--lane-a");
+    const { handlers, ws } = connectWs("do-box--lane-a");
+    await flush();
+    handlers.onMessage(
+      { data: JSON.stringify({ type: "resize", cols: 100, rows: 40 }) } as unknown as MessageEvent,
+      ws as any,
+    );
+    handlers.onMessage(
+      { data: JSON.stringify({ type: "send-keys", keys: "C-c" }) } as unknown as MessageEvent,
+      ws as any,
+    );
+    await flush();
+    expect(execFileCalls.some((c) => c.args[0] === "resize-window" || c.args[0] === "set-option" || c.args[0] === "send-keys")).toBe(false);
     handlers.onClose(new Event("close"), ws as any);
   });
 });

--- a/apps/server/src/routes/cockpit-proxy.ts
+++ b/apps/server/src/routes/cockpit-proxy.ts
@@ -1,0 +1,192 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+import { Hono } from "hono";
+import { getCookie, setCookie } from "hono/cookie";
+import { telegramAuth } from "../middleware.js";
+
+const DEFAULT_INTERNAL_URL = "http://127.0.0.1:38847";
+const PROXY_PREFIX = "/api/cockpit-proxy";
+const SESSION_COOKIE = "cpc_cockpit_proxy";
+const SESSION_TTL_SECONDS = 60 * 60;
+
+const HOP_BY_HOP_HEADERS = [
+  "connection",
+  "content-length",
+  "host",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "te",
+  "trailer",
+  "transfer-encoding",
+  "upgrade",
+];
+
+interface CockpitProxyConfig {
+  internalUrl: string;
+  authToken: string;
+}
+
+interface CockpitProxyOptions {
+  fetchImpl?: typeof fetch;
+  getConfig?: () => CockpitProxyConfig;
+  now?: () => number;
+}
+
+function defaultConfig(): CockpitProxyConfig {
+  return {
+    internalUrl: process.env.COCKPIT_INTERNAL_URL || DEFAULT_INTERNAL_URL,
+    authToken: process.env.COCKPIT_AUTH_TOKEN || "",
+  };
+}
+
+function configured(config: CockpitProxyConfig): boolean {
+  if (!config.authToken) return false;
+  try {
+    const url = new URL(config.internalUrl);
+    return url.protocol === "http:" || url.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+function sessionSignature(expires: string, token: string): string {
+  return createHmac("sha256", token)
+    .update(`cpc-cockpit-proxy:${expires}`)
+    .digest("base64url");
+}
+
+function makeSession(token: string, now: number): string {
+  const expires = String(Math.floor(now / 1000) + SESSION_TTL_SECONDS);
+  return `${expires}.${sessionSignature(expires, token)}`;
+}
+
+function validSession(value: string | undefined, token: string, now: number): boolean {
+  if (!value || !token) return false;
+  const separator = value.indexOf(".");
+  if (separator <= 0) return false;
+  const expires = value.slice(0, separator);
+  const signature = value.slice(separator + 1);
+  if (!/^\d+$/.test(expires) || Number(expires) <= Math.floor(now / 1000)) return false;
+
+  const actual = Buffer.from(signature);
+  const expected = Buffer.from(sessionSignature(expires, token));
+  return actual.length === expected.length && timingSafeEqual(actual, expected);
+}
+
+function upstreamUrl(incoming: URL, internalUrl: string): URL {
+  const base = new URL(internalUrl.endsWith("/") ? internalUrl : `${internalUrl}/`);
+  const proxyPath = incoming.pathname.slice(PROXY_PREFIX.length).replace(/^\/+/, "");
+  const target = new URL(proxyPath, base);
+  target.search = incoming.search;
+  return target;
+}
+
+function forwardedHeaders(incoming: Headers, authToken: string): Headers {
+  const headers = new Headers(incoming);
+  headers.delete("authorization");
+  headers.delete("cookie");
+  for (const name of HOP_BY_HOP_HEADERS) headers.delete(name);
+  headers.set("authorization", `Bearer ${authToken}`);
+  return headers;
+}
+
+function rewriteCockpitHtml(html: string): string {
+  // Cockpit currently keeps its CSS/JS inline, so relative future assets resolve
+  // beneath the iframe's trailing-slash URL automatically. Its fetch/EventSource
+  // calls are root-absolute, however; keep those on the authenticated proxy.
+  return html.replace(/(["'])\/api\//g, `$1${PROXY_PREFIX}/api/`);
+}
+
+export function createCockpitProxyRoute(options: CockpitProxyOptions = {}) {
+  const route = new Hono();
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const getConfig = options.getConfig ?? defaultConfig;
+  const now = options.now ?? Date.now;
+
+  // An iframe navigation and EventSource cannot attach Telegram's tma header.
+  // Bootstrap a narrow HttpOnly cookie from a normal authenticated CPC fetch,
+  // then accept only that signed cookie (or the normal middleware) here.
+  route.use("*", async (c, next) => {
+    const config = getConfig();
+    if (validSession(getCookie(c, SESSION_COOKIE), config.authToken, now())) {
+      await next();
+      return;
+    }
+    return telegramAuth(c, next);
+  });
+
+  route.get("/health", (c) => {
+    const config = getConfig();
+    const isConfigured = configured(config);
+    if (isConfigured) {
+      setCookie(c, SESSION_COOKIE, makeSession(config.authToken, now()), {
+        httpOnly: true,
+        maxAge: SESSION_TTL_SECONDS,
+        path: PROXY_PREFIX,
+        sameSite: "Strict",
+        secure: process.env.NODE_ENV !== "development" && process.env.NODE_ENV !== "test",
+      });
+    }
+    return c.json({ configured: isConfigured });
+  });
+
+  route.all("*", async (c) => {
+    const config = getConfig();
+    if (!configured(config)) {
+      return c.json({ error: "Cockpit proxy is not configured" }, 503);
+    }
+
+    const incoming = new URL(c.req.url);
+    let target: URL;
+    try {
+      target = upstreamUrl(incoming, config.internalUrl);
+    } catch {
+      return c.json({ error: "Cockpit proxy is not configured" }, 503);
+    }
+
+    const method = c.req.method.toUpperCase();
+    const init: RequestInit & { duplex?: "half" } = {
+      method,
+      headers: forwardedHeaders(c.req.raw.headers, config.authToken),
+      redirect: "manual",
+      signal: c.req.raw.signal,
+    };
+    if (method !== "GET" && method !== "HEAD") {
+      init.body = c.req.raw.body;
+      init.duplex = "half";
+    }
+
+    let upstream: Response;
+    try {
+      upstream = await fetchImpl(target, init);
+    } catch {
+      return c.json({ error: "Cockpit upstream unavailable" }, 502);
+    }
+
+    const contentType = upstream.headers.get("content-type") || "application/octet-stream";
+    const responseHeaders = new Headers({ "content-type": contentType });
+    const cacheControl = upstream.headers.get("cache-control");
+    if (cacheControl) responseHeaders.set("cache-control", cacheControl);
+
+    if (contentType.toLowerCase().includes("text/html")) {
+      const html = rewriteCockpitHtml(await upstream.text());
+      return new Response(html, {
+        status: upstream.status,
+        statusText: upstream.statusText,
+        headers: responseHeaders,
+      });
+    }
+
+    // Passing the upstream ReadableStream directly preserves SSE and polling
+    // response streaming without buffering live fleet data in CPC.
+    return new Response(upstream.body, {
+      status: upstream.status,
+      statusText: upstream.statusText,
+      headers: responseHeaders,
+    });
+  });
+
+  return route;
+}
+
+export const cockpitProxyRoute = createCockpitProxyRoute();

--- a/apps/server/src/routes/cockpit-proxy.ts
+++ b/apps/server/src/routes/cockpit-proxy.ts
@@ -72,7 +72,9 @@ function validSession(value: string | undefined, token: string, now: number): bo
   if (separator <= 0) return false;
   const expires = value.slice(0, separator);
   const signature = value.slice(separator + 1);
-  if (!/^\d+$/.test(expires) || Number(expires) <= Math.floor(now / 1000)) return false;
+  // base64url SHA-256 HMAC is always 43 chars — cheap reject before the
+  // regex and HMAC work (gemini review, release PR #324).
+  if (signature.length !== 43 || !/^\d+$/.test(expires) || Number(expires) <= Math.floor(now / 1000)) return false;
 
   const actual = Buffer.from(signature);
   const expected = Buffer.from(sessionSignature(expires, token));

--- a/apps/server/src/routes/cockpit-proxy.ts
+++ b/apps/server/src/routes/cockpit-proxy.ts
@@ -125,7 +125,11 @@ function forwardedHeaders(incoming: Headers, authToken: string): Headers {
 function proxiedRedirectLocation(location: string, internalUrl: string): string | null {
   let absolute: URL;
   try {
-    absolute = location.startsWith("//")
+    // Any leading-slash Location (root-relative "/login" or protocol-relative
+    // "//host/…") is resolved against the cockpit origin — a root-relative
+    // path passed through unmodified would resolve against CPC's own origin
+    // root and escape the proxy prefix (delta-review finding, PR #323).
+    absolute = location.startsWith("/")
       ? new URL(location, internalUrl)
       : new URL(location);
   } catch {

--- a/apps/server/src/routes/cockpit-proxy.ts
+++ b/apps/server/src/routes/cockpit-proxy.ts
@@ -32,6 +32,12 @@ interface CockpitProxyOptions {
   now?: () => number;
 }
 
+interface CockpitProxyEnv {
+  Variables: {
+    cockpitAuthVia: "cookie" | "tma";
+  };
+}
+
 function defaultConfig(): CockpitProxyConfig {
   return {
     internalUrl: process.env.COCKPIT_INTERNAL_URL || DEFAULT_INTERNAL_URL,
@@ -75,19 +81,59 @@ function validSession(value: string | undefined, token: string, now: number): bo
 
 function upstreamUrl(incoming: URL, internalUrl: string): URL {
   const base = new URL(internalUrl.endsWith("/") ? internalUrl : `${internalUrl}/`);
-  const proxyPath = incoming.pathname.slice(PROXY_PREFIX.length).replace(/^\/+/, "");
+  const rawProxyPath = incoming.pathname.slice(PROXY_PREFIX.length);
+  let decodedProxyPath: string;
+  try {
+    decodedProxyPath = decodeURIComponent(rawProxyPath);
+  } catch {
+    throw new Error("Invalid cockpit proxy path");
+  }
+  if (
+    rawProxyPath.includes("://") ||
+    rawProxyPath.includes("\\") ||
+    rawProxyPath.startsWith("//") ||
+    decodedProxyPath.includes("://") ||
+    decodedProxyPath.includes("\\") ||
+    decodedProxyPath.startsWith("//")
+  ) {
+    throw new Error("Invalid cockpit proxy path");
+  }
+
+  const proxyPath = rawProxyPath.replace(/^\/+/, "");
   const target = new URL(proxyPath, base);
+  if (target.origin !== new URL(internalUrl).origin) {
+    throw new Error("Cockpit proxy target origin mismatch");
+  }
   target.search = incoming.search;
   return target;
 }
 
 function forwardedHeaders(incoming: Headers, authToken: string): Headers {
   const headers = new Headers(incoming);
+  const connectionHeaders = (incoming.get("connection") || "")
+    .split(",")
+    .map((name) => name.trim())
+    .filter(Boolean);
   headers.delete("authorization");
   headers.delete("cookie");
+  for (const name of connectionHeaders) headers.delete(name);
   for (const name of HOP_BY_HOP_HEADERS) headers.delete(name);
   headers.set("authorization", `Bearer ${authToken}`);
   return headers;
+}
+
+function proxiedRedirectLocation(location: string, internalUrl: string): string | null {
+  let absolute: URL;
+  try {
+    absolute = location.startsWith("//")
+      ? new URL(location, internalUrl)
+      : new URL(location);
+  } catch {
+    return location;
+  }
+
+  if (absolute.origin !== new URL(internalUrl).origin) return null;
+  return `${PROXY_PREFIX}${absolute.pathname}${absolute.search}${absolute.hash}`;
 }
 
 function rewriteCockpitHtml(html: string): string {
@@ -98,7 +144,7 @@ function rewriteCockpitHtml(html: string): string {
 }
 
 export function createCockpitProxyRoute(options: CockpitProxyOptions = {}) {
-  const route = new Hono();
+  const route = new Hono<CockpitProxyEnv>();
   const fetchImpl = options.fetchImpl ?? fetch;
   const getConfig = options.getConfig ?? defaultConfig;
   const now = options.now ?? Date.now;
@@ -109,16 +155,20 @@ export function createCockpitProxyRoute(options: CockpitProxyOptions = {}) {
   route.use("*", async (c, next) => {
     const config = getConfig();
     if (validSession(getCookie(c, SESSION_COOKIE), config.authToken, now())) {
+      c.set("cockpitAuthVia", "cookie");
       await next();
       return;
     }
-    return telegramAuth(c, next);
+    return telegramAuth(c, async () => {
+      c.set("cockpitAuthVia", "tma");
+      await next();
+    });
   });
 
   route.get("/health", (c) => {
     const config = getConfig();
     const isConfigured = configured(config);
-    if (isConfigured) {
+    if (isConfigured && c.get("cockpitAuthVia") === "tma") {
       setCookie(c, SESSION_COOKIE, makeSession(config.authToken, now()), {
         httpOnly: true,
         maxAge: SESSION_TTL_SECONDS,
@@ -141,7 +191,7 @@ export function createCockpitProxyRoute(options: CockpitProxyOptions = {}) {
     try {
       target = upstreamUrl(incoming, config.internalUrl);
     } catch {
-      return c.json({ error: "Cockpit proxy is not configured" }, 503);
+      return c.json({ error: "Invalid cockpit proxy target" }, 400);
     }
 
     const method = c.req.method.toUpperCase();
@@ -167,6 +217,17 @@ export function createCockpitProxyRoute(options: CockpitProxyOptions = {}) {
     const responseHeaders = new Headers({ "content-type": contentType });
     const cacheControl = upstream.headers.get("cache-control");
     if (cacheControl) responseHeaders.set("cache-control", cacheControl);
+
+    if (upstream.status >= 300 && upstream.status < 400) {
+      const location = upstream.headers.get("location");
+      if (location) {
+        const proxiedLocation = proxiedRedirectLocation(location, config.internalUrl);
+        if (proxiedLocation === null) {
+          return c.json({ error: "Cockpit upstream redirected to an unsafe origin" }, 502);
+        }
+        responseHeaders.set("location", proxiedLocation);
+      }
+    }
 
     if (contentType.toLowerCase().includes("text/html")) {
       const html = rewriteCockpitHtml(await upstream.text());

--- a/apps/server/src/routes/cockpit-proxy.ts
+++ b/apps/server/src/routes/cockpit-proxy.ts
@@ -104,6 +104,13 @@ function upstreamUrl(incoming: URL, internalUrl: string): URL {
   if (target.origin !== new URL(internalUrl).origin) {
     throw new Error("Cockpit proxy target origin mismatch");
   }
+  // When the internal URL carries a subpath, dot-segment traversal in the
+  // proxy path resolves within the same origin and passes the origin check —
+  // keep the resolved target pinned under the configured base path (gemini
+  // cloud review, release PR #324).
+  if (!target.pathname.startsWith(base.pathname)) {
+    throw new Error("Cockpit proxy target escaped the configured base path");
+  }
   target.search = incoming.search;
   return target;
 }

--- a/apps/server/src/routes/terminal-ws.ts
+++ b/apps/server/src/routes/terminal-ws.ts
@@ -169,7 +169,7 @@ export class FitLatchReleaseError extends Error {
   }
 }
 
-export async function applyFitResize(cols: number, rows: number): Promise<void> {
+export async function applyFitResize(session: string, cols: number, rows: number): Promise<void> {
   // TMUX_TIMEOUT_MS on both calls (round-2 review, PR #299): every other
   // tmux invocation in this file is capped so a wedged tmux server fails
   // the request instead of hanging it forever; these two were the only
@@ -177,14 +177,14 @@ export async function applyFitResize(cols: number, rows: number): Promise<void> 
   // unbounded child process and never resolve for the caller.
   await execFileAsync("tmux", [
     "resize-window",
-    "-t", TMUX_SESSION,
+    "-t", `=${session}:`,
     "-x", String(cols),
     "-y", String(rows),
   ], { timeout: TMUX_TIMEOUT_MS });
   try {
     await execFileAsync("tmux", [
       "set-option",
-      "-t", TMUX_SESSION,
+      "-t", `=${session}:`,
       "window-size", "latest",
     ], { timeout: TMUX_TIMEOUT_MS });
   } catch (err) {
@@ -406,23 +406,12 @@ export function terminalWsRoute(c: any) {
       try {
         const msg = JSON.parse(event.data.toString());
         if (msg.type === "fit") {
-          // Fit resizes the REAL tmux window (a write). Only the default
-          // session — the one the REST write endpoints already target — may
-          // be resized; every client-picked session is view-only, so the
-          // multi-session feature adds zero new write surface. Checked
-          // before validation so applyFitResize (hardwired to TMUX_SESSION)
-          // can never be reached from a view-only connection.
-          if (sessionResolution.session !== TMUX_SESSION) {
-            console.log(`[ws] fit rejected: view-only session "${sessionResolution.session}"`);
-            ws.send(JSON.stringify({
-              type: "fit-error",
-              message: "This session is view-only — fit is only available on the default session",
-            }));
-            return;
-          }
           // Explicit, user-initiated "Fit screen" action only — the client
-          // never sends this automatically (see NOTE above). Validate
-          // before touching tmux.
+          // never sends this automatically (see NOTE above). Fit is the
+          // single sanctioned WS write for a client-picked session and is
+          // scoped to the session already charset-validated by
+          // resolveRequestedSession. Validate dimensions before touching
+          // tmux.
           const result = validateFitDimensions(msg);
           if (!result.ok) {
             console.log(`[ws] fit rejected: ${result.error}`);
@@ -435,9 +424,9 @@ export function terminalWsRoute(c: any) {
             return;
           }
           const { cols, rows } = result;
-          applyFitResize(cols, rows)
+          applyFitResize(sessionResolution.session, cols, rows)
             .then(() => {
-              console.log(`[ws] fit applied: ${cols}x${rows}`);
+              console.log(`[ws] fit applied to "${sessionResolution.session}": ${cols}x${rows}`);
               ws.send(JSON.stringify({ type: "fit-ack", cols, rows }));
             })
             .catch((err: Error) => {

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -11,9 +11,11 @@ import { haptic } from "./lib/haptic";
 import { DebugOverlay } from "./debug/DebugOverlay";
 import { PrTicker } from "./components/PrTicker";
 import { HomeScreenPrompt } from "./components/HomeScreenPrompt";
+import { CockpitPage } from "./components/CockpitPage";
 import { SessionPicker, type TmuxSessionInfo } from "./components/SessionPicker";
 import {
   buildLandingUrl,
+  isCockpitRoute,
   resolveInitialAppState,
   type AppTab as Tab,
 } from "./lib/app-routing";
@@ -120,6 +122,7 @@ export function App() {
   }, [initialRoute.redirectPath]);
 
   const [activeTab, setActiveTab] = useState<Tab>(initialRoute.tab);
+  const [cockpitOpen, setCockpitOpen] = useState(() => isCockpitRoute(window.location.hash));
   const [reconnectKey, setReconnectKey] = useState(0);
 
   // Multi-session terminal (world-os#218): which tmux session the terminal
@@ -162,6 +165,18 @@ export function App() {
   const [currentFolder, setCurrentFolder] = useState<string | null>(null);
   const [cpcBranch, setCpcBranch] = useState<string | null>(null);
   const [showHomeScreenPrompt, setShowHomeScreenPrompt] = useState(false);
+
+  useEffect(() => {
+    const syncCockpitRoute = () => setCockpitOpen(isCockpitRoute(window.location.hash));
+    window.addEventListener("hashchange", syncCockpitRoute);
+    return () => window.removeEventListener("hashchange", syncCockpitRoute);
+  }, []);
+
+  const closeCockpit = useCallback(() => {
+    setActiveTab("links");
+    window.location.hash = "links";
+    setCockpitOpen(false);
+  }, []);
 
   const fileViewerSequence = fileOpenRequest.sequence;
   const handleFileViewChange = useCallback((file: { path: string; name: string } | null) => {
@@ -433,6 +448,10 @@ export function App() {
         }} />
       </div>
     );
+  }
+
+  if (cockpitOpen) {
+    return <CockpitPage onBack={closeCockpit} />;
   }
 
   return (

--- a/apps/web/src/components/CockpitPage.tsx
+++ b/apps/web/src/components/CockpitPage.tsx
@@ -1,0 +1,61 @@
+import { useEffect, useState } from "react";
+import { getAuthHeaders, getTelegramWebApp } from "../lib/telegram";
+
+interface CockpitPageProps {
+  onBack: () => void;
+}
+
+export function CockpitPage({ onBack }: CockpitPageProps) {
+  const [state, setState] = useState<"loading" | "ready" | "unavailable">("loading");
+
+  useEffect(() => {
+    const backButton = getTelegramWebApp()?.BackButton;
+    backButton?.show();
+    backButton?.onClick(onBack);
+    return () => {
+      backButton?.offClick(onBack);
+      backButton?.hide();
+    };
+  }, [onBack]);
+
+  useEffect(() => {
+    let active = true;
+    fetch("/api/cockpit-proxy/health", {
+      headers: getAuthHeaders(),
+      credentials: "same-origin",
+    })
+      .then(async (response) => response.ok ? response.json() : { configured: false })
+      .then((result) => {
+        if (active) setState(result.configured === true ? "ready" : "unavailable");
+      })
+      .catch(() => {
+        if (active) setState("unavailable");
+      });
+    return () => { active = false; };
+  }, []);
+
+  if (state !== "ready") {
+    return (
+      <div style={{
+        alignItems: "center",
+        background: "var(--color-bg)",
+        color: "var(--color-muted)",
+        display: "flex",
+        height: "100%",
+        justifyContent: "center",
+        padding: 20,
+        textAlign: "center",
+      }}>
+        {state === "loading" ? "Opening Fleet Cockpit…" : "Fleet Cockpit is not configured."}
+      </div>
+    );
+  }
+
+  return (
+    <iframe
+      src="/api/cockpit-proxy/"
+      title="Fleet Cockpit"
+      style={{ border: 0, display: "block", height: "100%", width: "100%" }}
+    />
+  );
+}

--- a/apps/web/src/components/Links.tsx
+++ b/apps/web/src/components/Links.tsx
@@ -1,5 +1,5 @@
-import { useState } from "react";
-import { getTelegramWebApp } from "../lib/telegram";
+import { useEffect, useState } from "react";
+import { getAuthHeaders, getTelegramWebApp } from "../lib/telegram";
 import { ReadingList } from "./ReadingList";
 import "./Links.css";
 
@@ -15,6 +15,7 @@ interface LinkItem {
    * don't fit.
    */
   inApp?: boolean;
+  internalRoute?: string;
 }
 
 /**
@@ -62,14 +63,12 @@ const LINKS: LinkItem[] = [
     url: "https://cockpit.claude.do",
     icon: "🛩️",
     description: "Fleet grid + live lane terminals",
-    // In-app navigation (Liam voice msg 1185) is DISABLED until two blockers
-    // clear: (1) cockpit.claude.do sits behind Cloudflare Access, which a
-    // Telegram WebView cannot pass — the link dead-ends at the Access wall;
-    // (2) window.location.assign is a one-way trip — any return to CPC that
-    // isn't a fresh Telegram launch leaves the webview without initData,
-    // stranding the user on the login screen (live incident 2026-07-10,
-    // voice 1565). Re-enable inApp only with the Access lift + BackButton
-    // return wiring (world-os#218 plan addendum).
+    internalRoute: "#/cockpit",
+    // #315 reverted top-level in-app navigation because Cloudflare Access
+    // blocks Telegram WebViews and leaving the SPA loses initData on return.
+    // The internal route now keeps CPC mounted, embeds a same-origin authenticated
+    // proxy, and wires Telegram's BackButton. If the server reports that the
+    // proxy token is absent, this entry retains #315's external-tab fallback.
   },
   {
     title: "Transcription Glossary",
@@ -116,6 +115,22 @@ interface LinksProps {
 }
 
 export function Links({ onClose, onOpenFile }: LinksProps) {
+  const [cockpitProxyAvailable, setCockpitProxyAvailable] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+    fetch("/api/cockpit-proxy/health", {
+      headers: getAuthHeaders(),
+      credentials: "same-origin",
+    })
+      .then(async (response) => response.ok ? response.json() : { configured: false })
+      .then((result) => {
+        if (active) setCockpitProxyAvailable(result.configured === true);
+      })
+      .catch(() => {});
+    return () => { active = false; };
+  }, []);
+
   return (
     <div style={{ display: "flex", flexDirection: "column", height: "100%" }}>
       <div
@@ -146,24 +161,31 @@ export function Links({ onClose, onOpenFile }: LinksProps) {
 
       <div style={{ flex: 1, overflow: "auto" }}>
         <ReadingList onOpenFile={onOpenFile} />
-        {LINKS.map((link) => (
+        {LINKS.map((link) => {
+          const useInternalRoute = Boolean(link.internalRoute && cockpitProxyAvailable);
+          const href = useInternalRoute ? link.internalRoute! : link.url;
+          return (
           <a
             key={link.url}
-            href={link.url}
+            href={href}
             // In-app links navigate the webview itself (see openInApp);
             // everything else keeps the external-tab behavior. rel stays on
             // both: middle-click/context-menu can still open the href
             // without going through onClick (PR #290 gemini review, MED).
-            target={link.inApp ? undefined : "_blank"}
+            target={link.inApp || useInternalRoute ? undefined : "_blank"}
             rel="noopener noreferrer"
-            onClick={link.inApp ? (e) => {
+            onClick={link.inApp || useInternalRoute ? (e) => {
               // Respect explicit new-tab intent (ctrl/cmd/shift-click,
               // middle-click) — let the browser's default anchor behavior
               // handle those instead of hijacking into a same-tab
               // navigation. (PR #290 codex LOW / gemini MED.)
               if (e.ctrlKey || e.metaKey || e.shiftKey || e.altKey || e.button !== 0) return;
               e.preventDefault();
-              openInApp(link.url);
+              if (useInternalRoute) {
+                window.location.hash = link.internalRoute!.slice(1);
+              } else {
+                openInApp(link.url);
+              }
             } : undefined}
             style={{
               display: "flex",
@@ -187,7 +209,8 @@ export function Links({ onClose, onOpenFile }: LinksProps) {
             </div>
             <span style={{ color: "#3b4261", fontSize: 14 }}>→</span>
           </a>
-        ))}
+          );
+        })}
 
         {/* --- Apps section --- */}
         <div

--- a/apps/web/src/components/__tests__/ActionBar.test.tsx
+++ b/apps/web/src/components/__tests__/ActionBar.test.tsx
@@ -1256,13 +1256,24 @@ describe("ActionBar", () => {
 describe("ActionBar restricted session mode", () => {
   const SESSION = "do-box--lane-a";
 
-  it("shows Reconnect and /commands but hides Git and the reconnect menu", () => {
-    render(<ActionBar activeTab="terminal" onReconnect={() => {}} terminalSession={SESSION} />);
+  it("shows Reconnect, Fit Screen, and /commands but hides default-session controls", () => {
+    render(<ActionBar activeTab="terminal" onReconnect={() => {}} onFitScreen={() => {}} terminalSession={SESSION} />);
     expect(screen.getByText("Reconnect")).toBeInTheDocument();
+    expect(screen.getByText("Fit Screen")).toBeInTheDocument();
     expect(screen.getByText("/commands")).toBeInTheDocument();
     // Default-session-only actions must not be reachable.
     expect(screen.queryByText("Git")).not.toBeInTheDocument();
+    expect(screen.queryByText("Restart Claude Session")).not.toBeInTheDocument();
     expect(screen.queryByLabelText("Open reconnect menu")).not.toBeInTheDocument();
+  });
+
+  it("calls onFitScreen from the restricted session row", () => {
+    const onFitScreen = vi.fn();
+    render(<ActionBar activeTab="terminal" onReconnect={() => {}} onFitScreen={onFitScreen} terminalSession={SESSION} />);
+    fireEvent.click(screen.getByText("Fit Screen"));
+    expect(onFitScreen).toHaveBeenCalledOnce();
+    expect(screen.getByText("Fit screen requested")).toBeInTheDocument();
+    expect(screen.queryByText("Restart Claude Session")).not.toBeInTheDocument();
   });
 
   it("hides orchestrator-bookkeeping commands in the sheet and names the target", () => {

--- a/apps/web/src/components/__tests__/CockpitPage.test.tsx
+++ b/apps/web/src/components/__tests__/CockpitPage.test.tsx
@@ -1,0 +1,50 @@
+import { act, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { CockpitPage } from "../CockpitPage";
+
+const { backButton } = vi.hoisted(() => ({
+  backButton: {
+    hide: vi.fn(),
+    offClick: vi.fn(),
+    onClick: vi.fn(),
+    show: vi.fn(),
+  },
+}));
+
+vi.mock("../../lib/telegram", () => ({
+  getAuthHeaders: () => ({ Authorization: "tma test-init-data" }),
+  getTelegramWebApp: () => ({ BackButton: backButton }),
+}));
+
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("CockpitPage", () => {
+  it("refreshes proxy auth, renders the iframe, and owns Telegram BackButton", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ configured: true }),
+    }));
+    const onBack = vi.fn();
+    const { unmount } = render(<CockpitPage onBack={onBack} />);
+
+    expect(backButton.show).toHaveBeenCalledOnce();
+    expect(backButton.onClick).toHaveBeenCalledWith(onBack);
+    await waitFor(() => expect(screen.getByTitle("Fleet Cockpit")).toHaveAttribute(
+      "src",
+      "/api/cockpit-proxy/",
+    ));
+
+    act(() => {
+      const callback = backButton.onClick.mock.calls[0][0];
+      callback();
+    });
+    expect(onBack).toHaveBeenCalledOnce();
+
+    unmount();
+    expect(backButton.offClick).toHaveBeenCalledWith(onBack);
+    expect(backButton.hide).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/web/src/components/__tests__/Links.test.tsx
+++ b/apps/web/src/components/__tests__/Links.test.tsx
@@ -1,0 +1,50 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { Links } from "../Links";
+
+vi.mock("../ReadingList", () => ({ ReadingList: () => null }));
+vi.mock("../../lib/telegram", () => ({
+  getAuthHeaders: () => ({ Authorization: "tma test-init-data" }),
+  getTelegramWebApp: () => null,
+}));
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  window.history.replaceState(null, "", "#links");
+});
+
+describe("Fleet Cockpit link", () => {
+  it("uses the internal SPA route when the authenticated proxy is configured", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ configured: true }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    render(<Links onClose={vi.fn()} onOpenFile={vi.fn()} />);
+
+    const link = screen.getByRole("link", { name: /Fleet Cockpit/ });
+    await waitFor(() => expect(link).toHaveAttribute("href", "#/cockpit"));
+    expect(link).not.toHaveAttribute("target");
+    expect(fetchMock).toHaveBeenCalledWith("/api/cockpit-proxy/health", {
+      headers: { Authorization: "tma test-init-data" },
+      credentials: "same-origin",
+    });
+
+    fireEvent.click(link);
+    expect(window.location.hash).toBe("#/cockpit");
+  });
+
+  it("retains the external-tab fallback when the proxy is disabled", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ configured: false }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    render(<Links onClose={vi.fn()} onOpenFile={vi.fn()} />);
+
+    const link = screen.getByRole("link", { name: /Fleet Cockpit/ });
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledOnce());
+    expect(link).toHaveAttribute("href", "https://cockpit.claude.do");
+    expect(link).toHaveAttribute("target", "_blank");
+  });
+});

--- a/apps/web/src/components/action-bar/ActionBar.tsx
+++ b/apps/web/src/components/action-bar/ActionBar.tsx
@@ -544,6 +544,13 @@ export function ActionBar({ onReconnect, onFitScreen, fitResult, connected, acti
       setStatus(`Restart failed: ${err instanceof Error ? err.message : String(err)}`);
     }
   };
+  const handleFitScreen = () => {
+    if (!onFitScreen) return;
+    haptic.impact("light");
+    onFitScreen();
+    setModal(null);
+    setStatus("Fit screen requested");
+  };
   const handleSendToChat = async () => {
     if (!viewingFile) return;
     setStatus("Sharing...");
@@ -718,12 +725,7 @@ export function ActionBar({ onReconnect, onFitScreen, fitResult, connected, acti
           onClose={() => setModal(null)}
           onReconnect={() => { onReconnect(); setModal(null); }}
           onRestart={() => void handleRestartSession()}
-          onFitScreen={onFitScreen ? () => {
-            haptic.impact("light");
-            onFitScreen();
-            setModal(null);
-            setStatus("Fit screen requested");
-          } : undefined}
+          onFitScreen={onFitScreen ? handleFitScreen : undefined}
         />
       ) : null;
       break;
@@ -871,9 +873,9 @@ export function ActionBar({ onReconnect, onFitScreen, fitResult, connected, acti
 
           {/* Restricted terminal row: viewing a non-default session. The
               command palette targets the viewed session (Liam voice msg
-              1188); default-session-only actions — reconnect-menu's
-              Restart/Fit, git — are hidden so they can never act on the
-              wrong terminal. */}
+              1188). Restart and git stay hidden because they use default-
+              session command channels; Fit is allowed because it is scoped
+              to this view's own WebSocket/session. */}
           {activeTab === "terminal" && restrictedSession && <>
             {onReconnect && (
               <button
@@ -881,6 +883,14 @@ export function ActionBar({ onReconnect, onFitScreen, fitResult, connected, acti
                 style={{ ...btnStyle, background: "#1a3a2a", color: "var(--color-accent-green)", border: "1px solid #2d5a3d" }}
               >
                 Reconnect
+              </button>
+            )}
+            {onFitScreen && (
+              <button
+                onClick={handleFitScreen}
+                style={{ ...btnStyle, background: "#1a2a3a", color: "var(--color-accent-blue)", border: "1px solid #2d4a5a" }}
+              >
+                Fit Screen
               </button>
             )}
             <button

--- a/apps/web/src/lib/__tests__/app-routing.test.ts
+++ b/apps/web/src/lib/__tests__/app-routing.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildLandingUrl, resolveInitialAppState } from "../app-routing";
+import { buildLandingUrl, isCockpitRoute, resolveInitialAppState } from "../app-routing";
 
 describe("resolveInitialAppState", () => {
   it("resolves root to the default bot alias and a cosmetic redirect", () => {
@@ -72,6 +72,13 @@ describe("resolveInitialAppState", () => {
       file: null,
       redirectPath: null,
     });
+  });
+
+  it("recognizes #/cockpit as an app route without triggering the root redirect", () => {
+    expect(isCockpitRoute("#/cockpit")).toBe(true);
+    expect(isCockpitRoute("#/cockpit&source=links")).toBe(true);
+    expect(isCockpitRoute("#links")).toBe(false);
+    expect(resolveInitialAppState("/", "#/cockpit").redirectPath).toBeNull();
   });
 
   it("preserves terminal session deep-link resolution and validation", () => {

--- a/apps/web/src/lib/app-routing.ts
+++ b/apps/web/src/lib/app-routing.ts
@@ -75,7 +75,11 @@ function resolveHashState(hashParams: string): InitialAppState {
 
 function isAppDeepLink(hashParams: string): boolean {
   const firstSegment = hashParams.split("&", 1)[0];
-  return TABS.includes(firstSegment as AppTab) || DEEP_LINK_PARAM_RE.test(hashParams);
+  return firstSegment === "/cockpit" || TABS.includes(firstSegment as AppTab) || DEEP_LINK_PARAM_RE.test(hashParams);
+}
+
+export function isCockpitRoute(hash: string): boolean {
+  return hash.replace(/^#/, "").split("&", 1)[0] === "/cockpit";
 }
 
 /** Resolve the first-render route without reading from or mutating window. */

--- a/docs/guides/deploying.md
+++ b/docs/guides/deploying.md
@@ -49,6 +49,17 @@ curl https://cpc.claude.do/dev/api/health      # dev
 
 Both should return `{"status":"ok"}`.
 
+## Server Environment
+
+The server loads `~/.secrets/cpc.env` at startup. Fleet Cockpit embedding is
+disabled unless `COCKPIT_AUTH_TOKEN` is present; when disabled, the Links tab
+keeps opening the existing external Cockpit URL.
+
+| Variable | Required | Description |
+|---|---|---|
+| `COCKPIT_AUTH_TOKEN` | For in-app Cockpit | Must match the cockpit service's token. Never expose it to the web client. |
+| `COCKPIT_INTERNAL_URL` | No | Loopback Cockpit origin; defaults to `http://127.0.0.1:38847`. |
+
 ## URL Routing
 
 All traffic enters via Cloudflare tunnel → Caddy on `:18080` → reverse proxy.


### PR DESCRIPTION
Release: CPC v1.16.0. Sole scope = the cockpit hotfix Liam requested tonight (msg 1870).

- In-app Fleet Cockpit: same-origin authenticated proxy + `#/cockpit` route with BackButton — fixes the cockpit 401 and the external-Safari hop, closes the #315 stranding class.
- Gate: codex review REQUEST-CHANGES (1 HIGH token-exfiltration + 2 MED + 1 LOW) → fix round + residual round → delta-verified, final **APPROVE** at head b4b9773. Server 429/429, web 367/367, typechecks clean (Director-run, real runners).
- Deploy after tag: add `COCKPIT_AUTH_TOKEN` + `COCKPIT_INTERNAL_URL` to CPC prod server env, prod checkout → rebuild → restart unit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)