### PR TITLE
feat(web): vault explorer — read-only mobile viewer for link-check exports (second-brain PR-F)

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -12,10 +12,12 @@ import { DebugOverlay } from "./debug/DebugOverlay";
 import { PrTicker } from "./components/PrTicker";
 import { HomeScreenPrompt } from "./components/HomeScreenPrompt";
 import { CockpitPage } from "./components/CockpitPage";
+import { VaultExplorerPage } from "./components/VaultExplorerPage";
 import { SessionPicker, type TmuxSessionInfo } from "./components/SessionPicker";
 import {
   buildLandingUrl,
   isCockpitRoute,
+  isVaultRoute,
   resolveInitialAppState,
   type AppTab as Tab,
 } from "./lib/app-routing";
@@ -123,6 +125,7 @@ export function App() {
 
   const [activeTab, setActiveTab] = useState<Tab>(initialRoute.tab);
   const [cockpitOpen, setCockpitOpen] = useState(() => isCockpitRoute(window.location.hash));
+  const [vaultOpen, setVaultOpen] = useState(() => isVaultRoute(window.location.hash));
   const [reconnectKey, setReconnectKey] = useState(0);
 
   // Multi-session terminal (world-os#218): which tmux session the terminal
@@ -167,15 +170,24 @@ export function App() {
   const [showHomeScreenPrompt, setShowHomeScreenPrompt] = useState(false);
 
   useEffect(() => {
-    const syncCockpitRoute = () => setCockpitOpen(isCockpitRoute(window.location.hash));
-    window.addEventListener("hashchange", syncCockpitRoute);
-    return () => window.removeEventListener("hashchange", syncCockpitRoute);
+    const syncStandaloneRoutes = () => {
+      setCockpitOpen(isCockpitRoute(window.location.hash));
+      setVaultOpen(isVaultRoute(window.location.hash));
+    };
+    window.addEventListener("hashchange", syncStandaloneRoutes);
+    return () => window.removeEventListener("hashchange", syncStandaloneRoutes);
   }, []);
 
   const closeCockpit = useCallback(() => {
     setActiveTab("links");
     window.location.hash = "links";
     setCockpitOpen(false);
+  }, []);
+
+  const closeVault = useCallback(() => {
+    setActiveTab("links");
+    window.location.hash = "links";
+    setVaultOpen(false);
   }, []);
 
   const fileViewerSequence = fileOpenRequest.sequence;
@@ -452,6 +464,10 @@ export function App() {
 
   if (cockpitOpen) {
     return <CockpitPage onBack={closeCockpit} />;
+  }
+
+  if (vaultOpen) {
+    return <VaultExplorerPage onBack={closeVault} />;
   }
 
   return (

--- a/apps/web/src/components/Links.tsx
+++ b/apps/web/src/components/Links.tsx
@@ -5,7 +5,7 @@ import "./Links.css";
 
 interface LinkItem {
   title: string;
-  url: string;
+  url?: string;
   icon?: string;
   description?: string;
   /**
@@ -58,6 +58,12 @@ interface AppItem {
 }
 
 const LINKS: LinkItem[] = [
+  {
+    title: "Vault Explorer",
+    icon: "🗂️",
+    description: "Read-only second-brain structure + health",
+    internalRoute: "#/vault",
+  },
   {
     title: "Fleet Cockpit",
     url: "https://cockpit.claude.do",
@@ -162,11 +168,13 @@ export function Links({ onClose, onOpenFile }: LinksProps) {
       <div style={{ flex: 1, overflow: "auto" }}>
         <ReadingList onOpenFile={onOpenFile} />
         {LINKS.map((link) => {
-          const useInternalRoute = Boolean(link.internalRoute && cockpitProxyAvailable);
-          const href = useInternalRoute ? link.internalRoute! : link.url;
+          const useInternalRoute = Boolean(
+            link.internalRoute && (link.internalRoute === "#/vault" || cockpitProxyAvailable),
+          );
+          const href = useInternalRoute ? link.internalRoute! : (link.url ?? "#");
           return (
           <a
-            key={link.url}
+            key={link.internalRoute ?? link.url}
             href={href}
             // In-app links navigate the webview itself (see openInApp);
             // everything else keeps the external-tab behavior. rel stays on
@@ -183,7 +191,7 @@ export function Links({ onClose, onOpenFile }: LinksProps) {
               e.preventDefault();
               if (useInternalRoute) {
                 window.location.hash = link.internalRoute!.slice(1);
-              } else {
+              } else if (link.url) {
                 openInApp(link.url);
               }
             } : undefined}

--- a/apps/web/src/components/VaultExplorerPage.tsx
+++ b/apps/web/src/components/VaultExplorerPage.tsx
@@ -71,6 +71,7 @@ export function VaultExplorerPage({ onBack }: VaultExplorerPageProps) {
   const [loadError, setLoadError] = useState<string | null>(null);
   const [selection, setSelection] = useState<PageSelection>(() => pageSelection(SAMPLE_INDEX.pages[0]));
   const detailRef = useRef<HTMLDivElement>(null);
+  const fileReadSeq = useRef(0);
 
   useEffect(() => {
     const backButton = getTelegramWebApp()?.BackButton;
@@ -125,11 +126,16 @@ export function VaultExplorerPage({ onBack }: VaultExplorerPageProps) {
 
   const handleFile = async (file: File | undefined) => {
     if (!file) return;
+    // Sequence concurrent reads: only the most recent selection wins, so a
+    // slow first read can't clobber a newer one after it resolves.
+    const seq = ++fileReadSeq.current;
     try {
       const text = await file.text();
+      if (seq !== fileReadSeq.current) return;
       setPastedJson(text);
       loadValue(text);
     } catch {
+      if (seq !== fileReadSeq.current) return;
       setLoadError("The selected file could not be read.");
     }
   };

--- a/apps/web/src/components/VaultExplorerPage.tsx
+++ b/apps/web/src/components/VaultExplorerPage.tsx
@@ -1,0 +1,665 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import sampleExport from "../fixtures/vault-link-check.sample.json";
+import {
+  FINDING_CATEGORIES,
+  findPageByPath,
+  getBacklinks,
+  getOutgoingEdges,
+  groupVaultPages,
+  mapVaultFindings,
+  parseVaultIndex,
+  type FindingCategory,
+  type VaultEdge,
+  type VaultIndex,
+  type VaultPage,
+} from "../lib/vault-explorer";
+import { getTelegramWebApp } from "../lib/telegram";
+
+interface VaultExplorerPageProps {
+  onBack: () => void;
+}
+
+type ExplorerView = "browse" | "health";
+
+interface PageSelection {
+  path: string;
+  page: VaultPage | null;
+  line?: number;
+}
+
+const CATEGORY_LABELS: Record<FindingCategory, string> = {
+  broken: "Broken",
+  ambiguous: "Ambiguous",
+  orphan: "Orphan",
+  unreferenced_raw: "Unreferenced raw",
+  receipt: "Receipt",
+};
+
+const CATEGORY_COLORS: Record<FindingCategory, string> = {
+  broken: "var(--color-accent-red)",
+  ambiguous: "var(--color-accent-yellow)",
+  orphan: "var(--color-accent-purple)",
+  unreferenced_raw: "var(--color-accent-cyan)",
+  receipt: "var(--color-accent-orange)",
+};
+
+const sampleResult = parseVaultIndex(sampleExport);
+if (!sampleResult.ok) throw new Error(`Invalid bundled vault fixture: ${sampleResult.message}`);
+const SAMPLE_INDEX = sampleResult.data;
+
+function formatGeneratedAt(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+function pageSelection(page: VaultPage, line?: number): PageSelection {
+  return { path: page.path, page, ...(line === undefined ? {} : { line }) };
+}
+
+export function VaultExplorerPage({ onBack }: VaultExplorerPageProps) {
+  const [index, setIndex] = useState<VaultIndex>(SAMPLE_INDEX);
+  const [view, setView] = useState<ExplorerView>("browse");
+  const [loadOpen, setLoadOpen] = useState(false);
+  const [pastedJson, setPastedJson] = useState("");
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [selection, setSelection] = useState<PageSelection>(() => pageSelection(SAMPLE_INDEX.pages[0]));
+  const detailRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const backButton = getTelegramWebApp()?.BackButton;
+    backButton?.show();
+    backButton?.onClick(onBack);
+    return () => {
+      backButton?.offClick(onBack);
+      backButton?.hide();
+    };
+  }, [onBack]);
+
+  const groups = useMemo(() => groupVaultPages(index.pages), [index.pages]);
+  const mappedFindings = useMemo(() => mapVaultFindings(index), [index]);
+
+  const revealDetail = () => {
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => detailRef.current?.scrollIntoView({ behavior: "smooth", block: "start" }));
+    });
+  };
+
+  const selectPage = (page: VaultPage, line?: number) => {
+    setSelection(pageSelection(page, line));
+    revealDetail();
+  };
+
+  const selectReference = (path: string, line?: number) => {
+    const page = findPageByPath(index.pages, path);
+    setSelection({ path, page, ...(line === undefined ? {} : { line }) });
+    setView("browse");
+    revealDetail();
+  };
+
+  const loadValue = (value: string | unknown) => {
+    const result = parseVaultIndex(value);
+    if (!result.ok) {
+      setLoadError(result.message);
+      return false;
+    }
+    setIndex(result.data);
+    const firstPage = result.data.pages[0] ?? null;
+    setSelection(firstPage ? pageSelection(firstPage) : { path: "No page selected", page: null });
+    setLoadError(null);
+    setLoadOpen(false);
+    setView("browse");
+    return true;
+  };
+
+  const resetToSample = () => {
+    setPastedJson("");
+    loadValue(sampleExport);
+  };
+
+  const handleFile = async (file: File | undefined) => {
+    if (!file) return;
+    try {
+      const text = await file.text();
+      setPastedJson(text);
+      loadValue(text);
+    } catch {
+      setLoadError("The selected file could not be read.");
+    }
+  };
+
+  const statusColor = index.status === "clean" ? "var(--color-accent-green)" : "var(--color-accent-yellow)";
+
+  return (
+    <div
+      style={{
+        background: "var(--color-bg)",
+        color: "var(--color-fg)",
+        display: "flex",
+        flexDirection: "column",
+        height: "100%",
+        minHeight: 0,
+        width: "100%",
+      }}
+    >
+      <header
+        style={{
+          alignItems: "center",
+          borderBottom: "1px solid var(--color-border)",
+          display: "flex",
+          flexShrink: 0,
+          gap: 10,
+          minHeight: 48,
+          padding: "max(8px, env(safe-area-inset-top)) 12px 8px",
+        }}
+        onTouchStart={(event) => event.stopPropagation()}
+      >
+        <button onClick={onBack} aria-label="Back to Links" style={iconButtonStyle}>←</button>
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div style={{ fontSize: 15, fontWeight: 700, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+            Vault Explorer
+          </div>
+          <div style={{ color: "var(--color-muted)", fontSize: 11, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+            {index.vault}
+          </div>
+        </div>
+        <span style={{ color: "var(--color-muted)", fontSize: 10, letterSpacing: "0.08em", textTransform: "uppercase" }}>
+          Read only
+        </span>
+        <button
+          onClick={() => { setLoadError(null); setLoadOpen((open) => !open); }}
+          aria-expanded={loadOpen}
+          style={{ ...smallButtonStyle, color: "var(--color-accent-blue)" }}
+        >
+          Load
+        </button>
+      </header>
+
+      {loadOpen && (
+        <section style={{ background: "var(--color-bg-alt)", borderBottom: "1px solid var(--color-border)", padding: 12 }}>
+          <div style={{ color: "var(--color-fg-muted)", fontSize: 12, marginBottom: 10 }}>
+            Open a local <code style={codeStyle}>link-check --json</code> export. Nothing is uploaded or saved.
+          </div>
+          <div style={{ display: "flex", flexWrap: "wrap", gap: 8, marginBottom: 10 }}>
+            <label style={{ ...smallButtonStyle, alignItems: "center", display: "inline-flex" }}>
+              Choose JSON
+              <input
+                type="file"
+                accept="application/json,.json"
+                onChange={(event) => {
+                  void handleFile(event.currentTarget.files?.[0]);
+                  event.currentTarget.value = "";
+                }}
+                style={{ display: "none" }}
+              />
+            </label>
+            <button onClick={resetToSample} style={smallButtonStyle}>Reset sample</button>
+          </div>
+          <textarea
+            value={pastedJson}
+            onChange={(event) => setPastedJson(event.target.value)}
+            placeholder="Paste a version 1 link-check JSON export…"
+            aria-label="Pasted link-check JSON"
+            spellCheck={false}
+            style={{
+              background: "var(--color-surface)",
+              border: "1px solid var(--color-border-alt)",
+              borderRadius: 8,
+              color: "var(--color-fg)",
+              display: "block",
+              fontFamily: "var(--font-mono)",
+              fontSize: 11,
+              minHeight: 112,
+              padding: 10,
+              resize: "vertical",
+              width: "100%",
+            }}
+          />
+          {loadError && (
+            <div role="alert" style={{ color: "var(--color-accent-red)", fontSize: 12, marginTop: 8 }}>
+              {loadError}
+            </div>
+          )}
+          <button
+            onClick={() => loadValue(pastedJson)}
+            disabled={!pastedJson.trim()}
+            style={{
+              ...primaryButtonStyle,
+              marginTop: 10,
+              opacity: pastedJson.trim() ? 1 : 0.45,
+            }}
+          >
+            View pasted export
+          </button>
+        </section>
+      )}
+
+      <div style={{ borderBottom: "1px solid var(--color-border)", flexShrink: 0, padding: "10px 12px" }}>
+        <div style={{ alignItems: "center", display: "flex", gap: 8 }}>
+          <div style={{ background: "var(--color-surface)", borderRadius: 8, display: "flex", padding: 2 }}>
+            {(["browse", "health"] as const).map((item) => (
+              <button
+                key={item}
+                onClick={() => setView(item)}
+                style={{
+                  background: view === item ? "var(--color-border-alt)" : "transparent",
+                  border: 0,
+                  borderRadius: 6,
+                  color: view === item ? "var(--color-fg)" : "var(--color-muted)",
+                  fontSize: 12,
+                  fontWeight: view === item ? 700 : 500,
+                  minHeight: 32,
+                  padding: "6px 14px",
+                  textTransform: "capitalize",
+                }}
+              >
+                {item}
+              </button>
+            ))}
+          </div>
+          <span style={{ color: statusColor, fontSize: 11, fontWeight: 700, marginLeft: "auto", textTransform: "uppercase" }}>
+            {index.status}
+          </span>
+        </div>
+        <div style={{ color: "var(--color-muted)", fontSize: 10, marginTop: 6 }}>
+          {index.pages.length} pages · {index.edges.length} links · generated {formatGeneratedAt(index.generated_at)}
+        </div>
+      </div>
+
+      <main style={{ flex: 1, minHeight: 0, overflowY: "auto", padding: "12px 12px max(20px, env(safe-area-inset-bottom))" }}>
+        {view === "browse" ? (
+          <div
+            style={{
+              display: "grid",
+              gap: 12,
+              gridTemplateColumns: "repeat(auto-fit, minmax(min(100%, 340px), 1fr))",
+              margin: "0 auto",
+              maxWidth: 920,
+            }}
+          >
+            <section aria-label="Vault layers" style={panelStyle}>
+              <SectionTitle title="Layers" detail={`${index.pages.length} pages`} />
+              <LayerSection label="Index" pages={groups.index} selection={selection} onSelect={selectPage} defaultOpen />
+              <LayerSection label="Raw" pages={groups.raw} selection={selection} onSelect={selectPage} />
+              <details open style={detailsStyle}>
+                <summary style={summaryStyle}>
+                  <span>Wiki</span>
+                  <span style={countStyle}>
+                    {groups.wiki.concepts.length + groups.wiki.entities.length + groups.wiki.summaries.length + groups.wiki.other.length}
+                  </span>
+                </summary>
+                <div style={{ borderLeft: "1px solid var(--color-border)", marginLeft: 10, paddingLeft: 8 }}>
+                  <LayerSection label="Concepts" pages={groups.wiki.concepts} selection={selection} onSelect={selectPage} nested />
+                  <LayerSection label="Entities" pages={groups.wiki.entities} selection={selection} onSelect={selectPage} nested />
+                  <LayerSection label="Summaries" pages={groups.wiki.summaries} selection={selection} onSelect={selectPage} nested />
+                  {groups.wiki.other.length > 0 && (
+                    <LayerSection label="Other wiki" pages={groups.wiki.other} selection={selection} onSelect={selectPage} nested />
+                  )}
+                </div>
+              </details>
+              <LayerSection label="Doctrine" pages={groups.doctrine} selection={selection} onSelect={selectPage} />
+              <LayerSection label="Armory" pages={groups.armory} selection={selection} onSelect={selectPage} />
+              {groups.other.length > 0 && (
+                <LayerSection label="Other" pages={groups.other} selection={selection} onSelect={selectPage} />
+              )}
+            </section>
+
+            <PageDetail
+              detailRef={detailRef}
+              index={index}
+              selection={selection}
+              onSelect={selectPage}
+            />
+          </div>
+        ) : (
+          <HealthPanel
+            index={index}
+            mappedFindings={mappedFindings}
+            onSelectReference={selectReference}
+          />
+        )}
+      </main>
+    </div>
+  );
+}
+
+function LayerSection({
+  label,
+  pages,
+  selection,
+  onSelect,
+  defaultOpen = false,
+  nested = false,
+}: {
+  label: string;
+  pages: VaultPage[];
+  selection: PageSelection;
+  onSelect: (page: VaultPage) => void;
+  defaultOpen?: boolean;
+  nested?: boolean;
+}) {
+  return (
+    <details open={defaultOpen || nested} style={detailsStyle}>
+      <summary style={{ ...summaryStyle, fontSize: nested ? 11 : 12 }}>
+        <span>{label}</span>
+        <span style={countStyle}>{pages.length}</span>
+      </summary>
+      {pages.length === 0 ? (
+        <div style={{ color: "var(--color-muted)", fontSize: 11, padding: "5px 8px 8px" }}>No pages</div>
+      ) : (
+        <div style={{ display: "grid", gap: 4, padding: "4px 0 8px" }}>
+          {pages.map((page) => {
+            const selected = selection.page?.path === page.path;
+            return (
+              <button
+                key={page.path}
+                onClick={() => onSelect(page)}
+                style={{
+                  background: selected ? "rgba(122, 162, 247, 0.14)" : "transparent",
+                  border: selected ? "1px solid rgba(122, 162, 247, 0.45)" : "1px solid transparent",
+                  borderRadius: 7,
+                  color: "var(--color-fg)",
+                  minHeight: 42,
+                  padding: "7px 9px",
+                  textAlign: "left",
+                  width: "100%",
+                }}
+              >
+                <span style={{ display: "block", fontSize: 12, fontWeight: 600 }}>{page.title}</span>
+                <span style={{ color: "var(--color-muted)", display: "block", fontFamily: "var(--font-mono)", fontSize: 9, marginTop: 2, overflowWrap: "anywhere" }}>
+                  {page.path}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </details>
+  );
+}
+
+function PageDetail({
+  detailRef,
+  index,
+  selection,
+  onSelect,
+}: {
+  detailRef: React.RefObject<HTMLDivElement | null>;
+  index: VaultIndex;
+  selection: PageSelection;
+  onSelect: (page: VaultPage, line?: number) => void;
+}) {
+  const page = selection.page;
+  const outgoing = page ? getOutgoingEdges(page, index.edges) : [];
+  const backlinks = page ? getBacklinks(page, index.edges) : [];
+
+  return (
+    <section ref={detailRef} aria-label="Page details" style={{ ...panelStyle, scrollMarginTop: 12 }}>
+      <SectionTitle title="Page" detail={selection.line ? `line ${selection.line}` : undefined} />
+      {page ? (
+        <>
+          <div style={{ padding: "4px 0 14px" }}>
+            <div style={{ fontSize: 17, fontWeight: 700 }}>{page.title}</div>
+            <div style={{ color: "var(--color-accent-blue)", fontFamily: "var(--font-mono)", fontSize: 10, marginTop: 5, overflowWrap: "anywhere" }}>
+              {page.path}{selection.line ? `:${selection.line}` : ""}
+            </div>
+            <span style={{ ...pillStyle, marginTop: 8 }}>{page.kind}</span>
+          </div>
+          <EdgeList
+            title="Outgoing"
+            empty="No outgoing links"
+            edges={outgoing}
+            index={index}
+            direction="outgoing"
+            onSelect={onSelect}
+          />
+          <EdgeList
+            title="Backlinks"
+            empty="No pages link here"
+            edges={backlinks}
+            index={index}
+            direction="backlink"
+            onSelect={onSelect}
+          />
+        </>
+      ) : (
+        <div style={{ color: "var(--color-fg-muted)", fontSize: 12, padding: "8px 0" }}>
+          <div style={{ color: "var(--color-accent-yellow)", fontWeight: 700 }}>Page is not present in this export.</div>
+          <div style={{ fontFamily: "var(--font-mono)", marginTop: 8, overflowWrap: "anywhere" }}>
+            {selection.path}{selection.line ? `:${selection.line}` : ""}
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}
+
+function EdgeList({
+  title,
+  empty,
+  edges,
+  index,
+  direction,
+  onSelect,
+}: {
+  title: string;
+  empty: string;
+  edges: VaultEdge[];
+  index: VaultIndex;
+  direction: "outgoing" | "backlink";
+  onSelect: (page: VaultPage, line?: number) => void;
+}) {
+  return (
+    <div style={{ borderTop: "1px solid var(--color-border)", padding: "12px 0" }}>
+      <div style={{ color: "var(--color-fg-muted)", fontSize: 11, fontWeight: 700, letterSpacing: "0.06em", marginBottom: 7, textTransform: "uppercase" }}>
+        {title} <span style={{ color: "var(--color-muted)" }}>{edges.length}</span>
+      </div>
+      {edges.length === 0 ? (
+        <div style={{ color: "var(--color-muted)", fontSize: 11 }}>{empty}</div>
+      ) : (
+        <div style={{ display: "grid", gap: 6 }}>
+          {edges.map((edge, indexInList) => {
+            const linkedPath = direction === "outgoing" ? edge.target : edge.source;
+            const linkedPage = findPageByPath(index.pages, linkedPath);
+            const canNavigate = linkedPage !== null && (direction === "backlink" || edge.resolved);
+            return (
+              <button
+                key={`${edge.source}:${edge.line}:${edge.target}:${indexInList}`}
+                onClick={() => {
+                  if (canNavigate && linkedPage) onSelect(linkedPage, direction === "backlink" ? edge.line : undefined);
+                }}
+                disabled={!canNavigate}
+                style={{
+                  background: "var(--color-bg-alt)",
+                  border: "1px solid var(--color-border)",
+                  borderRadius: 7,
+                  color: "var(--color-fg)",
+                  cursor: canNavigate ? "pointer" : "default",
+                  minHeight: 44,
+                  opacity: canNavigate ? 1 : 0.85,
+                  padding: "8px 9px",
+                  textAlign: "left",
+                }}
+              >
+                <span style={{ alignItems: "center", display: "flex", gap: 6 }}>
+                  <span style={{ color: edge.resolved ? "var(--color-accent-green)" : "var(--color-accent-red)", fontSize: 10 }}>
+                    {edge.resolved ? "●" : "●"}
+                  </span>
+                  <span style={{ flex: 1, fontSize: 11, fontWeight: 600, overflowWrap: "anywhere" }}>
+                    {edge.label || linkedPage?.title || linkedPath}
+                  </span>
+                  <span style={{ color: "var(--color-muted)", fontSize: 9 }}>line {edge.line}</span>
+                </span>
+                <span style={{ color: "var(--color-muted)", display: "block", fontFamily: "var(--font-mono)", fontSize: 9, marginLeft: 16, marginTop: 3, overflowWrap: "anywhere" }}>
+                  {linkedPath}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function HealthPanel({
+  index,
+  mappedFindings,
+  onSelectReference,
+}: {
+  index: VaultIndex;
+  mappedFindings: ReturnType<typeof mapVaultFindings>;
+  onSelectReference: (path: string, line?: number) => void;
+}) {
+  return (
+    <section aria-label="Vault health" style={{ ...panelStyle, margin: "0 auto", maxWidth: 720 }}>
+      <SectionTitle title="Vault health" detail={index.status} />
+      <div style={{ display: "grid", gap: 7, gridTemplateColumns: "repeat(5, minmax(54px, 1fr))", margin: "6px 0 14px", overflowX: "auto" }}>
+        {FINDING_CATEGORIES.map((category) => (
+          <div key={category} style={{ background: "var(--color-bg-alt)", border: "1px solid var(--color-border)", borderRadius: 8, minWidth: 54, padding: "9px 5px", textAlign: "center" }}>
+            <div style={{ color: CATEGORY_COLORS[category], fontSize: 18, fontWeight: 800 }}>{index.counts[category]}</div>
+            <div style={{ color: "var(--color-muted)", fontSize: 8, lineHeight: 1.2, marginTop: 3 }}>{CATEGORY_LABELS[category]}</div>
+          </div>
+        ))}
+      </div>
+
+      {FINDING_CATEGORIES.map((category) => (
+        <details key={category} open={index.counts[category] > 0} style={detailsStyle}>
+          <summary style={summaryStyle}>
+            <span style={{ color: CATEGORY_COLORS[category] }}>{CATEGORY_LABELS[category]}</span>
+            <span style={countStyle}>{index.counts[category]}</span>
+          </summary>
+          {mappedFindings[category].length === 0 ? (
+            <div style={{ color: "var(--color-muted)", fontSize: 11, padding: "6px 8px 10px" }}>No findings</div>
+          ) : (
+            <div style={{ display: "grid", gap: 6, padding: "5px 0 10px" }}>
+              {mappedFindings[category].map(({ finding, page }, findingIndex) => (
+                <button
+                  key={`${finding.path}:${finding.line ?? ""}:${findingIndex}`}
+                  onClick={() => onSelectReference(finding.path, finding.line)}
+                  style={{
+                    background: "var(--color-bg-alt)",
+                    border: "1px solid var(--color-border)",
+                    borderRadius: 7,
+                    color: "var(--color-fg)",
+                    minHeight: 48,
+                    padding: "8px 9px",
+                    textAlign: "left",
+                    width: "100%",
+                  }}
+                >
+                  <span style={{ display: "block", fontSize: 11, fontWeight: 600 }}>{finding.reason}</span>
+                  <span style={{ color: page ? "var(--color-accent-blue)" : "var(--color-accent-yellow)", display: "block", fontFamily: "var(--font-mono)", fontSize: 9, marginTop: 4, overflowWrap: "anywhere" }}>
+                    {finding.path}{finding.line ? `:${finding.line}` : ""}
+                  </span>
+                </button>
+              ))}
+            </div>
+          )}
+        </details>
+      ))}
+    </section>
+  );
+}
+
+function SectionTitle({ title, detail }: { title: string; detail?: string }) {
+  return (
+    <div style={{ alignItems: "center", display: "flex", marginBottom: 8 }}>
+      <h2 style={{ fontSize: 13, margin: 0 }}>{title}</h2>
+      {detail && <span style={{ color: "var(--color-muted)", fontSize: 10, marginLeft: "auto" }}>{detail}</span>}
+    </div>
+  );
+}
+
+const panelStyle: React.CSSProperties = {
+  background: "var(--color-surface)",
+  border: "1px solid var(--color-border)",
+  borderRadius: 10,
+  minWidth: 0,
+  padding: 12,
+};
+
+const detailsStyle: React.CSSProperties = {
+  borderTop: "1px solid var(--color-border)",
+};
+
+const summaryStyle: React.CSSProperties = {
+  alignItems: "center",
+  color: "var(--color-fg-muted)",
+  cursor: "pointer",
+  display: "flex",
+  fontSize: 12,
+  fontWeight: 650,
+  justifyContent: "space-between",
+  minHeight: 38,
+  padding: "6px 4px",
+};
+
+const countStyle: React.CSSProperties = {
+  background: "var(--color-bg-alt)",
+  borderRadius: 999,
+  color: "var(--color-muted)",
+  fontSize: 9,
+  minWidth: 22,
+  padding: "2px 6px",
+  textAlign: "center",
+};
+
+const iconButtonStyle: React.CSSProperties = {
+  background: "var(--color-surface)",
+  border: "1px solid var(--color-border)",
+  borderRadius: 8,
+  color: "var(--color-fg)",
+  fontSize: 18,
+  height: 34,
+  width: 34,
+};
+
+const smallButtonStyle: React.CSSProperties = {
+  background: "var(--color-surface)",
+  border: "1px solid var(--color-border-alt)",
+  borderRadius: 7,
+  color: "var(--color-fg-muted)",
+  cursor: "pointer",
+  fontSize: 11,
+  minHeight: 34,
+  padding: "7px 10px",
+};
+
+const primaryButtonStyle: React.CSSProperties = {
+  background: "var(--color-accent-blue)",
+  border: 0,
+  borderRadius: 7,
+  color: "var(--color-bg)",
+  cursor: "pointer",
+  fontSize: 12,
+  fontWeight: 700,
+  minHeight: 38,
+  padding: "8px 12px",
+};
+
+const codeStyle: React.CSSProperties = {
+  background: "var(--color-surface)",
+  borderRadius: 4,
+  color: "var(--color-accent-cyan)",
+  fontFamily: "var(--font-mono)",
+  padding: "1px 4px",
+};
+
+const pillStyle: React.CSSProperties = {
+  background: "var(--color-bg-alt)",
+  border: "1px solid var(--color-border)",
+  borderRadius: 999,
+  color: "var(--color-fg-muted)",
+  display: "inline-block",
+  fontSize: 9,
+  letterSpacing: "0.06em",
+  padding: "3px 7px",
+  textTransform: "uppercase",
+};

--- a/apps/web/src/components/VaultExplorerPage.tsx
+++ b/apps/web/src/components/VaultExplorerPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import sampleExport from "../fixtures/vault-link-check.sample.json";
 import {
   FINDING_CATEGORIES,
+  MAX_INPUT_BYTES,
   findPageByPath,
   getBacklinks,
   getOutgoingEdges,
@@ -105,6 +106,10 @@ export function VaultExplorerPage({ onBack }: VaultExplorerPageProps) {
   };
 
   const loadValue = (value: string | unknown) => {
+    // Any load (reset, paste, or a completed file read) advances the read
+    // guard, so a still-in-flight file read from an earlier selection sees
+    // the bump and bails instead of clobbering this newer value.
+    fileReadSeq.current++;
     const result = parseVaultIndex(value);
     if (!result.ok) {
       setLoadError(result.message);
@@ -126,8 +131,14 @@ export function VaultExplorerPage({ onBack }: VaultExplorerPageProps) {
 
   const handleFile = async (file: File | undefined) => {
     if (!file) return;
+    // Reject an oversized file before reading it into memory at all.
+    if (file.size > MAX_INPUT_BYTES) {
+      setLoadError(`That file is too large to load (over ${Math.floor(MAX_INPUT_BYTES / 1024 / 1024)} MB).`);
+      return;
+    }
     // Sequence concurrent reads: only the most recent selection wins, so a
-    // slow first read can't clobber a newer one after it resolves.
+    // slow read can't clobber a newer selection, reset, or paste (all of
+    // which advance fileReadSeq via loadValue).
     const seq = ++fileReadSeq.current;
     try {
       const text = await file.text();

--- a/apps/web/src/components/__tests__/Links.test.tsx
+++ b/apps/web/src/components/__tests__/Links.test.tsx
@@ -48,3 +48,17 @@ describe("Fleet Cockpit link", () => {
     expect(link).toHaveAttribute("target", "_blank");
   });
 });
+
+describe("Vault Explorer link", () => {
+  it("always uses the local vault route without waiting for server configuration", () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("offline")));
+    render(<Links onClose={vi.fn()} onOpenFile={vi.fn()} />);
+
+    const link = screen.getByRole("link", { name: /Vault Explorer/ });
+    expect(link).toHaveAttribute("href", "#/vault");
+    expect(link).not.toHaveAttribute("target");
+
+    fireEvent.click(link);
+    expect(window.location.hash).toBe("#/vault");
+  });
+});

--- a/apps/web/src/fixtures/vault-link-check.sample.json
+++ b/apps/web/src/fixtures/vault-link-check.sample.json
@@ -1,0 +1,48 @@
+{
+  "index_schema_version": 1,
+  "pages": [
+    { "path": "index.md", "kind": "index", "title": "Second Brain" },
+    { "path": "raw/inbox-voice-note.md", "kind": "raw", "title": "Inbox voice note" },
+    { "path": "wiki/concepts/agency.md", "kind": "concept", "title": "Agency" },
+    { "path": "wiki/concepts/attention.md", "kind": "concept", "title": "Attention" },
+    { "path": "wiki/entities/claude.md", "kind": "entity", "title": "Claude" },
+    { "path": "wiki/summaries/weekly-review.md", "kind": "summary", "title": "Weekly review" },
+    { "path": "doctrine/write-it-down.md", "kind": "doctrine", "title": "Write it down" },
+    { "path": "armory/vault-ingest.md", "kind": "raw", "title": "vault-ingest" }
+  ],
+  "edges": [
+    { "source": "index.md", "target": "wiki/concepts/agency", "label": "Agency", "resolved": true, "line": 8 },
+    { "source": "index.md", "target": "wiki/summaries/weekly-review", "label": "Latest review", "resolved": true, "line": 12 },
+    { "source": "wiki/concepts/agency.md", "target": "doctrine/write-it-down", "label": null, "resolved": true, "line": 16 },
+    { "source": "wiki/concepts/agency.md", "target": "wiki/concepts/unknown", "label": "Unknown concept", "resolved": false, "line": 21 },
+    { "source": "wiki/summaries/weekly-review.md", "target": "wiki/concepts/agency", "label": null, "resolved": true, "line": 6 },
+    { "source": "armory/vault-ingest.md", "target": "wiki/entities/claude", "label": "Claude", "resolved": true, "line": 10 }
+  ],
+  "findings": {
+    "broken": [
+      { "category": "broken", "path": "wiki/concepts/agency.md", "reason": "Target wiki/concepts/unknown does not exist", "line": 21 }
+    ],
+    "ambiguous": [
+      { "category": "ambiguous", "path": "index.md", "reason": "Agency could refer to more than one title", "line": 8 }
+    ],
+    "orphan": [
+      { "category": "orphan", "path": "wiki/concepts/attention.md", "reason": "No incoming links" }
+    ],
+    "unreferenced_raw": [
+      { "category": "unreferenced_raw", "path": "raw/inbox-voice-note.md", "reason": "Raw note is not referenced by an indexed page" }
+    ],
+    "receipt": [
+      { "category": "receipt", "path": "wiki/summaries/weekly-review.md", "reason": "Summary has no receipt link", "line": 18 }
+    ]
+  },
+  "counts": {
+    "broken": 1,
+    "ambiguous": 1,
+    "orphan": 1,
+    "unreferenced_raw": 1,
+    "receipt": 1
+  },
+  "status": "findings",
+  "generated_at": "2026-07-14T14:30:00Z",
+  "vault": "second-brain-sample"
+}

--- a/apps/web/src/lib/__tests__/app-routing.test.ts
+++ b/apps/web/src/lib/__tests__/app-routing.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildLandingUrl, isCockpitRoute, resolveInitialAppState } from "../app-routing";
+import { buildLandingUrl, isCockpitRoute, isVaultRoute, resolveInitialAppState } from "../app-routing";
 
 describe("resolveInitialAppState", () => {
   it("resolves root to the default bot alias and a cosmetic redirect", () => {
@@ -79,6 +79,13 @@ describe("resolveInitialAppState", () => {
     expect(isCockpitRoute("#/cockpit&source=links")).toBe(true);
     expect(isCockpitRoute("#links")).toBe(false);
     expect(resolveInitialAppState("/", "#/cockpit").redirectPath).toBeNull();
+  });
+
+  it("recognizes #/vault as an app route without triggering the root redirect", () => {
+    expect(isVaultRoute("#/vault")).toBe(true);
+    expect(isVaultRoute("#/vault&source=links")).toBe(true);
+    expect(isVaultRoute("#links")).toBe(false);
+    expect(resolveInitialAppState("/", "#/vault").redirectPath).toBeNull();
   });
 
   it("preserves terminal session deep-link resolution and validation", () => {

--- a/apps/web/src/lib/__tests__/vault-explorer.test.ts
+++ b/apps/web/src/lib/__tests__/vault-explorer.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  buildPageIndex,
   getBacklinks,
   getOutgoingEdges,
   groupVaultPages,
@@ -124,5 +125,36 @@ describe("vault view model", () => {
     expect(mapped.orphan[0].page).toBeNull();
     expect(mapped.unreferenced_raw[0].finding.category).toBe("unreferenced_raw");
     expect(mapped.receipt[0]).toMatchObject({ page: { path: "wiki/concepts/agency.md" } });
+  });
+});
+
+describe("hardening", () => {
+  it("rejects oversized arrays instead of freezing", () => {
+    const pages = Array.from({ length: 20001 }, (_, i) => ({ path: `raw/${i}.md`, kind: "raw", title: `p${i}` }));
+    expect(parseVaultIndex(fixture({ pages }))).toMatchObject({ ok: false, code: "invalid-contract" });
+  });
+
+  it("derives counts and status from findings, ignoring self-reported values", () => {
+    const result = parseVaultIndex(fixture({
+      // export lies: claims clean/zero while a finding is present
+      status: "clean",
+      counts: { broken: 0, ambiguous: 0, orphan: 0, unreferenced_raw: 0, receipt: 0 },
+      findings: {
+        broken: [{ category: "broken", path: "index.md", reason: "x", line: 2 }],
+        ambiguous: [], orphan: [], unreferenced_raw: [], receipt: [],
+      },
+    }));
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data.status).toBe("findings");
+      expect(result.data.counts.broken).toBe(1);
+    }
+  });
+
+  it("buildPageIndex gives O(1) lookups matching findPageByPath", () => {
+    const idx = parsedIndex(fixture());
+    const map = buildPageIndex(idx.pages);
+    expect(map.get("wiki/concepts/agency")?.path).toBe("wiki/concepts/agency.md");
+    expect(map.get("index")?.path).toBe("index.md");
   });
 });

--- a/apps/web/src/lib/__tests__/vault-explorer.test.ts
+++ b/apps/web/src/lib/__tests__/vault-explorer.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+import {
+  getBacklinks,
+  getOutgoingEdges,
+  groupVaultPages,
+  mapVaultFindings,
+  parseVaultIndex,
+  type VaultIndex,
+} from "../vault-explorer";
+
+function fixture(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    index_schema_version: 1,
+    pages: [
+      { path: "index.md", kind: "index", title: "Home" },
+      { path: "wiki/concepts/agency.md", kind: "concept", title: "Agency" },
+    ],
+    edges: [
+      { source: "index.md", target: "wiki/concepts/agency", label: "Agency", resolved: true, line: 4 },
+    ],
+    findings: {
+      broken: [],
+      ambiguous: [],
+      orphan: [],
+      unreferenced_raw: [],
+      receipt: [],
+    },
+    counts: { broken: 0, ambiguous: 0, orphan: 0, unreferenced_raw: 0, receipt: 0 },
+    status: "clean",
+    generated_at: "2026-07-14T12:00:00Z",
+    vault: "sample-vault",
+    ...overrides,
+  };
+}
+
+function parsedIndex(value: Record<string, unknown>): VaultIndex {
+  const result = parseVaultIndex(value);
+  if (!result.ok) throw new Error(result.message);
+  return result.data;
+}
+
+describe("parseVaultIndex", () => {
+  it("accepts a version 1 link-check export", () => {
+    const result = parseVaultIndex(JSON.stringify(fixture()));
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.data.vault).toBe("sample-vault");
+  });
+
+  it("rejects unsupported schema versions with a compatibility message", () => {
+    const result = parseVaultIndex(fixture({ index_schema_version: 2 }));
+    expect(result).toMatchObject({
+      ok: false,
+      code: "unsupported-version",
+      message: "Unsupported index schema version 2. This viewer supports version 1.",
+    });
+  });
+
+  it("distinguishes malformed JSON from an invalid contract", () => {
+    expect(parseVaultIndex("{")).toMatchObject({ ok: false, code: "invalid-json" });
+    expect(parseVaultIndex(fixture({ pages: "not-an-array" }))).toMatchObject({
+      ok: false,
+      code: "invalid-contract",
+    });
+  });
+});
+
+describe("vault view model", () => {
+  it("groups top-level layers and nested wiki folders", () => {
+    const index = parsedIndex(fixture({
+      pages: [
+        { path: "index.md", kind: "index", title: "Home" },
+        { path: "raw/inbox.md", kind: "raw", title: "Inbox" },
+        { path: "wiki/concepts/c.md", kind: "concept", title: "Concept" },
+        { path: "wiki/entities/e.md", kind: "entity", title: "Entity" },
+        { path: "wiki/summaries/s.md", kind: "summary", title: "Summary" },
+        { path: "doctrine/rule.md", kind: "doctrine", title: "Rule" },
+        { path: "armory/tool.md", kind: "raw", title: "Tool" },
+        { path: "notes/misc.md", kind: "raw", title: "Misc" },
+      ],
+    }));
+
+    const groups = groupVaultPages(index.pages);
+    expect(groups.index.map((page) => page.path)).toEqual(["index.md"]);
+    expect(groups.raw.map((page) => page.path)).toEqual(["raw/inbox.md"]);
+    expect(groups.wiki.concepts).toHaveLength(1);
+    expect(groups.wiki.entities).toHaveLength(1);
+    expect(groups.wiki.summaries).toHaveLength(1);
+    expect(groups.doctrine).toHaveLength(1);
+    expect(groups.armory).toHaveLength(1);
+    expect(groups.other.map((page) => page.path)).toEqual(["notes/misc.md"]);
+  });
+
+  it("derives outgoing edges and backlinks across .md and extensionless paths", () => {
+    const index = parsedIndex(fixture());
+    const [home, agency] = index.pages;
+    expect(getOutgoingEdges(home, index.edges)).toHaveLength(1);
+    expect(getBacklinks(agency, index.edges)).toEqual(index.edges);
+    expect(getBacklinks(home, index.edges)).toHaveLength(0);
+  });
+
+  it("maps all finding categories to pages and preserves optional lines", () => {
+    const finding = (category: string, path: string, line?: number) => ({
+      category,
+      path,
+      reason: `${category} reason`,
+      ...(line ? { line } : {}),
+    });
+    const findings = {
+      broken: [finding("broken", "index.md", 8)],
+      ambiguous: [finding("ambiguous", "wiki/concepts/agency")],
+      orphan: [finding("orphan", "missing.md", 3)],
+      unreferenced_raw: [finding("unreferenced_raw", "index.md")],
+      receipt: [finding("receipt", "wiki/concepts/agency.md", 12)],
+    };
+    const index = parsedIndex(fixture({
+      findings,
+      counts: { broken: 1, ambiguous: 1, orphan: 1, unreferenced_raw: 1, receipt: 1 },
+      status: "findings",
+    }));
+
+    const mapped = mapVaultFindings(index);
+    expect(mapped.broken[0]).toMatchObject({ page: { path: "index.md" }, finding: { line: 8 } });
+    expect(mapped.ambiguous[0].page?.path).toBe("wiki/concepts/agency.md");
+    expect(mapped.orphan[0].page).toBeNull();
+    expect(mapped.unreferenced_raw[0].finding.category).toBe("unreferenced_raw");
+    expect(mapped.receipt[0]).toMatchObject({ page: { path: "wiki/concepts/agency.md" } });
+  });
+});

--- a/apps/web/src/lib/__tests__/vault-explorer.test.ts
+++ b/apps/web/src/lib/__tests__/vault-explorer.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  MAX_INPUT_BYTES,
   buildPageIndex,
   getBacklinks,
   getOutgoingEdges,
@@ -156,5 +157,18 @@ describe("hardening", () => {
     const map = buildPageIndex(idx.pages);
     expect(map.get("wiki/concepts/agency")?.path).toBe("wiki/concepts/agency.md");
     expect(map.get("index")?.path).toBe("index.md");
+  });
+});
+
+describe("raw input size cap (PR #329 swarm MUST-1)", () => {
+  it("rejects an oversized raw string before JSON.parse runs", () => {
+    const huge = " ".repeat(MAX_INPUT_BYTES + 1);
+    const result = parseVaultIndex(huge);
+    expect(result).toMatchObject({ ok: false, code: "invalid-contract" });
+    if (!result.ok) expect(result.message).toMatch(/too large/i);
+  });
+
+  it("still parses a normal-size export", () => {
+    expect(parseVaultIndex(JSON.stringify(fixture())).ok).toBe(true);
   });
 });

--- a/apps/web/src/lib/app-routing.ts
+++ b/apps/web/src/lib/app-routing.ts
@@ -75,11 +75,15 @@ function resolveHashState(hashParams: string): InitialAppState {
 
 function isAppDeepLink(hashParams: string): boolean {
   const firstSegment = hashParams.split("&", 1)[0];
-  return firstSegment === "/cockpit" || TABS.includes(firstSegment as AppTab) || DEEP_LINK_PARAM_RE.test(hashParams);
+  return firstSegment === "/cockpit" || firstSegment === "/vault" || TABS.includes(firstSegment as AppTab) || DEEP_LINK_PARAM_RE.test(hashParams);
 }
 
 export function isCockpitRoute(hash: string): boolean {
   return hash.replace(/^#/, "").split("&", 1)[0] === "/cockpit";
+}
+
+export function isVaultRoute(hash: string): boolean {
+  return hash.replace(/^#/, "").split("&", 1)[0] === "/vault";
 }
 
 /** Resolve the first-render route without reading from or mutating window. */

--- a/apps/web/src/lib/vault-explorer.ts
+++ b/apps/web/src/lib/vault-explorer.ts
@@ -1,0 +1,296 @@
+export const VAULT_SCHEMA_VERSION = 1 as const;
+
+export const PAGE_KINDS = [
+  "index",
+  "raw",
+  "summary",
+  "entity",
+  "concept",
+  "doctrine",
+] as const;
+
+export const FINDING_CATEGORIES = [
+  "broken",
+  "ambiguous",
+  "orphan",
+  "unreferenced_raw",
+  "receipt",
+] as const;
+
+export type VaultPageKind = (typeof PAGE_KINDS)[number];
+export type FindingCategory = (typeof FINDING_CATEGORIES)[number];
+
+export interface VaultPage {
+  path: string;
+  kind: VaultPageKind;
+  title: string;
+}
+
+export interface VaultEdge {
+  source: string;
+  target: string;
+  label: string | null;
+  resolved: boolean;
+  line: number;
+}
+
+export interface VaultFinding {
+  category: string;
+  path: string;
+  reason: string;
+  line?: number;
+}
+
+export type VaultFindings = Record<FindingCategory, VaultFinding[]>;
+export type VaultCounts = Record<FindingCategory, number>;
+
+export interface VaultIndex {
+  index_schema_version: typeof VAULT_SCHEMA_VERSION;
+  pages: VaultPage[];
+  edges: VaultEdge[];
+  findings: VaultFindings;
+  counts: VaultCounts;
+  status: "clean" | "findings";
+  generated_at: string;
+  vault: string;
+}
+
+export type VaultParseResult =
+  | { ok: true; data: VaultIndex }
+  | {
+      ok: false;
+      code: "invalid-json" | "unsupported-version" | "invalid-contract";
+      message: string;
+    };
+
+export interface VaultPageGroups {
+  index: VaultPage[];
+  raw: VaultPage[];
+  wiki: {
+    concepts: VaultPage[];
+    entities: VaultPage[];
+    summaries: VaultPage[];
+    other: VaultPage[];
+  };
+  doctrine: VaultPage[];
+  armory: VaultPage[];
+  other: VaultPage[];
+}
+
+export interface MappedFinding {
+  finding: VaultFinding;
+  page: VaultPage | null;
+}
+
+export type MappedFindings = Record<FindingCategory, MappedFinding[]>;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isLineNumber(value: unknown): value is number {
+  return Number.isInteger(value) && (value as number) > 0;
+}
+
+function invalid(message: string): VaultParseResult {
+  return { ok: false, code: "invalid-contract", message };
+}
+
+function parsePage(value: unknown, index: number): VaultPage | string {
+  if (!isRecord(value)) return `pages[${index}] must be an object.`;
+  if (typeof value.path !== "string") return `pages[${index}].path must be a string.`;
+  if (!PAGE_KINDS.includes(value.kind as VaultPageKind)) {
+    return `pages[${index}].kind is not supported.`;
+  }
+  if (typeof value.title !== "string") return `pages[${index}].title must be a string.`;
+  return { path: value.path, kind: value.kind as VaultPageKind, title: value.title };
+}
+
+function parseEdge(value: unknown, index: number): VaultEdge | string {
+  if (!isRecord(value)) return `edges[${index}] must be an object.`;
+  if (typeof value.source !== "string") return `edges[${index}].source must be a string.`;
+  if (typeof value.target !== "string") return `edges[${index}].target must be a string.`;
+  if (value.label !== null && typeof value.label !== "string") {
+    return `edges[${index}].label must be a string or null.`;
+  }
+  if (typeof value.resolved !== "boolean") return `edges[${index}].resolved must be a boolean.`;
+  if (!isLineNumber(value.line)) return `edges[${index}].line must be a positive integer.`;
+  return {
+    source: value.source,
+    target: value.target,
+    label: value.label as string | null,
+    resolved: value.resolved,
+    line: value.line,
+  };
+}
+
+function parseFinding(value: unknown, location: string): VaultFinding | string {
+  if (!isRecord(value)) return `${location} must be an object.`;
+  if (typeof value.category !== "string") return `${location}.category must be a string.`;
+  if (typeof value.path !== "string") return `${location}.path must be a string.`;
+  if (typeof value.reason !== "string") return `${location}.reason must be a string.`;
+  if (value.line !== undefined && !isLineNumber(value.line)) {
+    return `${location}.line must be a positive integer when present.`;
+  }
+  return {
+    category: value.category,
+    path: value.path,
+    reason: value.reason,
+    ...(value.line === undefined ? {} : { line: value.line }),
+  };
+}
+
+export function parseVaultIndex(input: string | unknown): VaultParseResult {
+  let value = input;
+  if (typeof input === "string") {
+    try {
+      value = JSON.parse(input) as unknown;
+    } catch {
+      return { ok: false, code: "invalid-json", message: "This is not valid JSON." };
+    }
+  }
+
+  if (!isRecord(value)) return invalid("The link-check export must be a JSON object.");
+  if (!("index_schema_version" in value)) {
+    return invalid("The export is missing index_schema_version.");
+  }
+  if (value.index_schema_version !== VAULT_SCHEMA_VERSION) {
+    return {
+      ok: false,
+      code: "unsupported-version",
+      message: `Unsupported index schema version ${String(value.index_schema_version)}. This viewer supports version 1.`,
+    };
+  }
+
+  if (!Array.isArray(value.pages)) return invalid("pages must be an array.");
+  const pages: VaultPage[] = [];
+  for (const [index, pageValue] of value.pages.entries()) {
+    const page = parsePage(pageValue, index);
+    if (typeof page === "string") return invalid(page);
+    pages.push(page);
+  }
+
+  if (!Array.isArray(value.edges)) return invalid("edges must be an array.");
+  const edges: VaultEdge[] = [];
+  for (const [index, edgeValue] of value.edges.entries()) {
+    const edge = parseEdge(edgeValue, index);
+    if (typeof edge === "string") return invalid(edge);
+    edges.push(edge);
+  }
+
+  if (!isRecord(value.findings)) return invalid("findings must be an object.");
+  if (!isRecord(value.counts)) return invalid("counts must be an object.");
+
+  const findings = {} as VaultFindings;
+  const counts = {} as VaultCounts;
+  for (const category of FINDING_CATEGORIES) {
+    const categoryFindings = value.findings[category];
+    if (!Array.isArray(categoryFindings)) return invalid(`findings.${category} must be an array.`);
+    const parsedFindings: VaultFinding[] = [];
+    for (const [index, findingValue] of categoryFindings.entries()) {
+      const finding = parseFinding(findingValue, `findings.${category}[${index}]`);
+      if (typeof finding === "string") return invalid(finding);
+      parsedFindings.push(finding);
+    }
+    findings[category] = parsedFindings;
+
+    const count = value.counts[category];
+    if (!Number.isInteger(count) || (count as number) < 0) {
+      return invalid(`counts.${category} must be a non-negative integer.`);
+    }
+    counts[category] = count as number;
+  }
+
+  if (value.status !== "clean" && value.status !== "findings") {
+    return invalid('status must be either "clean" or "findings".');
+  }
+  if (typeof value.generated_at !== "string") return invalid("generated_at must be a string.");
+  if (typeof value.vault !== "string") return invalid("vault must be a string.");
+
+  return {
+    ok: true,
+    data: {
+      index_schema_version: VAULT_SCHEMA_VERSION,
+      pages,
+      edges,
+      findings,
+      counts,
+      status: value.status,
+      generated_at: value.generated_at,
+      vault: value.vault,
+    },
+  };
+}
+
+export function canonicalVaultPath(path: string): string {
+  return path.trim().replace(/^\.\//, "").replace(/^\//, "").replace(/\.md$/, "");
+}
+
+export function findPageByPath(pages: VaultPage[], path: string): VaultPage | null {
+  const wanted = canonicalVaultPath(path);
+  return pages.find((page) => canonicalVaultPath(page.path) === wanted) ?? null;
+}
+
+function sorted(pages: VaultPage[]): VaultPage[] {
+  return [...pages].sort((a, b) => a.path.localeCompare(b.path));
+}
+
+export function groupVaultPages(pages: VaultPage[]): VaultPageGroups {
+  const groups: VaultPageGroups = {
+    index: [],
+    raw: [],
+    wiki: { concepts: [], entities: [], summaries: [], other: [] },
+    doctrine: [],
+    armory: [],
+    other: [],
+  };
+
+  for (const page of pages) {
+    const path = canonicalVaultPath(page.path);
+    const segments = path.split("/");
+    const top = segments[0];
+    const second = segments[1];
+
+    if (path === "index" || top === "index") groups.index.push(page);
+    else if (top === "raw") groups.raw.push(page);
+    else if (top === "wiki" && second === "concepts") groups.wiki.concepts.push(page);
+    else if (top === "wiki" && second === "entities") groups.wiki.entities.push(page);
+    else if (top === "wiki" && second === "summaries") groups.wiki.summaries.push(page);
+    else if (top === "wiki") groups.wiki.other.push(page);
+    else if (top === "doctrine") groups.doctrine.push(page);
+    else if (top === "armory") groups.armory.push(page);
+    else groups.other.push(page);
+  }
+
+  groups.index = sorted(groups.index);
+  groups.raw = sorted(groups.raw);
+  groups.wiki.concepts = sorted(groups.wiki.concepts);
+  groups.wiki.entities = sorted(groups.wiki.entities);
+  groups.wiki.summaries = sorted(groups.wiki.summaries);
+  groups.wiki.other = sorted(groups.wiki.other);
+  groups.doctrine = sorted(groups.doctrine);
+  groups.armory = sorted(groups.armory);
+  groups.other = sorted(groups.other);
+  return groups;
+}
+
+export function getOutgoingEdges(page: VaultPage, edges: VaultEdge[]): VaultEdge[] {
+  const source = canonicalVaultPath(page.path);
+  return edges.filter((edge) => canonicalVaultPath(edge.source) === source);
+}
+
+export function getBacklinks(page: VaultPage, edges: VaultEdge[]): VaultEdge[] {
+  const target = canonicalVaultPath(page.path);
+  return edges.filter((edge) => canonicalVaultPath(edge.target) === target);
+}
+
+export function mapVaultFindings(index: VaultIndex): MappedFindings {
+  const mapped = {} as MappedFindings;
+  for (const category of FINDING_CATEGORIES) {
+    mapped[category] = index.findings[category].map((finding) => ({
+      finding,
+      page: findPageByPath(index.pages, finding.path),
+    }));
+  }
+  return mapped;
+}

--- a/apps/web/src/lib/vault-explorer.ts
+++ b/apps/web/src/lib/vault-explorer.ts
@@ -1,5 +1,11 @@
 export const VAULT_SCHEMA_VERSION = 1 as const;
 
+// Bound an uploaded/pasted export so a large or malicious link-check blob
+// can't freeze the Telegram WebView during parse/render.
+export const MAX_PAGES = 20000;
+export const MAX_EDGES = 100000;
+export const MAX_FINDINGS_PER_CATEGORY = 50000;
+
 export const PAGE_KINDS = [
   "index",
   "raw",
@@ -163,6 +169,7 @@ export function parseVaultIndex(input: string | unknown): VaultParseResult {
   }
 
   if (!Array.isArray(value.pages)) return invalid("pages must be an array.");
+  if (value.pages.length > MAX_PAGES) return invalid(`Too many pages (max ${MAX_PAGES}).`);
   const pages: VaultPage[] = [];
   for (const [index, pageValue] of value.pages.entries()) {
     const page = parsePage(pageValue, index);
@@ -171,6 +178,7 @@ export function parseVaultIndex(input: string | unknown): VaultParseResult {
   }
 
   if (!Array.isArray(value.edges)) return invalid("edges must be an array.");
+  if (value.edges.length > MAX_EDGES) return invalid(`Too many edges (max ${MAX_EDGES}).`);
   const edges: VaultEdge[] = [];
   for (const [index, edgeValue] of value.edges.entries()) {
     const edge = parseEdge(edgeValue, index);
@@ -183,9 +191,13 @@ export function parseVaultIndex(input: string | unknown): VaultParseResult {
 
   const findings = {} as VaultFindings;
   const counts = {} as VaultCounts;
+  let anyFindings = false;
   for (const category of FINDING_CATEGORIES) {
     const categoryFindings = value.findings[category];
     if (!Array.isArray(categoryFindings)) return invalid(`findings.${category} must be an array.`);
+    if (categoryFindings.length > MAX_FINDINGS_PER_CATEGORY) {
+      return invalid(`Too many ${category} findings (max ${MAX_FINDINGS_PER_CATEGORY}).`);
+    }
     const parsedFindings: VaultFinding[] = [];
     for (const [index, findingValue] of categoryFindings.entries()) {
       const finding = parseFinding(findingValue, `findings.${category}[${index}]`);
@@ -193,12 +205,11 @@ export function parseVaultIndex(input: string | unknown): VaultParseResult {
       parsedFindings.push(finding);
     }
     findings[category] = parsedFindings;
-
-    const count = value.counts[category];
-    if (!Number.isInteger(count) || (count as number) < 0) {
-      return invalid(`counts.${category} must be a non-negative integer.`);
-    }
-    counts[category] = count as number;
+    // Derive counts/status from the actual findings arrays rather than
+    // trusting the export's self-reported values, so the display can never
+    // claim "clean"/zero while findings are present.
+    counts[category] = parsedFindings.length;
+    if (parsedFindings.length > 0) anyFindings = true;
   }
 
   if (value.status !== "clean" && value.status !== "findings") {
@@ -215,7 +226,8 @@ export function parseVaultIndex(input: string | unknown): VaultParseResult {
       edges,
       findings,
       counts,
-      status: value.status,
+      // Derived from the findings arrays, not the export's claim.
+      status: anyFindings ? "findings" : "clean",
       generated_at: value.generated_at,
       vault: value.vault,
     },
@@ -229,6 +241,16 @@ export function canonicalVaultPath(path: string): string {
 export function findPageByPath(pages: VaultPage[], path: string): VaultPage | null {
   const wanted = canonicalVaultPath(path);
   return pages.find((page) => canonicalVaultPath(page.path) === wanted) ?? null;
+}
+
+/** Canonical-path → page index for O(1) lookups over many findings/edges. */
+export function buildPageIndex(pages: VaultPage[]): Map<string, VaultPage> {
+  const index = new Map<string, VaultPage>();
+  for (const page of pages) {
+    const key = canonicalVaultPath(page.path);
+    if (!index.has(key)) index.set(key, page);
+  }
+  return index;
 }
 
 function sorted(pages: VaultPage[]): VaultPage[] {
@@ -285,11 +307,14 @@ export function getBacklinks(page: VaultPage, edges: VaultEdge[]): VaultEdge[] {
 }
 
 export function mapVaultFindings(index: VaultIndex): MappedFindings {
+  // Build the path index once instead of a linear scan per finding
+  // (was ~O(pages × findings), a WebView-freeze risk on large exports).
+  const pageIndex = buildPageIndex(index.pages);
   const mapped = {} as MappedFindings;
   for (const category of FINDING_CATEGORIES) {
     mapped[category] = index.findings[category].map((finding) => ({
       finding,
-      page: findPageByPath(index.pages, finding.path),
+      page: pageIndex.get(canonicalVaultPath(finding.path)) ?? null,
     }));
   }
   return mapped;

--- a/apps/web/src/lib/vault-explorer.ts
+++ b/apps/web/src/lib/vault-explorer.ts
@@ -2,6 +2,9 @@ export const VAULT_SCHEMA_VERSION = 1 as const;
 
 // Bound an uploaded/pasted export so a large or malicious link-check blob
 // can't freeze the Telegram WebView during parse/render.
+// MAX_INPUT_BYTES caps the RAW payload before JSON.parse even runs — the
+// per-array caps below only apply after a (potentially huge) parse.
+export const MAX_INPUT_BYTES = 16 * 1024 * 1024;
 export const MAX_PAGES = 20000;
 export const MAX_EDGES = 100000;
 export const MAX_FINDINGS_PER_CATEGORY = 50000;
@@ -149,6 +152,15 @@ function parseFinding(value: unknown, location: string): VaultFinding | string {
 export function parseVaultIndex(input: string | unknown): VaultParseResult {
   let value = input;
   if (typeof input === "string") {
+    // Cap the raw text before JSON.parse — an oversized blob would freeze
+    // the WebView at parse time, before any array-count check could apply.
+    if (input.length > MAX_INPUT_BYTES) {
+      return {
+        ok: false,
+        code: "invalid-contract",
+        message: `Export is too large to load (over ${Math.floor(MAX_INPUT_BYTES / 1024 / 1024)} MB).`,
+      };
+    }
     try {
       value = JSON.parse(input) as unknown;
     } catch {


### PR DESCRIPTION
Part of the second-brain v1 stack (do-box/second-brain lane, thread 781). This is the **CPC-side** slice — the world-os package slices are PRs #487/#493/#496/#497/#499.

## What
A **frontend-only** mobile vault explorer reachable at `#/vault` (and from **Links → Vault Explorer**). It renders a second-brain vault's structure from a `vault-ingest link-check --json` export (`index_schema_version: 1`). It never touches a real vault, filesystem, or server — it consumes the JSON contract only.

- **`lib/vault-explorer.ts`** — strict parser with discriminated results (valid v1 / invalid-json / unsupported-version / invalid-contract), layer grouping, `.md`/extensionless edge canonicalization, outgoing-edge + backlink derivation, and findings→page mapping. Renders only documented fields.
- **`VaultExplorerPage.tsx`** — mobile-first (Tokyo Night tokens): inline load panel (upload / paste / reset-to-sample, clear error messages), Browse/Health switch, collapsible layer browser (with wiki subgroups), page detail (outgoing links resolved/broken + backlinks), and a health panel over the five counts with tappable findings.
- **`#/vault` route** wired outside the swipe strip with Telegram BackButton; a bundled sample fixture loads on first render with **no network request**.
- Read-only: no editing, no server calls, no persistence of uploaded data.

## Scope
Explorer page + model/parse module + route/entry + one Links entry + vitest coverage + one sample fixture. No server or unrelated app changes.

## PM verification
`apps/web`: `typecheck` clean, **376 tests pass**, production `build` succeeds. (The chunk-size warning is pre-existing to the app, not from this change.)

## Consumes
The link-check JSON contract emitted by world-os `packages/second-brain` (PR #493). Treats `index_schema_version` as the compat gate.

## Review
Local review to follow. Merge is Liam-only per doctrine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)