### PR TITLE
feat(terminal): Fit Screen on every terminal session view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this p
 - `#/cockpit` SPA route rendering the proxied cockpit in a same-origin iframe with
   Telegram BackButton wiring — closes the #315 login-stranding class. Links entry falls
   back to the external tab when the server proxy is unconfigured.
+- Fit Screen is available on every terminal session view and resizes only the session
+  carried by that view's validated WebSocket connection; Restart and git remain
+  default-session-only.
 
 ### Security
 

--- a/apps/server/src/routes/__tests__/terminal-ws-fit.test.ts
+++ b/apps/server/src/routes/__tests__/terminal-ws-fit.test.ts
@@ -9,7 +9,7 @@ import { createSession } from "../../auth.js";
  *   1. `validateFitDimensions` — bounds/type checks in isolation (no tmux
  *      involved), since this is the untrusted input surface (WebView).
  *   2. `onMessage` wiring — a valid `{ type: "fit", cols, rows }` message
- *      calls `tmux resize-window -t <session> -x <cols> -y <rows>` via
+ *      calls `tmux resize-window -t =<session>: -x <cols> -y <rows>` via
  *      `execFile` (argv array, no shell) and acks over the socket; an
  *      invalid message never reaches `execFile` and gets a `fit-error`
  *      reply instead; the legacy `resize` message type remains a no-op.
@@ -224,7 +224,7 @@ describe("terminalWsRoute onMessage: fit", () => {
 
     expect(execFileCalls[0].cmd).toBe("tmux");
     expect(execFileCalls[0].args).toEqual([
-      "resize-window", "-t", "test-session", "-x", "92", "-y", "40",
+      "resize-window", "-t", "=test-session:", "-x", "92", "-y", "40",
     ]);
 
     (ws as any)._cleanup?.();
@@ -241,7 +241,7 @@ describe("terminalWsRoute onMessage: fit", () => {
     expect(execFileCalls).toHaveLength(2);
     expect(execFileCalls[1].cmd).toBe("tmux");
     expect(execFileCalls[1].args).toEqual([
-      "set-option", "-t", "test-session", "window-size", "latest",
+      "set-option", "-t", "=test-session:", "window-size", "latest",
     ]);
 
     (ws as any)._cleanup?.();

--- a/apps/server/src/routes/__tests__/terminal-ws-session.test.ts
+++ b/apps/server/src/routes/__tests__/terminal-ws-session.test.ts
@@ -13,9 +13,9 @@ import { createSession } from "../../auth.js";
  *      exact-match `=<name>`; an unknown session closes 4004 after the
  *      probe; the default session starts polling with no probe (legacy
  *      restart-tolerance).
- *   3. onMessage "fit" — a view-only (non-default) session gets fit-error
- *      and `tmux resize-window` is NEVER reached; the default session
- *      keeps its existing fit behavior.
+ *   3. onMessage "fit" — the single sanctioned session-scoped write
+ *      resizes the viewed session; the default session keeps its existing
+ *      behavior. Every other WS write-shaped message remains inert.
  */
 
 const TEST_USER_ID = "999222";
@@ -272,8 +272,8 @@ describe("terminalWsRoute capture-pane poll: null (timeout) exit code is transie
   });
 });
 
-describe("terminalWsRoute onMessage: fit is default-session-only", () => {
-  it("rejects fit on a non-default session with fit-error and never reaches resize-window", async () => {
+describe("terminalWsRoute onMessage: fit targets the viewed session", () => {
+  it("applies fit to a non-default session with an exact-match target", async () => {
     existingSessions.add("do-box--lane-a");
     const { handlers, ws } = connectWs("do-box--lane-a");
     await flush();
@@ -282,10 +282,11 @@ describe("terminalWsRoute onMessage: fit is default-session-only", () => {
       ws as any,
     );
     await flush();
-    const fitError = ws._sent.map((m) => JSON.parse(m)).find((m) => m.type === "fit-error");
-    expect(fitError).toBeTruthy();
-    expect(fitError.message).toMatch(/view-only/i);
-    expect(execFileCalls.find((c) => c.args[0] === "resize-window")).toBeUndefined();
+    const resize = execFileCalls.find((c) => c.args[0] === "resize-window");
+    expect(resize?.args).toEqual(["resize-window", "-t", "=do-box--lane-a:", "-x", "100", "-y", "40"]);
+    const release = execFileCalls.find((c) => c.args[0] === "set-option");
+    expect(release?.args).toEqual(["set-option", "-t", "=do-box--lane-a:", "window-size", "latest"]);
+    expect(ws._sent.map((m) => JSON.parse(m)).some((m) => m.type === "fit-ack")).toBe(true);
     handlers.onClose(new Event("close"), ws as any);
   });
 
@@ -298,8 +299,39 @@ describe("terminalWsRoute onMessage: fit is default-session-only", () => {
     );
     await flush();
     const resize = execFileCalls.find((c) => c.args[0] === "resize-window");
-    expect(resize?.args).toEqual(["resize-window", "-t", "test-session", "-x", "100", "-y", "40"]);
+    expect(resize?.args).toEqual(["resize-window", "-t", "=test-session:", "-x", "100", "-y", "40"]);
     expect(ws._sent.map((m) => JSON.parse(m)).some((m) => m.type === "fit-ack")).toBe(true);
+    handlers.onClose(new Event("close"), ws as any);
+  });
+
+  it("still rejects malformed fit dimensions on a non-default session without a tmux write", async () => {
+    existingSessions.add("do-box--lane-a");
+    const { handlers, ws } = connectWs("do-box--lane-a");
+    await flush();
+    handlers.onMessage(
+      { data: JSON.stringify({ type: "fit", cols: 100, rows: "40" }) } as unknown as MessageEvent,
+      ws as any,
+    );
+    await flush();
+    expect(execFileCalls.some((c) => c.args[0] === "resize-window" || c.args[0] === "set-option")).toBe(false);
+    expect(ws._sent.map((m) => JSON.parse(m)).some((m) => m.type === "fit-error")).toBe(true);
+    handlers.onClose(new Event("close"), ws as any);
+  });
+
+  it("keeps every other WS write path inert for a non-default session", async () => {
+    existingSessions.add("do-box--lane-a");
+    const { handlers, ws } = connectWs("do-box--lane-a");
+    await flush();
+    handlers.onMessage(
+      { data: JSON.stringify({ type: "resize", cols: 100, rows: 40 }) } as unknown as MessageEvent,
+      ws as any,
+    );
+    handlers.onMessage(
+      { data: JSON.stringify({ type: "send-keys", keys: "C-c" }) } as unknown as MessageEvent,
+      ws as any,
+    );
+    await flush();
+    expect(execFileCalls.some((c) => c.args[0] === "resize-window" || c.args[0] === "set-option" || c.args[0] === "send-keys")).toBe(false);
     handlers.onClose(new Event("close"), ws as any);
   });
 });

--- a/apps/server/src/routes/terminal-ws.ts
+++ b/apps/server/src/routes/terminal-ws.ts
@@ -169,7 +169,7 @@ export class FitLatchReleaseError extends Error {
   }
 }
 
-export async function applyFitResize(cols: number, rows: number): Promise<void> {
+export async function applyFitResize(session: string, cols: number, rows: number): Promise<void> {
   // TMUX_TIMEOUT_MS on both calls (round-2 review, PR #299): every other
   // tmux invocation in this file is capped so a wedged tmux server fails
   // the request instead of hanging it forever; these two were the only
@@ -177,14 +177,14 @@ export async function applyFitResize(cols: number, rows: number): Promise<void> 
   // unbounded child process and never resolve for the caller.
   await execFileAsync("tmux", [
     "resize-window",
-    "-t", TMUX_SESSION,
+    "-t", `=${session}:`,
     "-x", String(cols),
     "-y", String(rows),
   ], { timeout: TMUX_TIMEOUT_MS });
   try {
     await execFileAsync("tmux", [
       "set-option",
-      "-t", TMUX_SESSION,
+      "-t", `=${session}:`,
       "window-size", "latest",
     ], { timeout: TMUX_TIMEOUT_MS });
   } catch (err) {
@@ -406,23 +406,12 @@ export function terminalWsRoute(c: any) {
       try {
         const msg = JSON.parse(event.data.toString());
         if (msg.type === "fit") {
-          // Fit resizes the REAL tmux window (a write). Only the default
-          // session — the one the REST write endpoints already target — may
-          // be resized; every client-picked session is view-only, so the
-          // multi-session feature adds zero new write surface. Checked
-          // before validation so applyFitResize (hardwired to TMUX_SESSION)
-          // can never be reached from a view-only connection.
-          if (sessionResolution.session !== TMUX_SESSION) {
-            console.log(`[ws] fit rejected: view-only session "${sessionResolution.session}"`);
-            ws.send(JSON.stringify({
-              type: "fit-error",
-              message: "This session is view-only — fit is only available on the default session",
-            }));
-            return;
-          }
           // Explicit, user-initiated "Fit screen" action only — the client
-          // never sends this automatically (see NOTE above). Validate
-          // before touching tmux.
+          // never sends this automatically (see NOTE above). Fit is the
+          // single sanctioned WS write for a client-picked session and is
+          // scoped to the session already charset-validated by
+          // resolveRequestedSession. Validate dimensions before touching
+          // tmux.
           const result = validateFitDimensions(msg);
           if (!result.ok) {
             console.log(`[ws] fit rejected: ${result.error}`);
@@ -435,9 +424,9 @@ export function terminalWsRoute(c: any) {
             return;
           }
           const { cols, rows } = result;
-          applyFitResize(cols, rows)
+          applyFitResize(sessionResolution.session, cols, rows)
             .then(() => {
-              console.log(`[ws] fit applied: ${cols}x${rows}`);
+              console.log(`[ws] fit applied to "${sessionResolution.session}": ${cols}x${rows}`);
               ws.send(JSON.stringify({ type: "fit-ack", cols, rows }));
             })
             .catch((err: Error) => {

--- a/apps/web/src/components/__tests__/ActionBar.test.tsx
+++ b/apps/web/src/components/__tests__/ActionBar.test.tsx
@@ -1256,13 +1256,24 @@ describe("ActionBar", () => {
 describe("ActionBar restricted session mode", () => {
   const SESSION = "do-box--lane-a";
 
-  it("shows Reconnect and /commands but hides Git and the reconnect menu", () => {
-    render(<ActionBar activeTab="terminal" onReconnect={() => {}} terminalSession={SESSION} />);
+  it("shows Reconnect, Fit Screen, and /commands but hides default-session controls", () => {
+    render(<ActionBar activeTab="terminal" onReconnect={() => {}} onFitScreen={() => {}} terminalSession={SESSION} />);
     expect(screen.getByText("Reconnect")).toBeInTheDocument();
+    expect(screen.getByText("Fit Screen")).toBeInTheDocument();
     expect(screen.getByText("/commands")).toBeInTheDocument();
     // Default-session-only actions must not be reachable.
     expect(screen.queryByText("Git")).not.toBeInTheDocument();
+    expect(screen.queryByText("Restart Claude Session")).not.toBeInTheDocument();
     expect(screen.queryByLabelText("Open reconnect menu")).not.toBeInTheDocument();
+  });
+
+  it("calls onFitScreen from the restricted session row", () => {
+    const onFitScreen = vi.fn();
+    render(<ActionBar activeTab="terminal" onReconnect={() => {}} onFitScreen={onFitScreen} terminalSession={SESSION} />);
+    fireEvent.click(screen.getByText("Fit Screen"));
+    expect(onFitScreen).toHaveBeenCalledOnce();
+    expect(screen.getByText("Fit screen requested")).toBeInTheDocument();
+    expect(screen.queryByText("Restart Claude Session")).not.toBeInTheDocument();
   });
 
   it("hides orchestrator-bookkeeping commands in the sheet and names the target", () => {

--- a/apps/web/src/components/action-bar/ActionBar.tsx
+++ b/apps/web/src/components/action-bar/ActionBar.tsx
@@ -544,6 +544,13 @@ export function ActionBar({ onReconnect, onFitScreen, fitResult, connected, acti
       setStatus(`Restart failed: ${err instanceof Error ? err.message : String(err)}`);
     }
   };
+  const handleFitScreen = () => {
+    if (!onFitScreen) return;
+    haptic.impact("light");
+    onFitScreen();
+    setModal(null);
+    setStatus("Fit screen requested");
+  };
   const handleSendToChat = async () => {
     if (!viewingFile) return;
     setStatus("Sharing...");
@@ -718,12 +725,7 @@ export function ActionBar({ onReconnect, onFitScreen, fitResult, connected, acti
           onClose={() => setModal(null)}
           onReconnect={() => { onReconnect(); setModal(null); }}
           onRestart={() => void handleRestartSession()}
-          onFitScreen={onFitScreen ? () => {
-            haptic.impact("light");
-            onFitScreen();
-            setModal(null);
-            setStatus("Fit screen requested");
-          } : undefined}
+          onFitScreen={onFitScreen ? handleFitScreen : undefined}
         />
       ) : null;
       break;
@@ -871,9 +873,9 @@ export function ActionBar({ onReconnect, onFitScreen, fitResult, connected, acti
 
           {/* Restricted terminal row: viewing a non-default session. The
               command palette targets the viewed session (Liam voice msg
-              1188); default-session-only actions — reconnect-menu's
-              Restart/Fit, git — are hidden so they can never act on the
-              wrong terminal. */}
+              1188). Restart and git stay hidden because they use default-
+              session command channels; Fit is allowed because it is scoped
+              to this view's own WebSocket/session. */}
           {activeTab === "terminal" && restrictedSession && <>
             {onReconnect && (
               <button
@@ -881,6 +883,14 @@ export function ActionBar({ onReconnect, onFitScreen, fitResult, connected, acti
                 style={{ ...btnStyle, background: "#1a3a2a", color: "var(--color-accent-green)", border: "1px solid #2d5a3d" }}
               >
                 Reconnect
+              </button>
+            )}
+            {onFitScreen && (
+              <button
+                onClick={handleFitScreen}
+                style={{ ...btnStyle, background: "#1a2a3a", color: "var(--color-accent-blue)", border: "1px solid #2d4a5a" }}
+              >
+                Fit Screen
               </button>
             )}
             <button


### PR DESCRIPTION
Rides release v1.16.0 (Liam msg 1880). Fit becomes the single sanctioned session-scoped write: server resizes the WS connection's validated session (exact-match `=name:` target), restricted action-bar row gains the Fit button, Restart/git stay default-session-only. New tests prove non-default fit targets the viewed session, malformed dims still rejected, and every other write shape stays inert for picked sessions. Server 433/433, web 368/368 (Director-run, real runners).

🤖 Generated with [Claude Code](https://claude.com/claude-code)