### PR TITLE
fix(web): markdown download uses Telegram's native downloader (WORLD-375)

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback, useRef, useMemo } from "react";
 import { FiDownload } from "react-icons/fi";
-import { getAuthHeaders } from "../lib/telegram";
+import { getAuthHeaders, requestTelegramDownload } from "../lib/telegram";
 import { MarkdownViewer } from "./MarkdownViewer";
 import { BottomSheet } from "./BottomSheet";
 import { getFileIcon } from "./file-icons";
@@ -239,10 +239,20 @@ export function FileViewer({ onClose, initialFile, showHidden = false, sortMode 
         throw new Error("Download failed: missing ticket");
       }
 
-      // Use a hidden <a> element with download attribute to trigger the
-      // browser's native download. This works in Telegram WebView where
-      // window.open("about:blank") is blocked as a popup.
-      const url = `/api/files/download?ticket=${encodeURIComponent(data.ticket)}`;
+      // Absolute URL: Telegram's downloader runs outside this document and
+      // rejects anything that isn't a fully-qualified https URL.
+      const url = new URL(
+        `/api/files/download?ticket=${encodeURIComponent(data.ticket)}`,
+        window.location.href,
+      ).href;
+
+      // Prefer Telegram's native downloader. In its WebView an <a download>
+      // only navigates, and the WebView paints the bytes inline as uncopyable
+      // text rather than saving a file (WORLD-375).
+      if (requestTelegramDownload(url, fileName)) return;
+
+      // Fallback for desktop/browser, where <a download> does save the file.
+      // Preferred over window.open("about:blank"), which is popup-blocked.
       const anchor = document.createElement("a");
       anchor.href = url;
       anchor.download = fileName;

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -248,10 +248,12 @@ export function FileViewer({ onClose, initialFile, showHidden = false, sortMode 
 
       // Prefer Telegram's native downloader. In its WebView an <a download>
       // only navigates, and the WebView paints the bytes inline as uncopyable
-      // text rather than saving a file (WORLD-375).
-      if (requestTelegramDownload(url, fileName)) return;
+      // text rather than saving a file (WORLD-375). "busy" means Telegram
+      // already has a download popup open from a previous tap, so it owns the
+      // flow too — falling through would reproduce that bug on a double-tap.
+      if (requestTelegramDownload(url, fileName) !== "unsupported") return;
 
-      // Fallback for desktop/browser, where <a download> does save the file.
+      // Fallback for real browsers, where <a download> does save the file.
       // Preferred over window.open("about:blank"), which is popup-blocked.
       const anchor = document.createElement("a");
       anchor.href = url;

--- a/apps/web/src/components/__tests__/FileViewer.test.tsx
+++ b/apps/web/src/components/__tests__/FileViewer.test.tsx
@@ -3,8 +3,13 @@ import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 
 // --- Mocks (must be declared before importing FileViewer) ---
 
+const { requestTelegramDownloadMock } = vi.hoisted(() => ({
+  requestTelegramDownloadMock: vi.fn(),
+}));
+
 vi.mock("../../lib/telegram", () => ({
   getAuthHeaders: () => ({ Authorization: "tma test" }),
+  requestTelegramDownload: requestTelegramDownloadMock,
 }));
 
 // Minimal stub for MarkdownViewer (heavy dependency tree)
@@ -286,5 +291,103 @@ describe("middleTruncatePath", () => {
     const path = `/${"a".repeat(58)}/`;
     expect(path).toHaveLength(60);
     expect(middleTruncatePath(path)).toBe(path);
+  });
+});
+
+describe("FileViewer download (WORLD-375)", () => {
+  const TICKET = "a".repeat(32);
+
+  // restoreAllMocks() does not clear a vi.fn(), so call counts would leak
+  // between these tests.
+  beforeEach(() => {
+    requestTelegramDownloadMock.mockReset();
+  });
+
+  /** Open README.md and mock the ticket endpoint, leaving the viewer on-screen. */
+  async function openFileWithDownloadReady() {
+    render(<FileViewer onClose={vi.fn()} />);
+    await waitFor(() => {
+      expect(screen.getByText("README.md")).toBeInTheDocument();
+    });
+
+    fetchMock.mockImplementation(async (url: string) => {
+      if (typeof url === "string" && url.includes("/api/files/download-ticket")) {
+        return { ok: true, json: async () => ({ ticket: TICKET }) };
+      }
+      if (typeof url === "string" && url.includes("/api/files/read")) {
+        return {
+          ok: true,
+          json: async () => ({
+            content: "# Hello World",
+            path: "/home/claude/claudes-world/README.md",
+            name: "README.md",
+          }),
+        };
+      }
+      if (typeof url === "string" && url.includes("/api/terminal/dir-branch")) {
+        return makeDirBranchResponse();
+      }
+      return { ok: false, status: 404, json: async () => ({}) };
+    });
+
+    fireEvent.click(screen.getByText("README.md"));
+    await waitFor(() => {
+      expect(screen.getByLabelText("Download file")).toBeInTheDocument();
+    });
+  }
+
+  it("offers Telegram an absolute URL carrying the ticket, and stops there", async () => {
+    requestTelegramDownloadMock.mockReturnValue(true);
+    const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {});
+    await openFileWithDownloadReady();
+
+    fireEvent.click(screen.getByLabelText("Download file"));
+
+    await waitFor(() => {
+      expect(requestTelegramDownloadMock).toHaveBeenCalledTimes(1);
+    });
+    const [url, name] = requestTelegramDownloadMock.mock.calls[0];
+    // Absolute, not "/api/..." — Telegram's downloader runs outside this document.
+    expect(url).toMatch(new RegExp(`^https?://[^/]+/api/files/download\\?ticket=${TICKET}$`));
+    expect(name).toBe("README.md");
+    // Telegram took it, so the anchor fallback must not also fire.
+    expect(clickSpy).not.toHaveBeenCalled();
+  });
+
+  it("falls back to an anchor download when Telegram declines", async () => {
+    requestTelegramDownloadMock.mockReturnValue(false);
+    const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {});
+    await openFileWithDownloadReady();
+
+    fireEvent.click(screen.getByLabelText("Download file"));
+
+    await waitFor(() => {
+      expect(clickSpy).toHaveBeenCalledTimes(1);
+    });
+    const anchor = clickSpy.mock.instances[0] as HTMLAnchorElement;
+    expect(anchor.download).toBe("README.md");
+    expect(anchor.href).toContain(`/api/files/download?ticket=${TICKET}`);
+  });
+
+  it("surfaces an error and never downloads when the ticket is refused", async () => {
+    requestTelegramDownloadMock.mockReturnValue(true);
+    await openFileWithDownloadReady();
+
+    fetchMock.mockImplementation(async (url: string) => {
+      if (typeof url === "string" && url.includes("/api/files/download-ticket")) {
+        return { ok: false, status: 403, json: async () => ({ error: "path not allowed" }) };
+      }
+      if (typeof url === "string" && url.includes("/api/terminal/dir-branch")) {
+        return makeDirBranchResponse();
+      }
+      return { ok: false, status: 404, json: async () => ({}) };
+    });
+
+    fireEvent.click(screen.getByLabelText("Download file"));
+
+    await waitFor(() => {
+      expect(screen.getByText("path not allowed")).toBeInTheDocument();
+    });
+    expect(requestTelegramDownloadMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/components/__tests__/FileViewer.test.tsx
+++ b/apps/web/src/components/__tests__/FileViewer.test.tsx
@@ -337,7 +337,7 @@ describe("FileViewer download (WORLD-375)", () => {
   }
 
   it("offers Telegram an absolute URL carrying the ticket, and stops there", async () => {
-    requestTelegramDownloadMock.mockReturnValue(true);
+    requestTelegramDownloadMock.mockReturnValue("handed-off");
     const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {});
     await openFileWithDownloadReady();
 
@@ -354,8 +354,8 @@ describe("FileViewer download (WORLD-375)", () => {
     expect(clickSpy).not.toHaveBeenCalled();
   });
 
-  it("falls back to an anchor download when Telegram declines", async () => {
-    requestTelegramDownloadMock.mockReturnValue(false);
+  it("falls back to an anchor download only when Telegram is unsupported", async () => {
+    requestTelegramDownloadMock.mockReturnValue("unsupported");
     const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {});
     await openFileWithDownloadReady();
 
@@ -369,8 +369,27 @@ describe("FileViewer download (WORLD-375)", () => {
     expect(anchor.href).toContain(`/api/files/download?ticket=${TICKET}`);
   });
 
+  it("does NOT fall back to the anchor when Telegram is busy (double-tap)", async () => {
+    // Regression guard for the codex #331 finding: a second tap while
+    // Telegram's own confirm popup is open makes downloadFile throw. Treating
+    // that as "no Telegram" would run the anchor path inside the WebView and
+    // paint the bytes inline as text — the exact bug WORLD-375 fixes.
+    requestTelegramDownloadMock.mockReturnValue("busy");
+    const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {});
+    await openFileWithDownloadReady();
+
+    fireEvent.click(screen.getByLabelText("Download file"));
+
+    await waitFor(() => {
+      expect(requestTelegramDownloadMock).toHaveBeenCalledTimes(1);
+    });
+    expect(clickSpy).not.toHaveBeenCalled();
+    // Telegram already has a dialog up; this is not an error state.
+    expect(screen.queryByText(/Download failed/)).not.toBeInTheDocument();
+  });
+
   it("surfaces an error and never downloads when the ticket is refused", async () => {
-    requestTelegramDownloadMock.mockReturnValue(true);
+    requestTelegramDownloadMock.mockReturnValue("handed-off");
     await openFileWithDownloadReady();
 
     fetchMock.mockImplementation(async (url: string) => {

--- a/apps/web/src/lib/__tests__/telegram.test.ts
+++ b/apps/web/src/lib/__tests__/telegram.test.ts
@@ -23,56 +23,68 @@ describe("requestTelegramDownload (WORLD-375)", () => {
   it("hands the download to Telegram and reports it was taken", () => {
     const { downloadFile } = stubWebApp();
 
-    expect(requestTelegramDownload(HTTPS_URL, "README.md")).toBe(true);
+    expect(requestTelegramDownload(HTTPS_URL, "README.md")).toBe("handed-off");
     expect(downloadFile).toHaveBeenCalledWith({
       url: HTTPS_URL,
       file_name: "README.md",
     });
   });
 
-  it("declines when Telegram is absent entirely (plain browser)", () => {
-    expect(requestTelegramDownload(HTTPS_URL, "README.md")).toBe(false);
+  it("reports unsupported when Telegram is absent entirely (plain browser)", () => {
+    expect(requestTelegramDownload(HTTPS_URL, "README.md")).toBe("unsupported");
   });
 
-  it("declines when the client is older than Bot API 8.0", () => {
+  it("reports unsupported when the client is older than Bot API 8.0", () => {
     // downloadFile throws on such clients, so the version gate must come first.
     const { downloadFile } = stubWebApp({ isVersionAtLeast: () => false });
 
-    expect(requestTelegramDownload(HTTPS_URL, "README.md")).toBe(false);
+    expect(requestTelegramDownload(HTTPS_URL, "README.md")).toBe("unsupported");
     expect(downloadFile).not.toHaveBeenCalled();
   });
 
-  it("declines when the client predates isVersionAtLeast", () => {
+  it("reports unsupported when the client predates isVersionAtLeast", () => {
     const { downloadFile } = stubWebApp({ isVersionAtLeast: undefined });
 
-    expect(requestTelegramDownload(HTTPS_URL, "README.md")).toBe(false);
+    expect(requestTelegramDownload(HTTPS_URL, "README.md")).toBe("unsupported");
     expect(downloadFile).not.toHaveBeenCalled();
   });
 
-  it("declines when downloadFile is missing from the SDK", () => {
+  it("reports unsupported when downloadFile is missing from the SDK", () => {
     stubWebApp({ downloadFile: undefined });
 
-    expect(requestTelegramDownload(HTTPS_URL, "README.md")).toBe(false);
+    expect(requestTelegramDownload(HTTPS_URL, "README.md")).toBe("unsupported");
   });
 
-  it("declines a non-https URL instead of letting downloadFile throw", () => {
+  it("reports unsupported for a non-https URL instead of letting downloadFile throw", () => {
     // Local dev is served over http; downloadFile rejects any non-https url.
     const { downloadFile } = stubWebApp();
 
     expect(
       requestTelegramDownload("http://localhost:58830/api/files/download?ticket=abc", "README.md"),
-    ).toBe(false);
+    ).toBe("unsupported");
     expect(downloadFile).not.toHaveBeenCalled();
   });
 
-  it("declines rather than propagating a throw from downloadFile", () => {
-    // e.g. WebAppDownloadFilePopupOpened when a dialog is already up.
+  it("reports busy — NOT unsupported — when a download popup is already open", () => {
+    // The distinction is load-bearing: we are inside a capable Telegram client
+    // here, where the anchor fallback is broken. Reporting "unsupported" would
+    // send the caller down that path and reproduce WORLD-375 on a double-tap.
     stubWebApp({
       downloadFile: vi.fn(() => {
         throw new Error("WebAppDownloadFilePopupOpened");
       }),
     });
 
-    expect(requestTelegramDownload(HTTPS_URL, "README.md")).toBe(false);
+    expect(requestTelegramDownload(HTTPS_URL, "README.md")).toBe("busy");
+  });
+
+  it("reports busy for any other throw from a capable client", () => {
+    stubWebApp({
+      downloadFile: vi.fn(() => {
+        throw new Error("something else entirely");
+      }),
+    });
+
+    expect(requestTelegramDownload(HTTPS_URL, "README.md")).toBe("busy");
   });
 });

--- a/apps/web/src/lib/__tests__/telegram.test.ts
+++ b/apps/web/src/lib/__tests__/telegram.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { requestTelegramDownload } from "../telegram";
+
+const HTTPS_URL = "https://cpc.claude.do/api/files/download?ticket=abc";
+
+/** Install a fake WebApp. `downloadFile` defaults to a spy that succeeds. */
+function stubWebApp(overrides: Record<string, unknown> = {}) {
+  const downloadFile = vi.fn();
+  const webApp = {
+    isVersionAtLeast: () => true,
+    downloadFile,
+    ...overrides,
+  };
+  (window as unknown as { Telegram?: unknown }).Telegram = { WebApp: webApp };
+  return { downloadFile };
+}
+
+afterEach(() => {
+  delete (window as unknown as { Telegram?: unknown }).Telegram;
+});
+
+describe("requestTelegramDownload (WORLD-375)", () => {
+  it("hands the download to Telegram and reports it was taken", () => {
+    const { downloadFile } = stubWebApp();
+
+    expect(requestTelegramDownload(HTTPS_URL, "README.md")).toBe(true);
+    expect(downloadFile).toHaveBeenCalledWith({
+      url: HTTPS_URL,
+      file_name: "README.md",
+    });
+  });
+
+  it("declines when Telegram is absent entirely (plain browser)", () => {
+    expect(requestTelegramDownload(HTTPS_URL, "README.md")).toBe(false);
+  });
+
+  it("declines when the client is older than Bot API 8.0", () => {
+    // downloadFile throws on such clients, so the version gate must come first.
+    const { downloadFile } = stubWebApp({ isVersionAtLeast: () => false });
+
+    expect(requestTelegramDownload(HTTPS_URL, "README.md")).toBe(false);
+    expect(downloadFile).not.toHaveBeenCalled();
+  });
+
+  it("declines when the client predates isVersionAtLeast", () => {
+    const { downloadFile } = stubWebApp({ isVersionAtLeast: undefined });
+
+    expect(requestTelegramDownload(HTTPS_URL, "README.md")).toBe(false);
+    expect(downloadFile).not.toHaveBeenCalled();
+  });
+
+  it("declines when downloadFile is missing from the SDK", () => {
+    stubWebApp({ downloadFile: undefined });
+
+    expect(requestTelegramDownload(HTTPS_URL, "README.md")).toBe(false);
+  });
+
+  it("declines a non-https URL instead of letting downloadFile throw", () => {
+    // Local dev is served over http; downloadFile rejects any non-https url.
+    const { downloadFile } = stubWebApp();
+
+    expect(
+      requestTelegramDownload("http://localhost:58830/api/files/download?ticket=abc", "README.md"),
+    ).toBe(false);
+    expect(downloadFile).not.toHaveBeenCalled();
+  });
+
+  it("declines rather than propagating a throw from downloadFile", () => {
+    // e.g. WebAppDownloadFilePopupOpened when a dialog is already up.
+    stubWebApp({
+      downloadFile: vi.fn(() => {
+        throw new Error("WebAppDownloadFilePopupOpened");
+      }),
+    });
+
+    expect(requestTelegramDownload(HTTPS_URL, "README.md")).toBe(false);
+  });
+});

--- a/apps/web/src/lib/telegram.ts
+++ b/apps/web/src/lib/telegram.ts
@@ -60,29 +60,41 @@ export function getInitData(): string {
 }
 
 /**
- * Hand a download off to Telegram's native file downloader. Returns true when
- * the request was accepted by the SDK (Telegram then shows its own confirm
- * dialog and owns the rest of the flow).
+ * - `handed-off`: Telegram accepted it and now owns the flow (its own confirm
+ *   dialog, its own downloader).
+ * - `busy`: we ARE in a capable Telegram client, but it refused this call right
+ *   now — in practice because a download popup is already open.
+ * - `unsupported`: no Telegram, too old, or a URL its downloader won't take.
+ */
+export type TelegramDownloadOutcome = "handed-off" | "busy" | "unsupported";
+
+/**
+ * Hand a download off to Telegram's native file downloader.
  *
  * Inside Telegram's WebView a `<a download>` navigation does not save the file:
  * the WebView renders the response bytes inline as uncopyable text instead.
  * `downloadFile` is the only path that produces a real file, so callers should
- * prefer it and keep the anchor as a fallback for desktop/browser use.
+ * prefer it and keep the anchor strictly for non-Telegram browsers.
  *
- * Returns false — rather than throwing — whenever the native path is
- * unavailable, because `downloadFile` throws on an unsupported client, a
+ * Never throws, though `downloadFile` does — on an unsupported client, a
  * non-https URL (e.g. local dev over http), or an already-open popup.
+ *
+ * The `busy` case matters: once the capability and https gates pass we know we
+ * are inside a Telegram WebView, where the anchor is broken by definition. A
+ * caller that treated a refusal as "fall back to the anchor" would re-trigger
+ * the very inline-render bug this function exists to avoid — so a throw past
+ * those gates is reported as `busy`, never as `unsupported`.
  */
-export function requestTelegramDownload(url: string, fileName: string): boolean {
+export function requestTelegramDownload(url: string, fileName: string): TelegramDownloadOutcome {
   const tg = getTelegramWebApp();
-  if (typeof tg?.downloadFile !== "function") return false;
-  if (!tg.isVersionAtLeast?.("8.0")) return false;
-  if (!url.startsWith("https:")) return false;
+  if (typeof tg?.downloadFile !== "function") return "unsupported";
+  if (!tg.isVersionAtLeast?.("8.0")) return "unsupported";
+  if (!url.startsWith("https:")) return "unsupported";
   try {
     tg.downloadFile({ url, file_name: fileName });
-    return true;
+    return "handed-off";
   } catch {
-    return false;
+    return "busy";
   }
 }
 

--- a/apps/web/src/lib/telegram.ts
+++ b/apps/web/src/lib/telegram.ts
@@ -34,6 +34,14 @@ interface TelegramWebApp {
   themeParams: Record<string, string>;
   colorScheme: "light" | "dark";
   isExpanded: boolean;
+  version?: string;
+  isVersionAtLeast?(version: string): boolean;
+  /** Bot API 8.0+. Throws when unsupported, when `url` is not https, or when a
+   *  download popup is already open — always call via `requestTelegramDownload`. */
+  downloadFile?(
+    params: { url: string; file_name: string },
+    callback?: (accepted: boolean) => void,
+  ): void;
   checkHomeScreenStatus?(callback: (status: "added" | "missed" | "unknown") => void): void;
   addToHomeScreen?(): void;
   HapticFeedback?: {
@@ -49,6 +57,33 @@ export function getTelegramWebApp(): TelegramWebApp | null {
 
 export function getInitData(): string {
   return window.Telegram?.WebApp?.initData ?? "";
+}
+
+/**
+ * Hand a download off to Telegram's native file downloader. Returns true when
+ * the request was accepted by the SDK (Telegram then shows its own confirm
+ * dialog and owns the rest of the flow).
+ *
+ * Inside Telegram's WebView a `<a download>` navigation does not save the file:
+ * the WebView renders the response bytes inline as uncopyable text instead.
+ * `downloadFile` is the only path that produces a real file, so callers should
+ * prefer it and keep the anchor as a fallback for desktop/browser use.
+ *
+ * Returns false — rather than throwing — whenever the native path is
+ * unavailable, because `downloadFile` throws on an unsupported client, a
+ * non-https URL (e.g. local dev over http), or an already-open popup.
+ */
+export function requestTelegramDownload(url: string, fileName: string): boolean {
+  const tg = getTelegramWebApp();
+  if (typeof tg?.downloadFile !== "function") return false;
+  if (!tg.isVersionAtLeast?.("8.0")) return false;
+  if (!url.startsWith("https:")) return false;
+  try {
+    tg.downloadFile({ url, file_name: fileName });
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 export function getUrlToken(): string {

--- a/apps/web/src/lib/telegram.ts
+++ b/apps/web/src/lib/telegram.ts
@@ -93,7 +93,13 @@ export function requestTelegramDownload(url: string, fileName: string): Telegram
   try {
     tg.downloadFile({ url, file_name: fileName });
     return "handed-off";
-  } catch {
+  } catch (err) {
+    // Deliberately not classified by error content — matching on message text
+    // would be brittle. But that means a throw which is genuinely "this client
+    // won't take this request" is reported as `busy` and does nothing visible.
+    // We cannot see inside Telegram's downloader, so leave a breadcrumb: if a
+    // tap ever appears to do nothing on-device, this is the only evidence.
+    console.debug("[cpc] Telegram declined downloadFile; treating as busy", err);
     return "busy";
   }
 }


### PR DESCRIPTION
Closes-tracker: WORLD-375 (Plane; **not** auto-closed — only Liam closes trackers)

## The bug
Tapping **Download** on a markdown file shows raw, uncopyable text instead of saving a file.

## Root cause
The server side is fine — `createDownloadResponse` already sends `application/octet-stream` + `Content-Disposition: attachment` + `nosniff`. The problem is the client: inside Telegram's WebView a hidden `<a download>` **only navigates**. The WebView then paints the response bytes inline as text — which is also unselectable (see #330), producing exactly the reported symptom.

So there was no *real download trigger*, which is what the ticket asks for.

## Change
Hand the download to the SDK's `downloadFile` (Bot API 8.0+), which raises Telegram's own native save dialog.

- **`requestTelegramDownload()`** (new, in `lib/telegram.ts`) wraps the SDK call and returns `false` instead of throwing. This matters: `downloadFile` **throws, not warns**, on a pre-8.0 client, on a non-https URL (local dev over http), and when a popup is already open.
- **The ticket URL is now absolute.** Telegram's downloader runs outside this document and rejects relative/non-https URLs.
- **Why this works at all:** the existing one-time ticket already bypasses auth on `GET /api/files/download` (`middleware.ts:34-40`). That's precisely what lets the native downloader — which sends no `Authorization` header — fetch the bytes. The ticket flow wasn't wasted; it's the enabler.
- The `<a download>` path **stays** as the desktop/browser fallback, where it does work.

## Verification
- typecheck clean; **391 tests pass**; build succeeds.
- Adds the **first frontend coverage for the download button** — there was none (`FileViewer.test.tsx` had zero download references). 7 guard tests for `requestTelegramDownload` + 3 FileViewer wiring tests.
- Also repairs the `lib/telegram` mock in `FileViewer.test.tsx`, which stubbed only `getAuthHeaders` and would have yielded `undefined` for the new import.
- **Mutation-tested, not just green:** removing the handoff, the https guard, or the version gate each fails a test.
- **Not confirmed on-device yet** — the native dialog needs a real Telegram client.

## Known risk to watch in UAT
The download ticket TTL is **60s**, one-time. The native flow adds a user-confirmation dialog *before* Telegram fetches. A user who leaves the dialog open >60s gets an expired ticket. Left unchanged deliberately (no speculative server change); if UAT hits it, bump `DOWNLOAD_TICKET_TTL_MS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)