### PR TITLE
docs: fix stale cpc-dev.claude.do refs + de-duplicate keyboard recovery snippet

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,7 +110,7 @@ Read what you need for your current task. Start with the closest AGENTS.md.
 |--------------------|----------------------------------------------|
 | Server port        | `38830`                                      |
 | Prod tunnel        | `https://cpc.claude.do`                      |
-| Dev tunnel         | `https://cpc-dev.claude.do`                  |
+| Dev slot           | `https://cpc.claude.do/dev/` (a PATH, not a subdomain) |
 | Bot token env      | `TELEGRAM_BOT_TOKEN` in `~/.secrets/cpc.env` |
 | OpenAI key         | `OPENAI_API_KEY` in `~/.secrets/openai.env`  |
 | Allowed users      | `ALLOWED_TELEGRAM_USERS` in `~/.secrets/cpc.env` |

--- a/docs/conventions/gitflow.md
+++ b/docs/conventions/gitflow.md
@@ -33,6 +33,6 @@
 ## Deploy Flow
 
 1. Work on `dev` or `feat/*` branch
-2. Test via `cpc-dev.claude.do`
+2. Test via `cpc.claude.do/dev/`
 3. Merge to `main` when ready
 4. Use `/deploy` skill to build and ship

--- a/docs/guides/adding-a-modal.md
+++ b/docs/guides/adding-a-modal.md
@@ -102,4 +102,4 @@ Browser testing is not sufficient. You must verify:
 - Safe area insets are respected on devices with notches
 - Touch events do not leak to tab-swipe or other handlers
 
-Use `cpc-dev.claude.do` for testing before deploying to production.
+Use `cpc.claude.do/dev/` for testing before deploying to production.

--- a/docs/guides/recovery.md
+++ b/docs/guides/recovery.md
@@ -72,29 +72,28 @@ If the Telegram plugin is misbehaving (duplicate messages, missed messages):
 
 If the Telegram keyboard buttons disappear:
 
-```bash
-# Source credentials
-. ~/code/toolbox/hooks/common.sh
+Do NOT hand-roll the keyboard JSON. The Develop and Voice buttons carry a
+short-lived signed auth token in their URLs — a hardcoded copy has no token, so
+the app opens but the terminal cannot authenticate and shows "disconnected".
+Build the markup with the canonical helper instead:
 
-# Re-send the keyboard
+```bash
+# Source credentials + the canonical keyboard builder
+. ~/code/toolbox/hooks/common.sh
+. ~/code/toolbox/hooks/lib/launcher-keyboard.sh
+
+# Re-send the exact keyboard launcher-hook sends, with a fresh auth token
 curl -s -X POST "https://api.telegram.org/bot${BOTTOKEN}/sendMessage" \
   -H "Content-Type: application/json" \
-  -d '{
-    "chat_id": "'${TELEGRAM_CHAT_ID}'",
-    "text": "Keyboard restored.",
-    "reply_markup": {
-      "keyboard": [
-        [
-          {"text": "Actions"},
-          {"text": "Develop", "web_app": {"url": "https://cpc-dev.claude.do"}},
-          {"text": "Voice", "web_app": {"url": "https://cpc.claude.do/#voice"}}
-        ]
-      ],
-      "resize_keyboard": true,
-      "is_persistent": true
-    }
-  }'
+  -d "$(jq -n \
+        --arg chat_id "$TELEGRAM_CHAT_ID" \
+        --arg text "Keyboard restored." \
+        --argjson reply_markup "$(build_launcher_reply_markup "$TELEGRAM_CHAT_ID" "$BOTTOKEN")" \
+        '{chat_id: $chat_id, text: $text, reply_markup: $reply_markup}')"
 ```
+
+`build_launcher_reply_markup` (in `~/code/toolbox/hooks/lib/launcher-keyboard.sh`)
+is the single source of truth for the button set and their URLs.
 
 Or simply start a new Claude Code session -- `launcher-hook` will restore
 the keyboard automatically.

--- a/docs/reference/telegram-webview-rules.md
+++ b/docs/reference/telegram-webview-rules.md
@@ -82,5 +82,5 @@ if (tg?.safeAreaInset?.bottom) setBottomOffset(tg.safeAreaInset.bottom);
 const isDev = window.location.hostname.includes("cpc-dev");
 ```
 
-When running on `cpc-dev.claude.do`, a yellow "DEVELOPMENT" banner appears
+When running on `cpc.claude.do/dev/`, a yellow "DEVELOPMENT" banner appears
 at the top of the app.


### PR DESCRIPTION
Follow-on docs cleanup Liam asked for.

## What was wrong
The dev slot moved from the `cpc-dev.claude.do` **subdomain** to a **path** off prod (`cpc.claude.do/dev/`). Verified live: the subdomain returns **404**, `cpc.claude.do/dev/` returns **200**. Every doc pointing at it sent readers somewhere dead.

`docs/guides/recovery.md` was worse than stale. It hand-rolled the keyboard JSON with a hardcoded Develop URL and **no auth token** — following it yields an app that opens but whose terminal can't authenticate ("disconnected"). It had also drifted to 3 buttons; the real keyboard has 5. Replaced with a call to `build_launcher_reply_markup`, the single source of truth, so it can't rot out of sync again.

## Changed
- `AGENTS.md` — "Dev tunnel" → "Dev slot", `cpc.claude.do/dev/` (noting it's a path, not a subdomain)
- `docs/guides/recovery.md` — canonical keyboard builder instead of a hardcoded copy
- `docs/guides/adding-a-modal.md`, `docs/conventions/gitflow.md`, `docs/reference/telegram-webview-rules.md` — dev URL

`CLAUDE.md` is a symlink to `AGENTS.md`, so it follows automatically.

## Deliberately left alone
- `docs/reviews/v0.10.0-pre-release-review.md` — a historical record of what reviewers said at the time. Rewriting it would falsify the record, not clean docs.
- `docs/conventions/off-limits.md` — its mention is about which tunnels cloudflared manages. `/etc/cloudflared/config.yml` is off-limits, so I can't verify whether that tunnel still exists. Not asserting either way.

Docs-only; no runtime surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)