### PR TITLE
fix(cockpit-proxy): pin proxy target under the configured base path

### DIFF
--- a/apps/server/src/routes/__tests__/cockpit-proxy.test.ts
+++ b/apps/server/src/routes/__tests__/cockpit-proxy.test.ts
@@ -60,11 +60,11 @@ function makeInitData(): string {
   return params.toString();
 }
 
-function buildApp(): Hono {
+function buildApp(overrides: { internalUrl?: string } = {}): Hono {
   const app = new Hono();
   app.route("/api/cockpit-proxy", createCockpitProxyRoute({
     fetchImpl: fetchImpl as unknown as typeof fetch,
-    getConfig: () => config,
+    getConfig: () => ({ ...config, ...overrides }),
     now: () => Date.parse("2026-07-13T12:00:00Z"),
   }));
   return app;
@@ -183,6 +183,30 @@ describe("cockpit proxy", () => {
     expect(response.status).toBeGreaterThanOrEqual(400);
     expect(response.status).toBeLessThan(500);
     expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("rejects dot-segment traversal escaping a subpath internal URL", async () => {
+    const app = buildApp({ internalUrl: "http://127.0.0.1:38847/cockpit" });
+    const cookie = await proxyCookie(app);
+    fetchImpl.mockClear();
+
+    const response = await app.request("/api/cockpit-proxy/../admin/secrets", {
+      headers: { Cookie: cookie },
+    });
+
+    expect(response.status).toBeGreaterThanOrEqual(400);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("still proxies normally when the internal URL carries a subpath", async () => {
+    const app = buildApp({ internalUrl: "http://127.0.0.1:38847/cockpit" });
+    const cookie = await proxyCookie(app);
+    await app.request("/api/cockpit-proxy/api/fleet", {
+      headers: { Cookie: cookie },
+    });
+
+    const [target] = fetchImpl.mock.calls[0] as [URL];
+    expect(String(target)).toBe("http://127.0.0.1:38847/cockpit/api/fleet");
   });
 
   it("strips headers nominated by the incoming Connection header", async () => {

--- a/apps/server/src/routes/cockpit-proxy.ts
+++ b/apps/server/src/routes/cockpit-proxy.ts
@@ -104,6 +104,13 @@ function upstreamUrl(incoming: URL, internalUrl: string): URL {
   if (target.origin !== new URL(internalUrl).origin) {
     throw new Error("Cockpit proxy target origin mismatch");
   }
+  // When the internal URL carries a subpath, dot-segment traversal in the
+  // proxy path resolves within the same origin and passes the origin check —
+  // keep the resolved target pinned under the configured base path (gemini
+  // cloud review, release PR #324).
+  if (!target.pathname.startsWith(base.pathname)) {
+    throw new Error("Cockpit proxy target escaped the configured base path");
+  }
   target.search = incoming.search;
   return target;
 }


### PR DESCRIPTION
Cloud-review fix round for release PR #324 (gemini security-high): subpath `COCKPIT_INTERNAL_URL` configs were traversable via dot-segments within the same origin. Resolved target pathname is now asserted under the configured base path. Theoretical under our origin-only prod config, real hardening for subpath configs. +2 tests, server 431/431.

🤖 Generated with [Claude Code](https://claude.com/claude-code)