### PR TITLE
feat(web): session switcher sheet + safe-area top inset + chip row restore

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -13,7 +13,7 @@ import { PrTicker } from "./components/PrTicker";
 import { HomeScreenPrompt } from "./components/HomeScreenPrompt";
 import { CockpitPage } from "./components/CockpitPage";
 import { VaultExplorerPage } from "./components/VaultExplorerPage";
-import { type TmuxSessionInfo } from "./components/SessionPicker";
+import { SessionPicker, type TmuxSessionInfo } from "./components/SessionPicker";
 import { SessionSwitcherSheet } from "./components/SessionSwitcherSheet";
 import {
   buildLandingUrl,
@@ -144,7 +144,6 @@ export function App() {
   const sessionPicker = resolveSessionPickerProps(sessionList, activeSession, defaultSession);
   const [sessionSwitcherOpen, setSessionSwitcherOpen] = useState(false);
   const activeSessionName = activeSession ?? defaultSession ?? "";
-  const activeSessionInfo = sessionPicker.sessions.find((s) => s.name === activeSessionName);
   const [fileOpenRequest, setFileOpenRequest] = useState({ path: initialRoute.file, sequence: 0 });
   // FileViewer is keyed by this request sequence. Keep the latest request in
   // a ref so callbacks retained by an unmounted viewer cannot publish a late
@@ -600,75 +599,52 @@ export function App() {
         </div>
       )}
 
-      {/* Session bar — terminal tab only. A single big-tap-target row showing
-          the active session; tapping opens the SessionSwitcherSheet (a
-          bottom-sheet picker with full-width rows). Replaces the old cramped
-          horizontal chip strip (SessionPicker). Visibility + session list
-          (including the stale-deep-link escape hatch) are still decided by
-          resolveSessionPickerProps — see its docstring for the round-2
-          (PR #299) fix: an earlier inline `sessionList.length > 0` guard
-          hid the picker entirely whenever /api/terminal/sessions failed
-          while a stale session was active, stranding the user. */}
+      {/* Session switcher row — terminal tab only. Liam's design (2026-07-15):
+          BOTH a horizontal sliding chip strip (quick one-tap select) AND a
+          list-view button on its left that opens the full session list
+          (SessionSwitcherSheet). Visibility + session list (including the
+          stale-deep-link escape hatch) are decided by resolveSessionPickerProps
+          — see its docstring for the round-2 (PR #299) fix: an earlier inline
+          `sessionList.length > 0` guard hid the picker entirely whenever
+          /api/terminal/sessions failed while a stale session was active,
+          stranding the user. */}
       {activeTab === "terminal" && sessionPicker.visible && (
-        <button
-          data-testid="session-bar"
-          onClick={() => { haptic.selection(); setSessionSwitcherOpen(true); }}
-          onTouchStart={(e) => e.stopPropagation()}
+        <div
           style={{
             display: "flex",
-            alignItems: "center",
-            gap: 8,
-            width: "100%",
-            padding: "9px 14px",
-            background: "none",
-            border: "none",
+            alignItems: "stretch",
             borderBottom: "1px solid var(--color-border)",
             flexShrink: 0,
-            cursor: "pointer",
-            textAlign: "left",
           }}
+          onTouchStart={(e) => e.stopPropagation()}
         >
-          <span
-            aria-hidden="true"
+          <button
+            data-testid="session-list-button"
+            aria-label="Show all sessions in a list"
+            onClick={() => { haptic.selection(); setSessionSwitcherOpen(true); }}
             style={{
-              width: 7,
-              height: 7,
-              borderRadius: "50%",
-              flexShrink: 0,
-              background: (activeSessionInfo?.alive ?? true)
-                ? "var(--color-accent-green)"
-                : "var(--color-subtle)",
-            }}
-          />
-          <span
-            style={{
-              flex: 1,
-              minWidth: 0,
-              fontFamily: "monospace",
-              fontSize: 13,
-              fontWeight: 600,
-              color: "var(--color-fg)",
-              whiteSpace: "nowrap",
-              overflow: "hidden",
-              textOverflow: "ellipsis",
-            }}
-          >
-            {activeSessionName || "default"}
-          </span>
-          <span
-            style={{
-              fontSize: 11,
-              color: "var(--color-muted)",
               flexShrink: 0,
               display: "inline-flex",
               alignItems: "center",
-              gap: 4,
+              justifyContent: "center",
+              padding: "0 13px",
+              background: "none",
+              border: "none",
+              borderRight: "1px solid var(--color-border)",
+              cursor: "pointer",
+              color: "var(--color-muted)",
+              fontSize: 15,
+              lineHeight: 1,
             }}
           >
-            {sessionPicker.sessions.length > 1 ? `${sessionPicker.sessions.length} terminals` : "switch"}
-            <span aria-hidden="true">&#9662;</span>
-          </span>
-        </button>
+            <span aria-hidden="true">&#9776;</span>
+          </button>
+          <SessionPicker
+            sessions={sessionPicker.sessions}
+            active={activeSessionName}
+            onSelect={onSelectSession}
+          />
+        </div>
       )}
 
       {/* Content area — swipeable viewport */}

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -13,7 +13,8 @@ import { PrTicker } from "./components/PrTicker";
 import { HomeScreenPrompt } from "./components/HomeScreenPrompt";
 import { CockpitPage } from "./components/CockpitPage";
 import { VaultExplorerPage } from "./components/VaultExplorerPage";
-import { SessionPicker, type TmuxSessionInfo } from "./components/SessionPicker";
+import { type TmuxSessionInfo } from "./components/SessionPicker";
+import { SessionSwitcherSheet } from "./components/SessionSwitcherSheet";
 import {
   buildLandingUrl,
   isCockpitRoute,
@@ -141,6 +142,9 @@ export function App() {
   // same session), so the pessimistic default is safe either way.
   const paletteSession = activeSession !== null && activeSession !== defaultSession ? activeSession : null;
   const sessionPicker = resolveSessionPickerProps(sessionList, activeSession, defaultSession);
+  const [sessionSwitcherOpen, setSessionSwitcherOpen] = useState(false);
+  const activeSessionName = activeSession ?? defaultSession ?? "";
+  const activeSessionInfo = sessionPicker.sessions.find((s) => s.name === activeSessionName);
   const [fileOpenRequest, setFileOpenRequest] = useState({ path: initialRoute.file, sequence: 0 });
   // FileViewer is keyed by this request sequence. Keep the latest request in
   // a ref so callbacks retained by an unmounted viewer cannot publish a late
@@ -568,18 +572,75 @@ export function App() {
         </div>
       )}
 
-      {/* Session picker — terminal tab only. Visibility + session list
-          (including the stale-deep-link escape hatch) are decided by
+      {/* Session bar — terminal tab only. A single big-tap-target row showing
+          the active session; tapping opens the SessionSwitcherSheet (a
+          bottom-sheet picker with full-width rows). Replaces the old cramped
+          horizontal chip strip (SessionPicker). Visibility + session list
+          (including the stale-deep-link escape hatch) are still decided by
           resolveSessionPickerProps — see its docstring for the round-2
           (PR #299) fix: an earlier inline `sessionList.length > 0` guard
           hid the picker entirely whenever /api/terminal/sessions failed
           while a stale session was active, stranding the user. */}
       {activeTab === "terminal" && sessionPicker.visible && (
-        <SessionPicker
-          sessions={sessionPicker.sessions}
-          active={activeSession ?? defaultSession ?? ""}
-          onSelect={onSelectSession}
-        />
+        <button
+          data-testid="session-bar"
+          onClick={() => { haptic.selection(); setSessionSwitcherOpen(true); }}
+          onTouchStart={(e) => e.stopPropagation()}
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 8,
+            width: "100%",
+            padding: "9px 14px",
+            background: "none",
+            border: "none",
+            borderBottom: "1px solid var(--color-border)",
+            flexShrink: 0,
+            cursor: "pointer",
+            textAlign: "left",
+          }}
+        >
+          <span
+            aria-hidden="true"
+            style={{
+              width: 7,
+              height: 7,
+              borderRadius: "50%",
+              flexShrink: 0,
+              background: (activeSessionInfo?.alive ?? true)
+                ? "var(--color-accent-green)"
+                : "var(--color-subtle)",
+            }}
+          />
+          <span
+            style={{
+              flex: 1,
+              minWidth: 0,
+              fontFamily: "monospace",
+              fontSize: 13,
+              fontWeight: 600,
+              color: "var(--color-fg)",
+              whiteSpace: "nowrap",
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+            }}
+          >
+            {activeSessionName || "default"}
+          </span>
+          <span
+            style={{
+              fontSize: 11,
+              color: "var(--color-muted)",
+              flexShrink: 0,
+              display: "inline-flex",
+              alignItems: "center",
+              gap: 4,
+            }}
+          >
+            {sessionPicker.sessions.length > 1 ? `${sessionPicker.sessions.length} terminals` : "switch"}
+            <span aria-hidden="true">&#9662;</span>
+          </span>
+        </button>
       )}
 
       {/* Content area — swipeable viewport */}
@@ -643,6 +704,16 @@ export function App() {
           currentFolder={currentFolder}
         />
       </div>
+
+      {/* Terminal session switcher sheet — opened from the session bar */}
+      {sessionSwitcherOpen && (
+        <SessionSwitcherSheet
+          sessions={sessionPicker.sessions}
+          active={activeSessionName}
+          onSelect={onSelectSession}
+          onClose={() => setSessionSwitcherOpen(false)}
+        />
+      )}
 
       {/* Home screen prompt — rendered once, dismissed to localStorage */}
       {showHomeScreenPrompt && <HomeScreenPrompt onDismiss={handleHomeScreenDismiss} />}

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -619,6 +619,7 @@ export function App() {
           onTouchStart={(e) => e.stopPropagation()}
         >
           <button
+            type="button"
             data-testid="session-list-button"
             aria-label="Show all sessions in a list"
             onClick={() => { haptic.selection(); setSessionSwitcherOpen(true); }}

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -358,6 +358,34 @@ export function App() {
     }
   }, []);
 
+  // Telegram fullscreen chrome (the centered island + the Close / collapse /
+  // "⋯" buttons) floats OVER the top of the webview, stomping the app's tab
+  // bar and header (see on-device screenshot 2026-07-15). Pad the whole app
+  // below it. The offset is the device safe area PLUS Telegram's own content
+  // safe area — the band its buttons occupy. `env(safe-area-inset-top)` alone
+  // is NOT enough: Telegram's pills sit AT the device inset, so content padded
+  // only by the device inset still lands under the Close button. Both values
+  // are read straight off the WebApp object (CPC uses the raw WebApp, not the
+  // CSS-var-publishing SDK) and re-read on the change events, since they
+  // resolve asynchronously after requestFullscreen() and update on rotation /
+  // fullscreen toggle. Non-Telegram browsers report 0 → no padding.
+  const [topInset, setTopInset] = useState(0);
+  useEffect(() => {
+    const tg = getTelegramWebApp() as any;
+    if (!tg) return;
+    const readInset = () => {
+      const device = tg.safeAreaInset?.top ?? 0;
+      const content = tg.contentSafeAreaInset?.top ?? 0;
+      setTopInset(device + content);
+    };
+    readInset();
+    const events = ["safeAreaChanged", "contentSafeAreaChanged", "fullscreenChanged"];
+    if (typeof tg.onEvent === "function") events.forEach((e) => tg.onEvent(e, readInset));
+    return () => {
+      if (typeof tg.offEvent === "function") events.forEach((e) => tg.offEvent(e, readInset));
+    };
+  }, []);
+
   // Telegram Login Widget callback (for fallback auth)
   useEffect(() => {
     if (authed) return;
@@ -475,7 +503,7 @@ export function App() {
   }
 
   return (
-    <div style={{ display: "flex", flexDirection: "column", height: "100%", width: "100%", maxWidth: "100vw", overflowX: "hidden" }}>
+    <div style={{ display: "flex", flexDirection: "column", height: "100%", width: "100%", maxWidth: "100vw", overflowX: "hidden", boxSizing: "border-box", paddingTop: topInset, background: "var(--color-bg)" }}>
       {/* Dev mode banner */}
       {isDev && (
         <div style={{

--- a/apps/web/src/components/SessionPicker.tsx
+++ b/apps/web/src/components/SessionPicker.tsx
@@ -36,8 +36,12 @@ export function SessionPicker({ sessions, active, onSelect }: SessionPickerProps
         gap: 6,
         padding: "6px 12px",
         overflowX: "auto",
-        borderBottom: "1px solid var(--color-border)",
-        flexShrink: 0,
+        // Fills the row to the right of the list-view button (App.tsx owns the
+        // row's bottom border). flex:1 + minWidth:0 lets the strip scroll
+        // horizontally within the remaining width instead of pushing the button
+        // off-screen.
+        flex: 1,
+        minWidth: 0,
         // Momentum scrolling in the Telegram WebView
         WebkitOverflowScrolling: "touch",
       }}

--- a/apps/web/src/components/SessionSwitcherSheet.tsx
+++ b/apps/web/src/components/SessionSwitcherSheet.tsx
@@ -33,6 +33,7 @@ export function SessionSwitcherSheet({ sessions, active, onSelect, onClose }: Se
           return (
             <button
               key={s.name}
+              type="button"
               onClick={() => {
                 haptic.selection();
                 if (!isActive) onSelect(s.writable ? null : s.name);

--- a/apps/web/src/components/SessionSwitcherSheet.tsx
+++ b/apps/web/src/components/SessionSwitcherSheet.tsx
@@ -1,0 +1,123 @@
+import { BottomSheet } from "./BottomSheet";
+import { haptic } from "../lib/haptic";
+import type { TmuxSessionInfo } from "./SessionPicker";
+
+interface SessionSwitcherSheetProps {
+  sessions: TmuxSessionInfo[];
+  /** Resolved name of the session currently viewed. */
+  active: string;
+  /** null selects the server default (writable) session. */
+  onSelect: (name: string | null) => void;
+  onClose: () => void;
+}
+
+/**
+ * Full-screen-reachable terminal session picker. Replaces the cramped
+ * horizontal chip strip (SessionPicker) that lived under the Telegram
+ * buttons: that strip had ~11px labels and 3px tap padding and scrolled
+ * sideways, which made switching sessions on a phone genuinely hard.
+ *
+ * Here each session is a full-width row with a real tap target (~52px),
+ * a status dot, the session name, and the running command as a subtitle
+ * so cryptic session names are still identifiable. Same select semantics
+ * as SessionPicker — the writable/default session maps to `onSelect(null)`
+ * (the "view the server default" sentinel), every other name is passed
+ * through literally. Selecting closes the sheet.
+ */
+export function SessionSwitcherSheet({ sessions, active, onSelect, onClose }: SessionSwitcherSheetProps) {
+  return (
+    <BottomSheet onClose={onClose} title="Switch terminal">
+      <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+        {sessions.map((s) => {
+          const isActive = s.name === active;
+          return (
+            <button
+              key={s.name}
+              onClick={() => {
+                haptic.selection();
+                if (!isActive) onSelect(s.writable ? null : s.name);
+                onClose();
+              }}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 12,
+                width: "100%",
+                padding: "13px 14px",
+                borderRadius: 12,
+                cursor: "pointer",
+                textAlign: "left",
+                background: isActive ? "var(--color-surface)" : "transparent",
+                border: isActive
+                  ? "1px solid var(--color-accent-blue)"
+                  : "1px solid var(--color-border)",
+              }}
+            >
+              <span
+                aria-hidden="true"
+                style={{
+                  width: 9,
+                  height: 9,
+                  borderRadius: "50%",
+                  flexShrink: 0,
+                  background: s.alive ? "var(--color-accent-green)" : "var(--color-subtle)",
+                }}
+              />
+              <span style={{ flex: 1, minWidth: 0, display: "flex", flexDirection: "column", gap: 2 }}>
+                <span
+                  style={{
+                    fontFamily: "monospace",
+                    fontSize: 15,
+                    fontWeight: isActive ? 600 : 500,
+                    color: isActive ? "var(--color-fg)" : "var(--color-fg-muted)",
+                    whiteSpace: "nowrap",
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                  }}
+                >
+                  {s.name}
+                </span>
+                {(s.command || !s.alive) && (
+                  <span
+                    style={{
+                      fontSize: 11,
+                      color: "var(--color-muted)",
+                      whiteSpace: "nowrap",
+                      overflow: "hidden",
+                      textOverflow: "ellipsis",
+                    }}
+                  >
+                    {s.alive ? s.command : "ended"}
+                  </span>
+                )}
+              </span>
+              {s.writable && (
+                <span
+                  style={{
+                    fontSize: 11,
+                    color: "var(--color-accent-green)",
+                    display: "inline-flex",
+                    alignItems: "center",
+                    gap: 3,
+                    flexShrink: 0,
+                  }}
+                >
+                  <span aria-label="writable session">&#9998;</span>
+                  writable
+                </span>
+              )}
+              {isActive && (
+                <span
+                  aria-label="current session"
+                  style={{ fontSize: 15, color: "var(--color-accent-blue)", flexShrink: 0 }}
+                >
+                  &#10003;
+                </span>
+              )}
+            </button>
+          );
+        })}
+      </div>
+    </BottomSheet>
+  );
+}


### PR DESCRIPTION
Liam direct merge order 2026-07-16 12:12 ET (thread 1731): merge immediately — review gate waived by his word. PM's handoff state: 3 commits apps/web only (+216/-14), tsc --noEmit clean, 393/393 tests, zero external review, code already live via cpc.claude.do/dev HMR (merge buys durability). Post-merge review-behind available on request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)