### PR TITLE
fix(terminal): restart-session finds the orchestrator by role, not by rebuilding a stale launch command (WORLD-415)

### DIFF
--- a/apps/server/src/routes/__tests__/slash-commands-session.test.ts
+++ b/apps/server/src/routes/__tests__/slash-commands-session.test.ts
@@ -56,6 +56,9 @@ const execFileMock = vi.fn((...fnArgs: any[]) => {
   if (args[0] === "list-panes") {
     const format = args[args.indexOf("-F") + 1] || "";
     const rows = sessionPanes.map(([paneId, role]) =>
+      // Substitute verbatim, exactly as tmux does — including role values that
+      // contain spaces. Faithfulness here is the point: a role-first format
+      // mis-parses such a value, and this mock must be able to expose that.
       format
         .replace("#{@cpc-role}", role)
         .replace("#{pane_id}", paneId),
@@ -301,10 +304,38 @@ describe("default-session-only endpoints ignore session fields", () => {
     expect(execFileCalls.find((c) => c.args[0] === "respawn-pane")?.args).toEqual([
       "respawn-pane", "-k", "-t", "%183",
     ]);
-    // Role lookup must be session-wide and ask for the role + pane id only.
+    // Session-wide, and pane_id FIRST — see the spaced-role test below.
     expect(execFileCalls.find((c) => c.args[0] === "list-panes")?.args).toEqual([
-      "list-panes", "-s", "-t", `=${TMUX_SESSION}`, "-F", "#{@cpc-role} #{pane_id}",
+      "list-panes", "-s", "-t", `=${TMUX_SESSION}`, "-F", "#{pane_id} #{@cpc-role}",
     ]);
+  });
+
+  /**
+   * `@cpc-role` is a user-settable tmux option and its value can contain
+   * spaces (verified: `set-option -p @cpc-role "orchestrator x"` renders as
+   * `orchestrator x %229`). With a role-FIRST format the split yielded
+   * paneId="x". pane_id can never contain a space, so it must lead.
+   * A role that merely starts with "orchestrator" is not the role.
+   */
+  it("/restart-session does not treat a spaced role value as the orchestrator", async () => {
+    existingSessions.add(TMUX_SESSION);
+    sessionPanes = [["%229", "orchestrator x"]];
+
+    const { body } = await post("/restart-session");
+    // No exact-role pane => nothing to respawn => cold start, not a mis-parse.
+    expect(execFileCalls.some((c) => c.args[0] === "respawn-pane")).toBe(false);
+    expect(body.path).toBe("cold-started-fresh");
+  });
+
+  it("/restart-session refuses to guess when two panes claim the role", async () => {
+    existingSessions.add(TMUX_SESSION);
+    sessionPanes = [["%1", "orchestrator"], ["%2", "orchestrator"]];
+
+    const { status, body } = await post("/restart-session");
+    expect(status).toBe(500);
+    expect(body.error).toMatch(/ambiguous: 2 panes claim/);
+    expect(execFileCalls.some((c) => c.args[0] === "respawn-pane")).toBe(false);
+    expect(spawnCalls).toHaveLength(0);
   });
 
   /**

--- a/apps/server/src/routes/__tests__/slash-commands-session.test.ts
+++ b/apps/server/src/routes/__tests__/slash-commands-session.test.ts
@@ -368,6 +368,27 @@ describe("default-session-only endpoints ignore session fields", () => {
     expect(body.error).toMatch(/ENOENT|spawn/);
   }, 15_000);
 
+  /**
+   * The button must keep working, not work once. respawn-pane reuses the SAME
+   * pane, so its @cpc-role option survives (verified live: 5 consecutive presses
+   * each restarted the process, tag intact throughout). If a respawn ever
+   * dropped the tag, press 2 would find no candidate, cold-start, hit
+   * cw-launch's attach-or-start no-op, and 500 forever after.
+   */
+  it("/restart-session stays on the respawn path across repeated presses", async () => {
+    existingSessions.add(TMUX_SESSION);
+    sessionPanes = [["%183", "orchestrator"]];
+
+    for (let i = 0; i < 3; i++) {
+      const { status, body } = await post("/restart-session");
+      expect(status).toBe(200);
+      expect(body.path).toBe("respawned-tagged-pane");
+    }
+    expect(execFileCalls.filter((c) => c.args[0] === "respawn-pane").map((c) => c.args[3]))
+      .toEqual(["%183", "%183", "%183"]);
+    expect(spawnCalls).toHaveLength(0); // never falls through to a cold start
+  });
+
   it("/restart-session refuses to guess when two panes claim the role", async () => {
     existingSessions.add(TMUX_SESSION);
     sessionPanes = [["%1", "orchestrator"], ["%2", "orchestrator"]];

--- a/apps/server/src/routes/__tests__/slash-commands-session.test.ts
+++ b/apps/server/src/routes/__tests__/slash-commands-session.test.ts
@@ -248,6 +248,14 @@ describe("default-session-only endpoints ignore session fields", () => {
     expect(execFileCalls.find((c) => c.args[0] === "respawn-pane")?.args).toEqual([
       "respawn-pane", "-k", "-t", `${TMUX_SESSION}:1.1`,
     ]);
+    // Pin the lookup argv: without `-f #{pane_active}` a multi-pane session
+    // lists every pane and we would respawn whichever sorted first.
+    expect(execFileCalls.find((c) => c.args[0] === "list-panes")?.args).toEqual([
+      "list-panes",
+      "-t", `=${TMUX_SESSION}`,
+      "-F", "#{session_name}:#{window_index}.#{pane_index}",
+      "-f", "#{pane_active}",
+    ]);
   });
 
   /**

--- a/apps/server/src/routes/__tests__/slash-commands-session.test.ts
+++ b/apps/server/src/routes/__tests__/slash-commands-session.test.ts
@@ -16,7 +16,10 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
  *     with NO existence probe.
  *
  * Also: /restart-session and /resize-terminal remain default-session-only —
- * they ignore a `session` field entirely (never probe, never retarget).
+ * they ignore a `session` field entirely (never retarget). /restart-session
+ * does probe the DEFAULT session, to pick between respawning its live pane
+ * and cold-starting via cw-launch (WORLD-415); that probe never touches a
+ * client-supplied name.
  */
 
 const execFileCalls: { cmd: string; args: string[] }[] = [];
@@ -35,6 +38,13 @@ const execFileMock = vi.fn((...fnArgs: any[]) => {
       callback?.(new Error(`can't find session: ${target}`));
       return { kill: () => {} } as any;
     }
+  }
+  // Mirrors real tmux: `list-panes -F '#{session_name}:#{window_index}.#{pane_index}'`
+  // prints one target line per matching pane (base-index is 1 on this host).
+  if (args[0] === "list-panes") {
+    const target = (args[args.indexOf("-t") + 1] || "").replace(/^=/, "");
+    callback?.(null, { stdout: `${target}:1.1\n`, stderr: "" });
+    return { kill: () => {} } as any;
   }
   callback?.(null, { stdout: "", stderr: "" });
   return { kill: () => {} } as any;
@@ -228,10 +238,39 @@ describe("default-session-only endpoints ignore session fields", () => {
     expect(execCalls.some((cmd) => cmd.includes(`resize-window -t ${TMUX_SESSION}`))).toBe(true);
   });
 
-  it("/restart-session never probes or retargets", async () => {
+  it("/restart-session never retargets, and respawns the default session's own pane", async () => {
+    existingSessions.add(TMUX_SESSION);
     const { status } = await post("/restart-session", { session: "do-box--lane-a" });
     expect(status).toBe(200);
-    expect(probeCalls()).toHaveLength(0);
-    expect(execCalls.some((cmd) => cmd.includes(`kill-session -t ${TMUX_SESSION}`))).toBe(true);
+    // The probe is the default session's own liveness check — never the client's.
+    expect(probeCalls().map((c) => c.args)).toEqual([["has-session", "-t", `=${TMUX_SESSION}`]]);
+    expect(execFileCalls.some((c) => c.args.some((a) => a.includes("do-box--lane-a")))).toBe(false);
+    expect(execFileCalls.find((c) => c.args[0] === "respawn-pane")?.args).toEqual([
+      "respawn-pane", "-k", "-t", `${TMUX_SESSION}:1.1`,
+    ]);
+  });
+
+  /**
+   * WORLD-415 regression. The old handler killed the session and rebuilt the
+   * claude command inline; that copy drifted from cw-launch and silently
+   * restarted the orchestrator into a week-old session. Respawning the pane
+   * re-runs the pane's OWN start command, so CPC never holds launch config.
+   */
+  it("/restart-session never reconstructs a claude launch command", async () => {
+    existingSessions.add(TMUX_SESSION);
+    await post("/restart-session");
+    const issued = [...execCalls, ...execFileCalls.flatMap((c) => [c.cmd, ...c.args])].join(" ");
+    expect(issued).not.toContain("kill-session");
+    expect(issued).not.toContain("new-session");
+    expect(issued).not.toContain("claude-plugins-official");
+    expect(issued).not.toContain("--continue");
+  });
+
+  it("/restart-session falls back to the canonical launcher when the session is gone", async () => {
+    // existingSessions is empty → `has-session` fails → nothing to respawn.
+    const { status } = await post("/restart-session");
+    expect(status).toBe(200);
+    expect(execFileCalls.some((c) => c.cmd.endsWith("cw-launch"))).toBe(true);
+    expect(execFileCalls.some((c) => c.args[0] === "respawn-pane")).toBe(false);
   });
 });

--- a/apps/server/src/routes/__tests__/slash-commands-session.test.ts
+++ b/apps/server/src/routes/__tests__/slash-commands-session.test.ts
@@ -53,6 +53,26 @@ const execFileMock = vi.fn((...fnArgs: any[]) => {
   // uses are modelled. An unset @cpc-role formats as "" (real tmux behaviour),
   // which is what makes the "untagged panes must never be a candidate" tests
   // meaningful.
+  // Models `if-shell -F -t <pane> '#{==:#{@cpc-role},X}' <then> <else>`: tmux
+  // evaluates the role AT DISPATCH TIME inside its own command queue. Crucially
+  // it re-reads sessionPanes now, so a role changed after the lookup is seen —
+  // that is the whole point of the atomic form. Exits 0 either way; the else
+  // branch prints its marker to stdout.
+  if (args[0] === "if-shell") {
+    const pane = args[args.indexOf("-t") + 1];
+    const cond = args[args.indexOf("-t") + 2] || "";
+    const thenCmd = args[args.indexOf("-t") + 3] || "";
+    const elseCmd = args[args.indexOf("-t") + 4] || "";
+    const want = cond.match(/^#\{==:#\{@cpc-role\},(.*)\}$/)?.[1];
+    const role = sessionPanes.find(([id]) => id === pane)?.[1];
+    if (role !== undefined && role === want) {
+      ifShellRan.push(thenCmd);
+      callback?.(null, { stdout: "", stderr: "" });
+    } else {
+      callback?.(null, { stdout: elseCmd.replace(/^display-message -p /, "") + "\n", stderr: "" });
+    }
+    return { kill: () => {} } as any;
+  }
   if (args[0] === "list-panes") {
     const format = args[args.indexOf("-F") + 1] || "";
     const fIdx = args.indexOf("-f");
@@ -87,6 +107,8 @@ const execMock = vi.fn((...fnArgs: any[]) => {
  * can succeed. `unref` is asserted on: forgetting it would keep the request's
  * event loop tied to a process that runs for up to 300s.
  */
+/** `then` commands that if-shell actually dispatched. */
+const ifShellRan: string[] = [];
 const spawnCalls: { cmd: string; opts: any; unrefCalled: boolean }[] = [];
 const spawnMock = vi.fn((cmd: string, _args: string[], opts: any) => {
   const record = { cmd, opts, unrefCalled: false };
@@ -143,6 +165,7 @@ beforeEach(() => {
   sessionPanes = [["%1", "orchestrator"]];
   launcherOutcome = "starts-orchestrator";
   spawnCalls.length = 0;
+  ifShellRan.length = 0;
   execFileMock.mockClear();
   execMock.mockClear();
   spawnMock.mockClear();
@@ -320,9 +343,7 @@ describe("default-session-only endpoints ignore session fields", () => {
     const { status, body } = await post("/restart-session");
     expect(status).toBe(200);
     expect(body.path).toBe("respawned-tagged-pane");
-    expect(execFileCalls.find((c) => c.args[0] === "respawn-pane")?.args).toEqual([
-      "respawn-pane", "-k", "-t", "%183",
-    ]);
+    expect(ifShellRan).toEqual(["respawn-pane -k -t %183"]);
     // tmux does the exact match; we only ever receive pane ids.
     expect(execFileCalls.find((c) => c.args[0] === "list-panes")?.args).toEqual([
       "list-panes", "-s", "-t", `=${TMUX_SESSION}`,
@@ -348,7 +369,7 @@ describe("default-session-only endpoints ignore session fields", () => {
 
     const { body } = await post("/restart-session");
     // No exact-role pane => nothing to respawn => cold start, not a mis-parse.
-    expect(execFileCalls.some((c) => c.args[0] === "respawn-pane")).toBe(false);
+    expect(ifShellRan).toHaveLength(0);
     expect(body.path).toBe("cold-started-fresh");
   });
 
@@ -384,9 +405,40 @@ describe("default-session-only endpoints ignore session fields", () => {
       expect(status).toBe(200);
       expect(body.path).toBe("respawned-tagged-pane");
     }
-    expect(execFileCalls.filter((c) => c.args[0] === "respawn-pane").map((c) => c.args[3]))
-      .toEqual(["%183", "%183", "%183"]);
+    expect(ifShellRan).toEqual([
+      "respawn-pane -k -t %183", "respawn-pane -k -t %183", "respawn-pane -k -t %183",
+    ]);
     expect(spawnCalls).toHaveLength(0); // never falls through to a cold start
+  });
+
+  /**
+   * codex r4 HIGH — the fifth wrong-action bug. The role check goes stale:
+   * `respawn-pane -k -t %183` kills by pane id and never re-reads the tag, so a
+   * pane that stopped qualifying between lookup and respawn got killed anyway,
+   * ok:true. Verified live: revoking @cpc-role then respawning by id still
+   * killed the pane — the old comment's claim that tmux would error was false.
+   *
+   * `if-shell -F` re-evaluates the role inside tmux's own command queue, so it
+   * cannot go stale. It exits 0 either way, hence the else-branch marker: a
+   * silent refusal would otherwise be reported as a successful restart.
+   */
+  it("/restart-session does not kill a pane that stopped claiming the role after lookup", async () => {
+    existingSessions.add(TMUX_SESSION);
+    sessionPanes = [["%183", "orchestrator"]];
+
+    // The role is revoked after orchestratorPane() resolves but before respawn —
+    // the TOCTOU window. list-panes still reports %183; if-shell must not fire.
+    const original = execFileMock.getMockImplementation()!;
+    execFileMock.mockImplementation(((...a: any[]) => {
+      const out = original(...a);
+      if (a[1]?.[0] === "list-panes") sessionPanes = [["%183", "revoked"]];
+      return out;
+    }) as any);
+
+    const { status, body } = await post("/restart-session");
+    expect(ifShellRan).toHaveLength(0);            // never killed it
+    expect(status).toBe(500);
+    expect(body.error).toMatch(/stopped claiming @cpc-role/);
   });
 
   it("/restart-session refuses to guess when two panes claim the role", async () => {
@@ -396,7 +448,7 @@ describe("default-session-only endpoints ignore session fields", () => {
     const { status, body } = await post("/restart-session");
     expect(status).toBe(500);
     expect(body.error).toMatch(/ambiguous: 2 panes claim/);
-    expect(execFileCalls.some((c) => c.args[0] === "respawn-pane")).toBe(false);
+    expect(ifShellRan).toHaveLength(0);
     expect(spawnCalls).toHaveLength(0);
   });
 
@@ -415,7 +467,7 @@ describe("default-session-only endpoints ignore session fields", () => {
 
     const { status, body } = await post("/restart-session");
     expect(status).toBe(200);
-    expect(execFileCalls.some((c) => c.args[0] === "respawn-pane")).toBe(false);
+    expect(ifShellRan).toHaveLength(0);
     expect(body.path).toBe("cold-started-fresh");
     expect(spawnCalls).toHaveLength(1);
   });
@@ -446,6 +498,7 @@ describe("default-session-only endpoints ignore session fields", () => {
     // 300s loop; and create-only — a cold start must never kill anything.
     expect(spawnCalls[0]?.opts?.detached).toBe(true);
     expect(spawnCalls[0]?.unrefCalled).toBe(true);
+    expect(ifShellRan).toHaveLength(0);
     expect(execFileCalls.some((c) => ["respawn-pane", "kill-session", "kill-pane"].includes(c.args[0]!))).toBe(false);
   });
 
@@ -476,6 +529,7 @@ describe("default-session-only endpoints ignore session fields", () => {
     expect(status).toBe(500);
     expect(body.error).toMatch(/did not produce an orchestrator pane/);
     // Never kills the bystander to force a cold start.
+    expect(ifShellRan).toHaveLength(0);
     expect(execFileCalls.some((c) => ["respawn-pane", "kill-session", "kill-pane"].includes(c.args[0]!))).toBe(false);
   }, 15_000);
 });

--- a/apps/server/src/routes/__tests__/slash-commands-session.test.ts
+++ b/apps/server/src/routes/__tests__/slash-commands-session.test.ts
@@ -16,20 +16,26 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
  *     with NO existence probe.
  *
  * Also: /restart-session and /resize-terminal remain default-session-only —
- * they ignore a `session` field entirely (never retarget). /restart-session
- * does probe the DEFAULT session, to pick between respawning its live pane
- * and cold-starting via cw-launch (WORLD-415); that probe never touches a
- * client-supplied name.
+ * they ignore a `session` field entirely (never retarget).
+ *
+ * /restart-session (WORLD-415) finds the orchestrator by ROLE — the pane
+ * cw-launch tags `@cpc-role=orchestrator` — and never by position, because
+ * `renumber-windows` is on and indices are reassigned when a window dies. It
+ * respawns that pane if present, else cold-starts via cw-launch. Neither the
+ * role lookup nor the cold start ever touches a client-supplied name, and
+ * neither ever kills a pane it cannot identify.
  */
 
 const execFileCalls: { cmd: string; args: string[] }[] = [];
 const execCalls: string[] = [];
 /** Session names `tmux has-session` should report as existing. */
 let existingSessions = new Set<string>();
-/** [window_index, pane_index] pairs the fake tmux session contains. */
-let sessionPanes: [number, number][] = [[1, 1]];
-/** Which window the fake session currently has selected. */
-let selectedWindow = 1;
+/**
+ * Panes in the fake tmux session: [pane_id, @cpc-role]. An empty role is an
+ * untagged pane (an SSH tab, a split). Mirrors real tmux, where an unset pane
+ * option formats as the empty string.
+ */
+let sessionPanes: [string, string][] = [["%1", "orchestrator"]];
 
 const execFileMock = vi.fn((...fnArgs: any[]) => {
   const cmd = fnArgs[0] as string;
@@ -43,18 +49,17 @@ const execFileMock = vi.fn((...fnArgs: any[]) => {
       return { kill: () => {} } as any;
     }
   }
-  // Models real tmux (verified live, 3.5a): WITHOUT `-s`, `-t` is a WINDOW
-  // target and list-panes reports only the session's *currently selected*
-  // window — so a handler that omits `-s` resolves to whatever window a human
-  // last clicked. WITH `-s` it reports every pane in the session, in window
-  // order. `sessionPanes` is "window_index pane_index" pairs; the selected
-  // window is `selectedWindow`.
+  // Renders the requested -F fields per pane. Only the two formats the handler
+  // uses are modelled. An unset @cpc-role formats as "" (real tmux behaviour),
+  // which is what makes the "untagged panes must never be a candidate" tests
+  // meaningful.
   if (args[0] === "list-panes") {
-    const session = (args[args.indexOf("-t") + 1] || "").replace(/^=/, "");
-    const sessionWide = args.includes("-s");
-    const rows = sessionPanes
-      .filter(([w]) => sessionWide || w === selectedWindow)
-      .map(([w, p]) => `${w} ${p} ${session}:${w}.${p}`);
+    const format = args[args.indexOf("-F") + 1] || "";
+    const rows = sessionPanes.map(([paneId, role]) =>
+      format
+        .replace("#{@cpc-role}", role)
+        .replace("#{pane_id}", paneId),
+    );
     callback?.(null, { stdout: rows.join("\n") + (rows.length ? "\n" : ""), stderr: "" });
     return { kill: () => {} } as any;
   }
@@ -69,9 +74,31 @@ const execMock = vi.fn((...fnArgs: any[]) => {
   return { kill: () => {} } as any;
 });
 
+/**
+ * Cold start spawns the launcher detached. The fake launcher does what the real
+ * one does — makes the session exist — so `coldStartDetached`'s confirm poll
+ * can succeed. `unref` is asserted on: forgetting it would keep the request's
+ * event loop tied to a process that runs for up to 300s.
+ */
+const spawnCalls: { cmd: string; opts: any; unrefCalled: boolean }[] = [];
+const spawnMock = vi.fn((cmd: string, _args: string[], opts: any) => {
+  const record = { cmd, opts, unrefCalled: false };
+  spawnCalls.push(record);
+  if (launcherOutcome === "starts-orchestrator") {
+    existingSessions.add(TMUX_SESSION);
+    sessionPanes = [["%200", "orchestrator"]];
+  } else if (launcherOutcome === "noop-session-occupied") {
+    // cw-launch is attach-or-start: a live session means "nothing to do", so an
+    // occupied-but-orchestrator-less session gets NO new orchestrator.
+    existingSessions.add(TMUX_SESSION);
+  }
+  return { unref: () => { record.unrefCalled = true; } } as any;
+});
+let launcherOutcome: "starts-orchestrator" | "noop-session-occupied" | "fails" = "starts-orchestrator";
+
 vi.mock("node:child_process", async () => {
   const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
-  return { ...actual, execFile: execFileMock, exec: execMock };
+  return { ...actual, execFile: execFileMock, exec: execMock, spawn: spawnMock };
 });
 
 vi.mock("../utils.js", async () => {
@@ -91,10 +118,12 @@ beforeEach(() => {
   execFileCalls.length = 0;
   execCalls.length = 0;
   existingSessions = new Set();
-  sessionPanes = [[1, 1]];
-  selectedWindow = 1;
+  sessionPanes = [["%1", "orchestrator"]];
+  launcherOutcome = "starts-orchestrator";
+  spawnCalls.length = 0;
   execFileMock.mockClear();
   execMock.mockClear();
+  spawnMock.mockClear();
 });
 
 async function post(path: string, body?: unknown) {
@@ -252,58 +281,56 @@ describe("default-session-only endpoints ignore session fields", () => {
     expect(execCalls.some((cmd) => cmd.includes(`resize-window -t ${TMUX_SESSION}`))).toBe(true);
   });
 
-  it("/restart-session never retargets, and respawns the default session's own pane", async () => {
+  it("/restart-session never retargets: a client session field is ignored entirely", async () => {
     existingSessions.add(TMUX_SESSION);
-    const { status } = await post("/restart-session", { session: "do-box--lane-a" });
+    const { status, body } = await post("/restart-session", { session: "do-box--lane-a" });
     expect(status).toBe(200);
+    expect(body.path).toBe("respawned-tagged-pane");
     // The probe is the default session's own liveness check — never the client's.
     expect(probeCalls().map((c) => c.args)).toEqual([["has-session", "-t", `=${TMUX_SESSION}`]]);
     expect(execFileCalls.some((c) => c.args.some((a) => a.includes("do-box--lane-a")))).toBe(false);
+  });
+
+  it("/restart-session respawns the pane tagged @cpc-role=orchestrator, by pane id", async () => {
+    existingSessions.add(TMUX_SESSION);
+    sessionPanes = [["%9", ""], ["%183", "orchestrator"], ["%12", ""]];
+
+    const { status, body } = await post("/restart-session");
+    expect(status).toBe(200);
+    expect(body.path).toBe("respawned-tagged-pane");
     expect(execFileCalls.find((c) => c.args[0] === "respawn-pane")?.args).toEqual([
-      "respawn-pane", "-k", "-t", `${TMUX_SESSION}:1.1`,
+      "respawn-pane", "-k", "-t", "%183",
     ]);
-    // Pin the lookup argv: `-s` is load-bearing (see the multi-window test).
+    // Role lookup must be session-wide and ask for the role + pane id only.
     expect(execFileCalls.find((c) => c.args[0] === "list-panes")?.args).toEqual([
-      "list-panes",
-      "-s",
-      "-t", `=${TMUX_SESSION}`,
-      "-F", "#{window_index} #{pane_index} #{session_name}:#{window_index}.#{pane_index}",
+      "list-panes", "-s", "-t", `=${TMUX_SESSION}`, "-F", "#{@cpc-role} #{pane_id}",
     ]);
   });
 
   /**
-   * Regression for the pane-resolution bug (codex, PR #335 round 1). Without
-   * `-s`, tmux resolves `-t <session>` as a WINDOW target and reports only the
-   * selected window — so with an SSH tab open and focused, Restart respawned
-   * THAT pane: it killed an unrelated process, left the orchestrator running
-   * untouched, and still returned ok:true.
+   * PR #335 rounds 1+2 — both wrong-kill bugs in one assertion. Positional
+   * targeting killed a bystander (the selected window; then the SSH tab that
+   * inherited slot 1 after the orchestrator's window died) while the
+   * orchestrator went unrestarted and the call still returned ok:true.
+   * renumber-windows is ON globally, so index is never identity: an untagged
+   * pane must NEVER be a respawn candidate, whatever slot it occupies.
    */
-  it("/restart-session respawns the orchestrator's pane even when another window is selected", async () => {
+  it("/restart-session never kills an untagged pane — it cold-starts instead", async () => {
     existingSessions.add(TMUX_SESSION);
-    sessionPanes = [[1, 1], [2, 1]]; // window 2 = someone's SSH tab
-    selectedWindow = 2;
+    existingSessions.add(TMUX_SESSION);
+    sessionPanes = [["%77", ""]]; // orchestrator window died; only an SSH tab survives
 
-    const { status } = await post("/restart-session");
+    const { status, body } = await post("/restart-session");
     expect(status).toBe(200);
-    expect(execFileCalls.find((c) => c.args[0] === "respawn-pane")?.args).toEqual([
-      "respawn-pane", "-k", "-t", `${TMUX_SESSION}:1.1`,
-    ]);
-  });
-
-  it("/restart-session picks the lowest window/pane regardless of tmux's listing order", async () => {
-    existingSessions.add(TMUX_SESSION);
-    sessionPanes = [[3, 2], [1, 2], [1, 1]];
-    selectedWindow = 3;
-
-    await post("/restart-session");
-    expect(execFileCalls.find((c) => c.args[0] === "respawn-pane")?.args?.[3]).toBe(`${TMUX_SESSION}:1.1`);
+    expect(execFileCalls.some((c) => c.args[0] === "respawn-pane")).toBe(false);
+    expect(body.path).toBe("cold-started-fresh");
+    expect(spawnCalls).toHaveLength(1);
   });
 
   /**
    * WORLD-415 regression. The old handler killed the session and rebuilt the
    * claude command inline; that copy drifted from cw-launch and silently
-   * restarted the orchestrator into a week-old session. Respawning the pane
-   * re-runs the pane's OWN start command, so CPC never holds launch config.
+   * restarted the orchestrator into a week-old session.
    */
   it("/restart-session never reconstructs a claude launch command", async () => {
     existingSessions.add(TMUX_SESSION);
@@ -315,11 +342,47 @@ describe("default-session-only endpoints ignore session fields", () => {
     expect(issued).not.toContain("--continue");
   });
 
-  it("/restart-session falls back to the canonical launcher when the session is gone", async () => {
-    // existingSessions is empty → `has-session` fails → nothing to respawn.
-    const { status } = await post("/restart-session");
+  it("/restart-session cold-starts detached via the launcher when the session is gone", async () => {
+    // existingSessions empty → has-session fails → no pane can be tagged.
+    const { status, body } = await post("/restart-session");
     expect(status).toBe(200);
-    expect(execFileCalls.some((c) => c.cmd.endsWith("cw-launch"))).toBe(true);
-    expect(execFileCalls.some((c) => c.args[0] === "respawn-pane")).toBe(false);
+    expect(body.path).toBe("cold-started-fresh");
+    expect(spawnCalls).toHaveLength(1);
+    expect(spawnCalls[0]?.cmd.endsWith("cw-launch")).toBe(true);
+    // Detached + unref'd, or the request stays tethered to cw-boot-confirm's
+    // 300s loop; and create-only — a cold start must never kill anything.
+    expect(spawnCalls[0]?.opts?.detached).toBe(true);
+    expect(spawnCalls[0]?.unrefCalled).toBe(true);
+    expect(execFileCalls.some((c) => ["respawn-pane", "kill-session", "kill-pane"].includes(c.args[0]!))).toBe(false);
   });
+
+  // Deliberately outlasts COLD_START_CONFIRM_MS (5s): this test exercises the
+  // real confirm poll expiring, so it needs more headroom than vitest's default.
+  it("/restart-session reports 500 when the launcher never starts anything", async () => {
+    launcherOutcome = "fails";
+    const { status, body } = await post("/restart-session");
+    expect(status).toBe(500);
+    expect(body.ok).toBe(false);
+    expect(body.error).toMatch(/did not produce an orchestrator pane/);
+  }, 15_000);
+
+  /**
+   * Confirming a cold start on SESSION existence would report a phantom
+   * success here: cw-launch is attach-or-start, so an occupied session with no
+   * orchestrator makes it no-op and start nothing — while `has-session` says
+   * true the whole time. Observed live before the confirm was tightened:
+   * `{"path":"cold-started-fresh"}` with no orchestrator pane in existence.
+   * The confirm must check the TAGGED PANE, and this case must fail loudly.
+   */
+  it("/restart-session does not report a phantom cold start when the session is occupied but orchestrator-less", async () => {
+    existingSessions.add(TMUX_SESSION);
+    sessionPanes = [["%77", ""]];      // SSH tab holding the session open
+    launcherOutcome = "noop-session-occupied";
+
+    const { status, body } = await post("/restart-session");
+    expect(status).toBe(500);
+    expect(body.error).toMatch(/did not produce an orchestrator pane/);
+    // Never kills the bystander to force a cold start.
+    expect(execFileCalls.some((c) => ["respawn-pane", "kill-session", "kill-pane"].includes(c.args[0]!))).toBe(false);
+  }, 15_000);
 });

--- a/apps/server/src/routes/__tests__/slash-commands-session.test.ts
+++ b/apps/server/src/routes/__tests__/slash-commands-session.test.ts
@@ -55,14 +55,18 @@ const execFileMock = vi.fn((...fnArgs: any[]) => {
   // meaningful.
   if (args[0] === "list-panes") {
     const format = args[args.indexOf("-F") + 1] || "";
-    const rows = sessionPanes.map(([paneId, role]) =>
-      // Substitute verbatim, exactly as tmux does — including role values that
-      // contain spaces. Faithfulness here is the point: a role-first format
-      // mis-parses such a value, and this mock must be able to expose that.
-      format
-        .replace("#{@cpc-role}", role)
-        .replace("#{pane_id}", paneId),
-    );
+    const fIdx = args.indexOf("-f");
+    const filter = fIdx === -1 ? null : args[fIdx + 1] || "";
+    // Model tmux's `-f '#{==:#{@cpc-role},X}'`: an EXACT comparison of the raw
+    // option value. No trimming, no normalisation — a role of "orchestrator "
+    // is simply not equal to "orchestrator". That exactness is the whole point:
+    // client-side parsing kept smuggling near-misses through.
+    const match = filter?.match(/^#\{==:#\{@cpc-role\},(.*)\}$/);
+    const rows = sessionPanes
+      .filter(([, role]) => (match ? role === match[1] : true))
+      .map(([paneId, role]) =>
+        format.replace("#{@cpc-role}", role).replace("#{pane_id}", paneId),
+      );
     callback?.(null, { stdout: rows.join("\n") + (rows.length ? "\n" : ""), stderr: "" });
     return { kill: () => {} } as any;
   }
@@ -87,17 +91,32 @@ const spawnCalls: { cmd: string; opts: any; unrefCalled: boolean }[] = [];
 const spawnMock = vi.fn((cmd: string, _args: string[], opts: any) => {
   const record = { cmd, opts, unrefCalled: false };
   spawnCalls.push(record);
-  if (launcherOutcome === "starts-orchestrator") {
-    existingSessions.add(TMUX_SESSION);
-    sessionPanes = [["%200", "orchestrator"]];
-  } else if (launcherOutcome === "noop-session-occupied") {
-    // cw-launch is attach-or-start: a live session means "nothing to do", so an
-    // occupied-but-orchestrator-less session gets NO new orchestrator.
-    existingSessions.add(TMUX_SESSION);
-  }
-  return { unref: () => { record.unrefCalled = true; } } as any;
+  const handlers: Record<string, ((arg?: any) => void)[]> = {};
+  const child: any = {
+    unref: () => { record.unrefCalled = true; },
+    once: (ev: string, fn: (arg?: any) => void) => { (handlers[ev] ||= []).push(fn); return child; },
+  };
+  // Real spawn signals success/failure ASYNCHRONOUSLY, via 'spawn'/'error' —
+  // it does not throw. Modelling that is what lets the missing-binary test
+  // prove we attach a listener instead of crashing the process.
+  queueMicrotask(() => {
+    if (launcherOutcome === "spawn-error") {
+      handlers["error"]?.forEach((fn) => fn(Object.assign(new Error("spawn ENOENT"), { code: "ENOENT" })));
+      return;
+    }
+    if (launcherOutcome === "starts-orchestrator") {
+      existingSessions.add(TMUX_SESSION);
+      sessionPanes = [["%200", "orchestrator"]];
+    } else if (launcherOutcome === "noop-session-occupied") {
+      // cw-launch is attach-or-start: a live session means "nothing to do", so
+      // an occupied-but-orchestrator-less session gets NO new orchestrator.
+      existingSessions.add(TMUX_SESSION);
+    }
+    handlers["spawn"]?.forEach((fn) => fn());
+  });
+  return child;
 });
-let launcherOutcome: "starts-orchestrator" | "noop-session-occupied" | "fails" = "starts-orchestrator";
+let launcherOutcome: "starts-orchestrator" | "noop-session-occupied" | "fails" | "spawn-error" = "starts-orchestrator";
 
 vi.mock("node:child_process", async () => {
   const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
@@ -304,9 +323,10 @@ describe("default-session-only endpoints ignore session fields", () => {
     expect(execFileCalls.find((c) => c.args[0] === "respawn-pane")?.args).toEqual([
       "respawn-pane", "-k", "-t", "%183",
     ]);
-    // Session-wide, and pane_id FIRST — see the spaced-role test below.
+    // tmux does the exact match; we only ever receive pane ids.
     expect(execFileCalls.find((c) => c.args[0] === "list-panes")?.args).toEqual([
-      "list-panes", "-s", "-t", `=${TMUX_SESSION}`, "-F", "#{pane_id} #{@cpc-role}",
+      "list-panes", "-s", "-t", `=${TMUX_SESSION}`,
+      "-F", "#{pane_id}", "-f", "#{==:#{@cpc-role},orchestrator}",
     ]);
   });
 
@@ -317,15 +337,36 @@ describe("default-session-only endpoints ignore session fields", () => {
    * paneId="x". pane_id can never contain a space, so it must lead.
    * A role that merely starts with "orchestrator" is not the role.
    */
-  it("/restart-session does not treat a spaced role value as the orchestrator", async () => {
+  it.each([
+    ["a spaced value", "orchestrator x"],
+    ["a trailing space", "orchestrator "],   // codex r3 HIGH: line.trim() collapsed this into a match
+    ["a leading space", " orchestrator"],
+    ["a trailing tab", "orchestrator\t"],
+  ])("/restart-session does not treat %s as the orchestrator role", async (_label, role) => {
     existingSessions.add(TMUX_SESSION);
-    sessionPanes = [["%229", "orchestrator x"]];
+    sessionPanes = [["%229", role]];
 
     const { body } = await post("/restart-session");
     // No exact-role pane => nothing to respawn => cold start, not a mis-parse.
     expect(execFileCalls.some((c) => c.args[0] === "respawn-pane")).toBe(false);
     expect(body.path).toBe("cold-started-fresh");
   });
+
+  /**
+   * codex r3 MEDIUM. spawn() reports a missing/non-executable binary via an
+   * ASYNC 'error' event, not a throw. Unhandled, that is an uncaughtException
+   * and the whole CPC server dies — pressing Restart would kill the console
+   * itself. Verified against real node: spawn("/nonexistent") reaches
+   * uncaughtException with ENOENT. Must be a clean 500 for the one request.
+   */
+  it("/restart-session surfaces a launcher spawn error as a 500 instead of crashing the server", async () => {
+    launcherOutcome = "spawn-error";
+    const { status, body } = await post("/restart-session");
+    expect(status).toBe(500);
+    expect(body.ok).toBe(false);
+    expect(body.error).toMatch(/cannot launch/);
+    expect(body.error).toMatch(/ENOENT|spawn/);
+  }, 15_000);
 
   it("/restart-session refuses to guess when two panes claim the role", async () => {
     existingSessions.add(TMUX_SESSION);

--- a/apps/server/src/routes/__tests__/slash-commands-session.test.ts
+++ b/apps/server/src/routes/__tests__/slash-commands-session.test.ts
@@ -26,6 +26,10 @@ const execFileCalls: { cmd: string; args: string[] }[] = [];
 const execCalls: string[] = [];
 /** Session names `tmux has-session` should report as existing. */
 let existingSessions = new Set<string>();
+/** [window_index, pane_index] pairs the fake tmux session contains. */
+let sessionPanes: [number, number][] = [[1, 1]];
+/** Which window the fake session currently has selected. */
+let selectedWindow = 1;
 
 const execFileMock = vi.fn((...fnArgs: any[]) => {
   const cmd = fnArgs[0] as string;
@@ -39,11 +43,19 @@ const execFileMock = vi.fn((...fnArgs: any[]) => {
       return { kill: () => {} } as any;
     }
   }
-  // Mirrors real tmux: `list-panes -F '#{session_name}:#{window_index}.#{pane_index}'`
-  // prints one target line per matching pane (base-index is 1 on this host).
+  // Models real tmux (verified live, 3.5a): WITHOUT `-s`, `-t` is a WINDOW
+  // target and list-panes reports only the session's *currently selected*
+  // window — so a handler that omits `-s` resolves to whatever window a human
+  // last clicked. WITH `-s` it reports every pane in the session, in window
+  // order. `sessionPanes` is "window_index pane_index" pairs; the selected
+  // window is `selectedWindow`.
   if (args[0] === "list-panes") {
-    const target = (args[args.indexOf("-t") + 1] || "").replace(/^=/, "");
-    callback?.(null, { stdout: `${target}:1.1\n`, stderr: "" });
+    const session = (args[args.indexOf("-t") + 1] || "").replace(/^=/, "");
+    const sessionWide = args.includes("-s");
+    const rows = sessionPanes
+      .filter(([w]) => sessionWide || w === selectedWindow)
+      .map(([w, p]) => `${w} ${p} ${session}:${w}.${p}`);
+    callback?.(null, { stdout: rows.join("\n") + (rows.length ? "\n" : ""), stderr: "" });
     return { kill: () => {} } as any;
   }
   callback?.(null, { stdout: "", stderr: "" });
@@ -79,6 +91,8 @@ beforeEach(() => {
   execFileCalls.length = 0;
   execCalls.length = 0;
   existingSessions = new Set();
+  sessionPanes = [[1, 1]];
+  selectedWindow = 1;
   execFileMock.mockClear();
   execMock.mockClear();
 });
@@ -248,14 +262,41 @@ describe("default-session-only endpoints ignore session fields", () => {
     expect(execFileCalls.find((c) => c.args[0] === "respawn-pane")?.args).toEqual([
       "respawn-pane", "-k", "-t", `${TMUX_SESSION}:1.1`,
     ]);
-    // Pin the lookup argv: without `-f #{pane_active}` a multi-pane session
-    // lists every pane and we would respawn whichever sorted first.
+    // Pin the lookup argv: `-s` is load-bearing (see the multi-window test).
     expect(execFileCalls.find((c) => c.args[0] === "list-panes")?.args).toEqual([
       "list-panes",
+      "-s",
       "-t", `=${TMUX_SESSION}`,
-      "-F", "#{session_name}:#{window_index}.#{pane_index}",
-      "-f", "#{pane_active}",
+      "-F", "#{window_index} #{pane_index} #{session_name}:#{window_index}.#{pane_index}",
     ]);
+  });
+
+  /**
+   * Regression for the pane-resolution bug (codex, PR #335 round 1). Without
+   * `-s`, tmux resolves `-t <session>` as a WINDOW target and reports only the
+   * selected window — so with an SSH tab open and focused, Restart respawned
+   * THAT pane: it killed an unrelated process, left the orchestrator running
+   * untouched, and still returned ok:true.
+   */
+  it("/restart-session respawns the orchestrator's pane even when another window is selected", async () => {
+    existingSessions.add(TMUX_SESSION);
+    sessionPanes = [[1, 1], [2, 1]]; // window 2 = someone's SSH tab
+    selectedWindow = 2;
+
+    const { status } = await post("/restart-session");
+    expect(status).toBe(200);
+    expect(execFileCalls.find((c) => c.args[0] === "respawn-pane")?.args).toEqual([
+      "respawn-pane", "-k", "-t", `${TMUX_SESSION}:1.1`,
+    ]);
+  });
+
+  it("/restart-session picks the lowest window/pane regardless of tmux's listing order", async () => {
+    existingSessions.add(TMUX_SESSION);
+    sessionPanes = [[3, 2], [1, 2], [1, 1]];
+    selectedWindow = 3;
+
+    await post("/restart-session");
+    expect(execFileCalls.find((c) => c.args[0] === "respawn-pane")?.args?.[3]).toBe(`${TMUX_SESSION}:1.1`);
   });
 
   /**

--- a/apps/server/src/routes/terminal/slash-commands.ts
+++ b/apps/server/src/routes/terminal/slash-commands.ts
@@ -7,7 +7,42 @@ import { SpanStatusCode } from "@opentelemetry/api";
 
 const execFileAsync = promisify(execFile);
 
+const TMUX_TIMEOUT_MS = 5_000;
+// cw-launch creates the session and then execs cw-boot-confirm, which waits on
+// the fresh agent's boot dialog — slower than a plain tmux call.
+const LAUNCHER_TIMEOUT_MS = 30_000;
+
+// The canonical orchestrator launcher (attach-or-start). CPC must never
+// reconstruct the claude command itself: the previous hardcoded copy silently
+// drifted from cw-launch (wrong cwd, retired channel plugin, no WOS_* env) and
+// shipped restarts into a stale session for weeks (WORLD-415). Only the
+// launcher's own definition is authoritative. Absolute by default because the
+// systemd unit's PATH does not include claudes-world/bin.
+const CW_LAUNCH = process.env.CW_LAUNCH_BIN || "/home/claude/claudes-world/bin/cw-launch";
+
 const tmuxTracer = getTracer('cpc-server-tmux');
+
+/**
+ * Resolve a session to its active pane as an explicit `session:window.pane`
+ * target. `respawn-pane` rejects a bare session name, and base-index /
+ * pane-base-index are user config (both are 1 on this host, but reading them
+ * back beats assuming), so ask tmux for the real indices.
+ */
+async function activePaneTarget(session: string): Promise<string> {
+  const { stdout } = await execFileAsync(
+    "tmux",
+    [
+      "list-panes",
+      "-t", `=${session}`,
+      "-F", "#{session_name}:#{window_index}.#{pane_index}",
+      "-f", "#{pane_active}",
+    ],
+    { timeout: TMUX_TIMEOUT_MS },
+  );
+  const target = stdout.split("\n")[0]?.trim();
+  if (!target) throw new Error(`no active pane in tmux session ${session}`);
+  return target;
+}
 
 async function tracedTmux<T>(
   spanName: string,
@@ -66,9 +101,11 @@ const RAW_KEY_TOKEN = /^[A-Za-z][A-Za-z0-9_-]*$/;
  * session, by contrast, must exist before we send keys anywhere near it.
  *
  * NOT wired into /restart-session or /resize-terminal: those stay
- * default-session-only by design (restart recreates the orchestrator
- * launch command; resize has the window-size latch side effect) — the
- * palette never offers them for other sessions.
+ * default-session-only by design (restart respawns the orchestrator's own
+ * pane, and falls back to the orchestrator-specific cw-launch; resize has
+ * the window-size latch side effect) — the palette never offers them for
+ * other sessions, and the UI hides them while a non-default session is
+ * being viewed (ActionBar.tsx, `restrictedSession`).
  */
 async function resolvePaletteTarget(c: any, body: any): Promise<{ session: string } | { response: Response }> {
   const target = resolveTargetSession(body?.session);
@@ -206,14 +243,13 @@ app.post("/reload-plugins", async (c) => {
 app.post("/restart-session", async (c) => {
   try {
     await tracedTmux('tmux.restart-session', TMUX_SESSION, 'restart-session', async () => {
-      // Kill existing tmux session, then recreate using the same command as the cw alias
-      await execAsync(`tmux kill-session -t ${TMUX_SESSION} 2>/dev/null || true`, { shell: "/bin/bash" });
-      // Match the cw alias exactly: tmux new-session with the full claude command
-      const cmd = [
-        `tmux new-session -d -s ${TMUX_SESSION}`,
-        `"cd ~/claudes-world && TZ=America/New_York claude --dangerously-skip-permissions --continue --channels plugin:telegram@claude-plugins-official"`,
-      ].join(" ");
-      await execAsync(cmd, { shell: "/bin/bash" });
+      if (await tmuxSessionExists(TMUX_SESSION)) {
+        await execFileAsync("tmux", ["respawn-pane", "-k", "-t", await activePaneTarget(TMUX_SESSION)], {
+          timeout: TMUX_TIMEOUT_MS,
+        });
+        return;
+      }
+      await execFileAsync(CW_LAUNCH, [], { timeout: LAUNCHER_TIMEOUT_MS });
     });
     return c.json({ ok: true, action: "restart-session" });
   } catch (err: any) {

--- a/apps/server/src/routes/terminal/slash-commands.ts
+++ b/apps/server/src/routes/terminal/slash-commands.ts
@@ -47,8 +47,10 @@ const tmuxTracer = getTracer('cpc-server-tmux');
  * running, whatever the session's own liveness says. A session outlives its
  * windows: an SSH tab alone keeps it alive after the agent's window is gone.
  *
- * Pane ids are used deliberately: they are stable for a pane's whole life and
- * are never reused or renumbered, unlike `session:window.pane`.
+ * Pane ids are used deliberately: unlike `session:window.pane` they are stable
+ * for a pane's whole life and are not reused. Verified on tmux 3.5a — the
+ * counter is monotonic (killing %260 gave the next pane %261, not %260), and a
+ * respawn keeps the id (%259 -> %259). Stated because the design leans on it.
  */
 async function orchestratorPane(session: string): Promise<string | null> {
   const { stdout } = await execFileAsync(

--- a/apps/server/src/routes/terminal/slash-commands.ts
+++ b/apps/server/src/routes/terminal/slash-commands.ts
@@ -64,6 +64,12 @@ async function orchestratorPane(session: string): Promise<string | null> {
       // match, promoting a NON-orchestrator pane into a respawn candidate).
       // `#{==:...}` compares the raw value, so none of that is reachable, and
       // pane ids can't be mis-parsed.
+      //
+      // It also means the untrusted value never reaches our stdout at all, so
+      // it cannot inject. Verified against tmux 3.5a, with the value set to:
+      // `#{pane_id}` (renders literally — tmux does not re-expand option
+      // values), an embedded newline (no extra output line), and `#{==:1,1}`
+      // (no match). In every case only the genuinely-tagged pane came back.
       "-F", "#{pane_id}",
       "-f", `#{==:#{@cpc-role},${ORCHESTRATOR_ROLE}}`,
     ],

--- a/apps/server/src/routes/terminal/slash-commands.ts
+++ b/apps/server/src/routes/terminal/slash-commands.ts
@@ -94,6 +94,60 @@ async function orchestratorPane(session: string): Promise<string | null> {
   return tagged[0]?.paneId ?? null;
 }
 
+/** tmux pane ids are `%<n>`. Validated before being interpolated into a tmux
+ *  command STRING below (they come from tmux, not a client — this is a fence,
+ *  not a fix for a known hole). */
+const PANE_ID_RE = /^%\d+$/;
+/** Printed by the else-branch when the role no longer matches at respawn time. */
+const ROLE_CHANGED_MARKER = "cpc-role-changed";
+
+/**
+ * Respawn the pane ONLY if it still claims the role, re-checked inside tmux's
+ * own command queue so there is no window between the check and the kill.
+ *
+ * The obvious `respawn-pane -k -t %183` is wrong, and an earlier comment here
+ * claimed a safety property that does not exist: a stale pane id does NOT make
+ * tmux error, because respawn-pane never looks at the tag. Verified — revoking
+ * @cpc-role and then respawning by id killed the pane anyway. That is a fifth
+ * way to kill something that no longer qualifies and still return ok:true
+ * (codex round 4 HIGH), and it is the same false-proxy shape as the rest: an
+ * authorization decision that goes stale before the action it authorizes.
+ *
+ * `if-shell -F` evaluates the format and dispatches within one command queue,
+ * so the role is true at the instant of the respawn. It exits 0 either way, so
+ * the else-branch prints a marker — otherwise a refusal would read as success.
+ *
+ * KNOWN GAP, accepted deliberately (codex round 4 MEDIUM): a successful respawn
+ * proves tmux started the command, not that it stayed up. If the replayed
+ * command dies immediately we still report respawned-tagged-pane. cw-launch's
+ * `... || <fresh>` fallback covers the first command failing but not the
+ * fallback itself. A stabilization window (re-check the pane is present, still
+ * tagged, and not #{pane_dead} after ~a second) would close it without waiting
+ * for a full boot — deliberately NOT added here: it changes the endpoint's
+ * timing and is worth a decision rather than a silent addition. Flagged
+ * in-thread; the failure it leaves needs a human either way.
+ */
+async function respawnIfStillOrchestrator(pane: string): Promise<void> {
+  if (!PANE_ID_RE.test(pane)) throw new Error(`refusing to respawn a non-pane-id target: ${pane}`);
+  const { stdout } = await execFileAsync(
+    "tmux",
+    [
+      "if-shell",
+      "-F",
+      "-t", pane,
+      `#{==:#{@cpc-role},${ORCHESTRATOR_ROLE}}`,
+      `respawn-pane -k -t ${pane}`,
+      `display-message -p ${ROLE_CHANGED_MARKER}`,
+    ],
+    { timeout: TMUX_TIMEOUT_MS },
+  );
+  if (stdout.includes(ROLE_CHANGED_MARKER)) {
+    throw new Error(
+      `${pane} stopped claiming @cpc-role=${ORCHESTRATOR_ROLE} before the respawn — refusing to kill it`,
+    );
+  }
+}
+
 /**
  * COLD START — create-only, never destructive. Reached only when no pane claims
  * the orchestrator role, i.e. there is nothing qualifying to kill.
@@ -366,18 +420,7 @@ app.post("/restart-session", async (c) => {
         : null;
 
       if (pane) {
-        // Re-runs the pane's own creation-time command, keeping its cwd, its
-        // WOS_* env and any attached viewers.
-        //
-        // Two accepted gaps here (codex round 3). The lookup and the respawn are
-        // separate tmux calls, so the tag could in principle change in between —
-        // tmux would then error and surface a 500, which is the safe direction.
-        // And a successful respawn proves tmux ACCEPTED the command, not that
-        // the new process stayed up; cw-launch's own `... || <fresh>` fallback
-        // covers the realistic failure, and polling for liveness here would mean
-        // guessing how long a boot takes. Both are reported honestly rather than
-        // papered over.
-        await execFileAsync("tmux", ["respawn-pane", "-k", "-t", pane], { timeout: TMUX_TIMEOUT_MS });
+        await respawnIfStillOrchestrator(pane);
         return "respawned-tagged-pane" as const;
       }
 

--- a/apps/server/src/routes/terminal/slash-commands.ts
+++ b/apps/server/src/routes/terminal/slash-commands.ts
@@ -95,7 +95,16 @@ async function orchestratorPane(session: string): Promise<string | null> {
  * take the respawn branch, and never re-run boot-confirm. Unrecoverable without
  * SSH. So: detach, let boot-confirm finish on its own, and only wait long enough
  * to confirm the session actually came up. cw-launch is idempotent, so a racing
- * second press is harmless.
+ * second press is harmless (verified: two concurrent presses => one create, one
+ * no-op, one session, one tagged pane).
+ *
+ * Known limitation: detaching escapes the process group, not the cgroup, and
+ * cpc.service runs KillMode=control-group. So `systemctl restart cpc.service`
+ * inside boot-confirm's window SIGTERMs it mid-loop, leaving a session whose
+ * boot gates were never dismissed. The tmux server has its own cgroup, so the
+ * session itself survives. Narrow — it needs a CPC restart during a cold start —
+ * and escaping the cgroup properly would mean systemd-run --scope, which is not
+ * worth it here.
  */
 async function coldStartDetached(session: string): Promise<void> {
   const child = spawn(CW_LAUNCH, [], { detached: true, stdio: "ignore" });

--- a/apps/server/src/routes/terminal/slash-commands.ts
+++ b/apps/server/src/routes/terminal/slash-commands.ts
@@ -1,5 +1,5 @@
 import { Hono } from "hono";
-import { execFile } from "node:child_process";
+import { execFile, spawn } from "node:child_process";
 import { promisify } from "node:util";
 import { execAsync, resolveTargetSession, sendToTmux, tmuxSessionExists, TMUX_SESSION } from "../utils.js";
 import { getTracer } from "../../lib/otel.js";
@@ -8,9 +8,23 @@ import { SpanStatusCode } from "@opentelemetry/api";
 const execFileAsync = promisify(execFile);
 
 const TMUX_TIMEOUT_MS = 5_000;
-// cw-launch creates the session and then execs cw-boot-confirm, which waits on
-// the fresh agent's boot dialog — slower than a plain tmux call.
-const LAUNCHER_TIMEOUT_MS = 30_000;
+// How long to wait for a detached cold start to make the session appear.
+// cw-launch's `tmux new-session -d` returns near-instantly; we are NOT waiting
+// for the agent to finish booting (see COLD START below).
+const COLD_START_CONFIRM_MS = 5_000;
+const COLD_START_POLL_MS = 250;
+
+// The pane option cw-launch stamps on the orchestrator's pane at creation
+// (claudes-world abb7d11). This is the ONLY sanctioned way to find that pane.
+//
+// Never target it positionally. `renumber-windows` is on globally on this host,
+// so when a window dies the next one is promoted into its index: `session:1.1`
+// means "whatever currently occupies slot 1", not "the pane cw-launch created".
+// Two separate wrong-kill bugs came from positional targeting (PR #335 rounds
+// 1+2) — each killed a bystander pane, left the orchestrator running, and still
+// reported ok:true. Role lookup fails LOUD instead: no tagged pane means no
+// candidate, so we never -k something we cannot prove is the orchestrator.
+const ORCHESTRATOR_ROLE = "orchestrator";
 
 // The canonical orchestrator launcher (attach-or-start). CPC must never
 // reconstruct the claude command itself: the previous hardcoded copy silently
@@ -28,42 +42,67 @@ const CW_LAUNCH = process.env.CW_LAUNCH_BIN || "/home/claude/claudes-world/bin/c
 const tmuxTracer = getTracer('cpc-server-tmux');
 
 /**
- * Resolve the orchestrator's pane to an explicit `session:window.pane` target.
- * `respawn-pane` rejects a bare session name, so a concrete target is required.
+ * Find the orchestrator's pane by ROLE. Returns its unique pane id (`%183`),
+ * or null when no pane claims the role — which means the orchestrator is not
+ * running, whatever the session's own liveness says. A session outlives its
+ * windows: an SSH tab alone keeps it alive after the agent's window is gone.
  *
- * The pane we want is the one cw-launch created: the session's FIRST window,
- * first pane. Do NOT use the *active* pane — `list-panes -t "=<session>"`
- * without `-s` treats the target as a WINDOW and returns whichever window is
- * currently selected. If anyone has a second window open in this session (an
- * SSH tab, a split) and left it selected, that resolves to their pane, and
- * `respawn-pane -k` would kill THEIR process while reporting success and
- * leaving the orchestrator untouched. `-s` lists the whole session instead;
- * sort by (window, pane) so the result never depends on what a human last
- * clicked, nor on base-index / pane-base-index.
+ * Pane ids are used deliberately: they are stable for a pane's whole life and
+ * are never reused or renumbered, unlike `session:window.pane`.
  */
-async function orchestratorPaneTarget(session: string): Promise<string> {
+async function orchestratorPane(session: string): Promise<string | null> {
   const { stdout } = await execFileAsync(
     "tmux",
-    [
-      "list-panes",
-      "-s",
-      "-t", `=${session}`,
-      "-F", "#{window_index} #{pane_index} #{session_name}:#{window_index}.#{pane_index}",
-    ],
+    ["list-panes", "-s", "-t", `=${session}`, "-F", "#{@cpc-role} #{pane_id}"],
     { timeout: TMUX_TIMEOUT_MS },
   );
-  const panes = stdout
+  const tagged = stdout
     .split("\n")
-    .map((line) => line.trim())
-    .filter(Boolean)
-    .map((line) => {
-      const [windowIndex, paneIndex, target] = line.split(" ");
-      return { windowIndex: Number(windowIndex), paneIndex: Number(paneIndex), target };
-    })
-    .filter((p) => Number.isFinite(p.windowIndex) && Number.isFinite(p.paneIndex) && p.target);
-  if (panes.length === 0) throw new Error(`no panes in tmux session ${session}`);
-  panes.sort((a, b) => a.windowIndex - b.windowIndex || a.paneIndex - b.paneIndex);
-  return panes[0]!.target!;
+    .map((line) => line.trim().split(" "))
+    .filter(([role, paneId]) => role === ORCHESTRATOR_ROLE && paneId)
+    .map(([, paneId]) => paneId!);
+  return tagged[0] ?? null;
+}
+
+/**
+ * COLD START — create-only, never destructive. Reached only when no pane claims
+ * the orchestrator role, i.e. there is nothing qualifying to kill.
+ *
+ * Detached on purpose. cw-launch ends with `exec cw-boot-confirm`, which polls
+ * for up to 300s dismissing boot dialogs and injecting the kickoff. Holding the
+ * HTTP request open for that is untenable, and killing it on a timeout is worse:
+ * `tmux new-session -d` has already succeeded by then, so we would strand a
+ * half-booted session behind a dialog — and a retry would find the session live,
+ * take the respawn branch, and never re-run boot-confirm. Unrecoverable without
+ * SSH. So: detach, let boot-confirm finish on its own, and only wait long enough
+ * to confirm the session actually came up. cw-launch is idempotent, so a racing
+ * second press is harmless.
+ */
+async function coldStartDetached(session: string): Promise<void> {
+  const child = spawn(CW_LAUNCH, [], { detached: true, stdio: "ignore" });
+  child.unref();
+
+  // Confirm on the TAGGED PANE, never on the session. The session existing does
+  // not mean the orchestrator is running — that false proxy is the whole bug
+  // this endpoint keeps re-learning. It bites here specifically: cw-launch is
+  // attach-or-start, so if the session is alive but the orchestrator's window
+  // died (an SSH tab holding it open), cw-launch no-ops and starts nothing. A
+  // session-existence check would call that success and report a cold start
+  // that never happened.
+  const deadline = Date.now() + COLD_START_CONFIRM_MS;
+  while (Date.now() < deadline) {
+    if ((await tmuxSessionExists(session)) && (await orchestratorPane(session))) return;
+    await new Promise((resolve) => setTimeout(resolve, COLD_START_POLL_MS));
+  }
+  // Honest failure. The common cause is the case above: an occupied session
+  // with no orchestrator. cw-launch cannot fix that without killing the
+  // session, and a restart must never kill panes it cannot identify — so this
+  // needs a human, and says so rather than reporting a phantom success.
+  throw new Error(
+    `cold start did not produce an orchestrator pane in tmux session ${session}` +
+      ` (if the session is alive but has no @cpc-role=${ORCHESTRATOR_ROLE} pane,` +
+      ` cw-launch will no-op — recover it manually)`,
+  );
 }
 
 async function tracedTmux<T>(
@@ -264,16 +303,27 @@ app.post("/reload-plugins", async (c) => {
 
 app.post("/restart-session", async (c) => {
   try {
-    await tracedTmux('tmux.restart-session', TMUX_SESSION, 'restart-session', async () => {
-      if (await tmuxSessionExists(TMUX_SESSION)) {
-        await execFileAsync("tmux", ["respawn-pane", "-k", "-t", await orchestratorPaneTarget(TMUX_SESSION)], {
-          timeout: TMUX_TIMEOUT_MS,
-        });
-        return;
+    const path = await tracedTmux('tmux.restart-session', TMUX_SESSION, 'restart-session', async () => {
+      // Ask for the role-tagged pane, not the session: the session can outlive
+      // the orchestrator's own window, so its liveness proves nothing here.
+      const pane = (await tmuxSessionExists(TMUX_SESSION))
+        ? await orchestratorPane(TMUX_SESSION)
+        : null;
+
+      if (pane) {
+        // Re-runs the pane's own creation-time command, keeping its cwd, its
+        // WOS_* env and any attached viewers.
+        await execFileAsync("tmux", ["respawn-pane", "-k", "-t", pane], { timeout: TMUX_TIMEOUT_MS });
+        return "respawned-tagged-pane" as const;
       }
-      await execFileAsync(CW_LAUNCH, [], { timeout: LAUNCHER_TIMEOUT_MS });
+
+      await coldStartDetached(TMUX_SESSION);
+      return "cold-started-fresh" as const;
     });
-    return c.json({ ok: true, action: "restart-session" });
+    // Report WHICH path ran: the two outcomes differ enough that the UI must
+    // not present them identically — a cold start is a brand-new session, not
+    // a resumed one.
+    return c.json({ ok: true, action: "restart-session", path });
   } catch (err: any) {
     return c.json({ ok: false, error: err.message }, 500);
   }

--- a/apps/server/src/routes/terminal/slash-commands.ts
+++ b/apps/server/src/routes/terminal/slash-commands.ts
@@ -168,11 +168,23 @@ async function respawnIfStillOrchestrator(pane: string): Promise<void> {
  * half-booted session behind a dialog — and a retry would find the session live,
  * take the respawn branch, and never re-run boot-confirm. Unrecoverable without
  * SSH. So: detach, let boot-confirm finish on its own, and only wait long enough
- * to confirm the session actually came up. cw-launch is idempotent, so a racing
- * second press does no damage (verified: two concurrent presses => one create,
- * one no-op, one session, one tagged pane). It is not perfectly accurate,
- * though: both requests observe the winner's pane, so both report
- * "cold-started-fresh" while only one press caused it. Mis-attribution in a
+ * to confirm the session actually came up.
+ *
+ * A racing second press does no damage, but NOT via the mechanism you would
+ * assume. Under a true simultaneous race both launchers pass cw-launch's
+ * `has-session` guard before either creates, so the loser does NOT take the
+ * graceful "already running" branch — it hits `duplicate session` from tmux and
+ * dies on `set -e`, exit 1. That is invisible here on purpose: the launcher is
+ * spawned detached and its exit status is never read; success is judged solely
+ * by the tagged pane appearing. Verified over 5 forced races — every trial left
+ * exactly one session and exactly one tagged pane.
+ *
+ * (An earlier comment here claimed "one create, one no-op". That was wrong: the
+ * probe behind it wasn't actually racing, so the second launcher ran after the
+ * first had finished. Caught in review.)
+ *
+ * Both requests then observe the winner's pane and both report
+ * "cold-started-fresh" though only one press caused it. Mis-attribution in a
  * status string, not a mis-action — accepted.
  *
  * Known limitation: detaching escapes the process group, not the cgroup, and

--- a/apps/server/src/routes/terminal/slash-commands.ts
+++ b/apps/server/src/routes/terminal/slash-commands.ts
@@ -53,22 +53,27 @@ const tmuxTracer = getTracer('cpc-server-tmux');
 async function orchestratorPane(session: string): Promise<string | null> {
   const { stdout } = await execFileAsync(
     "tmux",
-    // pane_id FIRST: @cpc-role is a user-settable option whose value may contain
-    // spaces, so it has to be the trailing field or it shifts the parse. (With
-    // role first, `@cpc-role="orchestrator x"` yields paneId="x".) Pane ids never
-    // contain spaces, so token 0 is always unambiguous and the role is the rest.
-    ["list-panes", "-s", "-t", `=${session}`, "-F", "#{pane_id} #{@cpc-role}"],
+    [
+      "list-panes",
+      "-s",
+      "-t", `=${session}`,
+      // Let tmux do the comparison and hand back nothing but pane ids. Parsing
+      // the role here kept getting it wrong: @cpc-role is a user-settable value,
+      // so it could contain spaces (shifting a role-first split) or trailing
+      // whitespace (which a line-level trim() silently collapsed into an exact
+      // match, promoting a NON-orchestrator pane into a respawn candidate).
+      // `#{==:...}` compares the raw value, so none of that is reachable, and
+      // pane ids can't be mis-parsed.
+      "-F", "#{pane_id}",
+      "-f", `#{==:#{@cpc-role},${ORCHESTRATOR_ROLE}}`,
+    ],
     { timeout: TMUX_TIMEOUT_MS },
   );
   const tagged = stdout
     .split("\n")
     .map((line) => line.trim())
     .filter(Boolean)
-    .map((line) => {
-      const [paneId, ...role] = line.split(" ");
-      return { paneId, role: role.join(" ") };
-    })
-    .filter((p) => p.paneId && p.role === ORCHESTRATOR_ROLE);
+    .map((paneId) => ({ paneId }));
 
   // Ambiguity fails loud. Nothing legitimate produces two orchestrators in one
   // session — cw-launch tags exactly one pane and splits do not inherit pane
@@ -95,8 +100,11 @@ async function orchestratorPane(session: string): Promise<string | null> {
  * take the respawn branch, and never re-run boot-confirm. Unrecoverable without
  * SSH. So: detach, let boot-confirm finish on its own, and only wait long enough
  * to confirm the session actually came up. cw-launch is idempotent, so a racing
- * second press is harmless (verified: two concurrent presses => one create, one
- * no-op, one session, one tagged pane).
+ * second press does no damage (verified: two concurrent presses => one create,
+ * one no-op, one session, one tagged pane). It is not perfectly accurate,
+ * though: both requests observe the winner's pane, so both report
+ * "cold-started-fresh" while only one press caused it. Mis-attribution in a
+ * status string, not a mis-action — accepted.
  *
  * Known limitation: detaching escapes the process group, not the cgroup, and
  * cpc.service runs KillMode=control-group. So `systemctl restart cpc.service`
@@ -107,8 +115,21 @@ async function orchestratorPane(session: string): Promise<string | null> {
  * worth it here.
  */
 async function coldStartDetached(session: string): Promise<void> {
-  const child = spawn(CW_LAUNCH, [], { detached: true, stdio: "ignore" });
-  child.unref();
+  // spawn() reports a missing/non-executable binary ASYNCHRONOUSLY, via an
+  // 'error' event — it does not throw here. With no listener attached that
+  // event is an unhandled 'error', which by EventEmitter's contract becomes an
+  // uncaughtException and takes the WHOLE CPC server down — so a misconfigured
+  // CW_LAUNCH would turn Restart into "kill the console Liam is holding".
+  // Verified: `spawn("/nonexistent")` reaches uncaughtException with ENOENT.
+  // Wait for 'spawn' (success) or 'error' (clean 500) before unref'ing.
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn(CW_LAUNCH, [], { detached: true, stdio: "ignore" });
+    child.once("error", (err) => reject(new Error(`cannot launch ${CW_LAUNCH}: ${err.message}`)));
+    child.once("spawn", () => {
+      child.unref();
+      resolve();
+    });
+  });
 
   // Confirm on the TAGGED PANE, never on the session. The session existing does
   // not mean the orchestrator is running — that false proxy is the whole bug
@@ -341,6 +362,15 @@ app.post("/restart-session", async (c) => {
       if (pane) {
         // Re-runs the pane's own creation-time command, keeping its cwd, its
         // WOS_* env and any attached viewers.
+        //
+        // Two accepted gaps here (codex round 3). The lookup and the respawn are
+        // separate tmux calls, so the tag could in principle change in between —
+        // tmux would then error and surface a 500, which is the safe direction.
+        // And a successful respawn proves tmux ACCEPTED the command, not that
+        // the new process stayed up; cw-launch's own `... || <fresh>` fallback
+        // covers the realistic failure, and polling for liveness here would mean
+        // guessing how long a boot takes. Both are reported honestly rather than
+        // papered over.
         await execFileAsync("tmux", ["respawn-pane", "-k", "-t", pane], { timeout: TMUX_TIMEOUT_MS });
         return "respawned-tagged-pane" as const;
       }

--- a/apps/server/src/routes/terminal/slash-commands.ts
+++ b/apps/server/src/routes/terminal/slash-commands.ts
@@ -23,7 +23,15 @@ const COLD_START_POLL_MS = 250;
 // Two separate wrong-kill bugs came from positional targeting (PR #335 rounds
 // 1+2) — each killed a bystander pane, left the orchestrator running, and still
 // reported ok:true. Role lookup fails LOUD instead: no tagged pane means no
-// candidate, so we never -k something we cannot prove is the orchestrator.
+// candidate, so nothing gets -k'd on a guess.
+//
+// Trust model, stated plainly rather than overclaimed: the tag is a DESIGNATED
+// MARKER, not proof. @cpc-role is a mutable tmux option, so anything carrying it
+// is treated as the orchestrator. That grants nobody new power — setting a pane
+// option needs local access to this tmux server, and whoever has that can
+// `kill-pane` directly. The tag defends against ACCIDENTS (renumbering,
+// selection, splits, SSH tabs), which is what actually bit us, not against an
+// adversary who already owns the socket.
 const ORCHESTRATOR_ROLE = "orchestrator";
 
 // The canonical orchestrator launcher (attach-or-start). CPC must never
@@ -158,8 +166,13 @@ async function respawnIfStillOrchestrator(pane: string): Promise<void> {
 }
 
 /**
- * COLD START — create-only, never destructive. Reached only when no pane claims
- * the orchestrator role, i.e. there is nothing qualifying to kill.
+ * COLD START — create-only, never destructive. Reached when no pane claimed the
+ * role AT CHECK TIME. Not the same as "no pane claims it now": one could get
+ * tagged between that check and this call (a concurrent cw-launch). Harmless —
+ * cw-launch is attach-or-start, so it no-ops, and the confirm poll then finds
+ * the pane the other launcher tagged. It matters only that this path never
+ * kills anything, which holds unconditionally: it issues no destructive command
+ * at all, whatever raced ahead of it.
  *
  * Detached on purpose. cw-launch ends with `exec cw-boot-confirm`, which polls
  * for up to 300s dismissing boot dialogs and injecting the kickoff. Holding the

--- a/apps/server/src/routes/terminal/slash-commands.ts
+++ b/apps/server/src/routes/terminal/slash-commands.ts
@@ -53,15 +53,34 @@ const tmuxTracer = getTracer('cpc-server-tmux');
 async function orchestratorPane(session: string): Promise<string | null> {
   const { stdout } = await execFileAsync(
     "tmux",
-    ["list-panes", "-s", "-t", `=${session}`, "-F", "#{@cpc-role} #{pane_id}"],
+    // pane_id FIRST: @cpc-role is a user-settable option whose value may contain
+    // spaces, so it has to be the trailing field or it shifts the parse. (With
+    // role first, `@cpc-role="orchestrator x"` yields paneId="x".) Pane ids never
+    // contain spaces, so token 0 is always unambiguous and the role is the rest.
+    ["list-panes", "-s", "-t", `=${session}`, "-F", "#{pane_id} #{@cpc-role}"],
     { timeout: TMUX_TIMEOUT_MS },
   );
   const tagged = stdout
     .split("\n")
-    .map((line) => line.trim().split(" "))
-    .filter(([role, paneId]) => role === ORCHESTRATOR_ROLE && paneId)
-    .map(([, paneId]) => paneId!);
-  return tagged[0] ?? null;
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      const [paneId, ...role] = line.split(" ");
+      return { paneId, role: role.join(" ") };
+    })
+    .filter((p) => p.paneId && p.role === ORCHESTRATOR_ROLE);
+
+  // Ambiguity fails loud. Nothing legitimate produces two orchestrators in one
+  // session — cw-launch tags exactly one pane and splits do not inherit pane
+  // options (verified). If it happens anyway, something is wrong that we cannot
+  // reason about, and guessing is how this endpoint shipped three wrong-kills.
+  if (tagged.length > 1) {
+    throw new Error(
+      `ambiguous: ${tagged.length} panes claim @cpc-role=${ORCHESTRATOR_ROLE} in tmux session ${session}` +
+        ` (${tagged.map((p) => p.paneId).join(", ")}) — refusing to guess which is the orchestrator`,
+    );
+  }
+  return tagged[0]?.paneId ?? null;
 }
 
 /**

--- a/apps/server/src/routes/terminal/slash-commands.ts
+++ b/apps/server/src/routes/terminal/slash-commands.ts
@@ -15,33 +15,55 @@ const LAUNCHER_TIMEOUT_MS = 30_000;
 // The canonical orchestrator launcher (attach-or-start). CPC must never
 // reconstruct the claude command itself: the previous hardcoded copy silently
 // drifted from cw-launch (wrong cwd, retired channel plugin, no WOS_* env) and
-// shipped restarts into a stale session for weeks (WORLD-415). Only the
-// launcher's own definition is authoritative. Absolute by default because the
-// systemd unit's PATH does not include claudes-world/bin.
+// shipped restarts into a stale session for weeks (WORLD-415). Absolute by
+// default because the systemd unit's PATH does not include claudes-world/bin.
+//
+// Scope, precisely: this launcher is authoritative for the COLD-START branch
+// only. The respawn branch replays the pane's creation-time command, so an
+// edit to cw-launch does not reach a session that is already running — only a
+// full kill picks it up. That is still strictly better than the old code,
+// which rebuilt a known-stale command every time.
 const CW_LAUNCH = process.env.CW_LAUNCH_BIN || "/home/claude/claudes-world/bin/cw-launch";
 
 const tmuxTracer = getTracer('cpc-server-tmux');
 
 /**
- * Resolve a session to its active pane as an explicit `session:window.pane`
- * target. `respawn-pane` rejects a bare session name, and base-index /
- * pane-base-index are user config (both are 1 on this host, but reading them
- * back beats assuming), so ask tmux for the real indices.
+ * Resolve the orchestrator's pane to an explicit `session:window.pane` target.
+ * `respawn-pane` rejects a bare session name, so a concrete target is required.
+ *
+ * The pane we want is the one cw-launch created: the session's FIRST window,
+ * first pane. Do NOT use the *active* pane — `list-panes -t "=<session>"`
+ * without `-s` treats the target as a WINDOW and returns whichever window is
+ * currently selected. If anyone has a second window open in this session (an
+ * SSH tab, a split) and left it selected, that resolves to their pane, and
+ * `respawn-pane -k` would kill THEIR process while reporting success and
+ * leaving the orchestrator untouched. `-s` lists the whole session instead;
+ * sort by (window, pane) so the result never depends on what a human last
+ * clicked, nor on base-index / pane-base-index.
  */
-async function activePaneTarget(session: string): Promise<string> {
+async function orchestratorPaneTarget(session: string): Promise<string> {
   const { stdout } = await execFileAsync(
     "tmux",
     [
       "list-panes",
+      "-s",
       "-t", `=${session}`,
-      "-F", "#{session_name}:#{window_index}.#{pane_index}",
-      "-f", "#{pane_active}",
+      "-F", "#{window_index} #{pane_index} #{session_name}:#{window_index}.#{pane_index}",
     ],
     { timeout: TMUX_TIMEOUT_MS },
   );
-  const target = stdout.split("\n")[0]?.trim();
-  if (!target) throw new Error(`no active pane in tmux session ${session}`);
-  return target;
+  const panes = stdout
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      const [windowIndex, paneIndex, target] = line.split(" ");
+      return { windowIndex: Number(windowIndex), paneIndex: Number(paneIndex), target };
+    })
+    .filter((p) => Number.isFinite(p.windowIndex) && Number.isFinite(p.paneIndex) && p.target);
+  if (panes.length === 0) throw new Error(`no panes in tmux session ${session}`);
+  panes.sort((a, b) => a.windowIndex - b.windowIndex || a.paneIndex - b.paneIndex);
+  return panes[0]!.target!;
 }
 
 async function tracedTmux<T>(
@@ -244,7 +266,7 @@ app.post("/restart-session", async (c) => {
   try {
     await tracedTmux('tmux.restart-session', TMUX_SESSION, 'restart-session', async () => {
       if (await tmuxSessionExists(TMUX_SESSION)) {
-        await execFileAsync("tmux", ["respawn-pane", "-k", "-t", await activePaneTarget(TMUX_SESSION)], {
+        await execFileAsync("tmux", ["respawn-pane", "-k", "-t", await orchestratorPaneTarget(TMUX_SESSION)], {
           timeout: TMUX_TIMEOUT_MS,
         });
         return;

--- a/apps/server/src/routes/terminal/slash-commands.ts
+++ b/apps/server/src/routes/terminal/slash-commands.ts
@@ -117,6 +117,13 @@ const ROLE_CHANGED_MARKER = "cpc-role-changed";
  * so the role is true at the instant of the respawn. It exits 0 either way, so
  * the else-branch prints a marker — otherwise a refusal would read as success.
  *
+ * The marker survives the way this actually runs: `display-message -p` writes to
+ * the invoking tmux CLI's stdout, NOT to an attached client, so it works from
+ * cpc.service where no client exists. Verified with `env -u TMUX` against a
+ * detached session — revoked: marker printed, pane untouched; valid: restarted,
+ * stdout empty. Worth stating because if it HAD needed a client, every refusal
+ * would have silently reported a successful restart.
+ *
  * KNOWN GAP, accepted deliberately (codex round 4 MEDIUM): a successful respawn
  * proves tmux started the command, not that it stayed up. If the replayed
  * command dies immediately we still report respawned-tagged-pane. cw-launch's


### PR DESCRIPTION
## The bug

Pressing **Restart Claude Session** respawned the orchestrator into a **~week-old session**. Observed live by Liam; he recovered by hand via Termius.

`POST /api/terminal/restart-session` rebuilt the launch command inline:

```
tmux kill-session -t claudes-world
tmux new-session -d -s claudes-world \
  "cd ~/claudes-world && TZ=America/New_York claude --dangerously-skip-permissions \
   --continue --channels plugin:telegram@claude-plugins-official"
```

That hardcoded copy had drifted from the canonical launcher (`~/claudes-world/bin/cw-launch`):

| | legacy handler | canonical |
|---|---|---|
| cwd | `~/claudes-world` | `/home/claude/.world/director/workspace` |
| channel plugin | `plugin:telegram@claude-plugins-official` (retired) | `--plugin-dir .../channel-plugin --channels plugin:world@inline` |
| `WOS_*` env | none | `WOS_HOME_CHAT_ID`, `WOS_AGENT_ID`, … |
| fresh-start fallback | none | `--continue … \|\| <fresh>` |

**Root cause of the stale session:** `claude --continue` resolves session history **per-cwd**. Run from `~/claudes-world` it resumes the newest session *in that directory* — not the Director's real session under `.world/director/workspace`. Both project dirs exist and are distinct under `~/.claude/projects/`, which is the mechanism.

The deeper cause is the duplication: CPC held launch config that nothing kept in sync. `cw-launch` even carries a `KEEP THE CLAUDE COMMAND IN SYNC` warning — this is that warning coming true.

## The fix

CPC never reconstructs the launch command, and never guesses which pane the orchestrator is.

- **Orchestrator found by ROLE.** `cw-launch` stamps `@cpc-role=orchestrator` on its pane at creation (claudes-world `db7e204`). CPC asks tmux for that pane and acts on its `pane_id`, stable for the pane's whole life.
- **Tagged pane present** → `respawn-pane -k` it. Re-runs the pane's *own* creation-time command: right cwd, right `WOS_*` env, attached viewers stay attached.
- **No tagged pane** → the orchestrator isn't running → cold-start via `cw-launch`, spawned **detached + unref'd**, confirmed by polling for the *tagged pane*. Create-only: a cold start never kills anything.
- Response reports which path ran: `path: "respawned-tagged-pane" | "cold-started-fresh"`.

### Why not positional targeting

`renumber-windows` is **on** globally on this host, so a dying window promotes the next into its index. `session:1.1` means "whatever occupies slot 1", not "the pane cw-launch created". Two review rounds each produced a wrong-kill from positional targeting — both killed a bystander, left the orchestrator running, and returned `ok:true`:

```
round 1  selected window resolved                   -> killed a focused SSH tab
round 2  window 1 died, tab renumbered into slot 1  -> killed the tab
```

Role lookup fails **loud** instead: no tagged pane means no candidate, so nothing unidentified is ever `-k`'d. Ambiguity (two tagged panes) also throws rather than guessing.

### The other false proxy

*"Session exists"* is not *"the orchestrator is alive"* — a session outlives its windows; an SSH tab alone keeps it open. So the tag decides the branch **and** confirms the cold start. Before that was tightened, a cold start onto an occupied session reported `{"path":"cold-started-fresh"}` while `cw-launch` (attach-or-start) no-opped and started nothing. It now 500s with an actionable message.

## Verification — live, not test counts

Real handler, real tmux, **no mocks**, throwaway sessions only (never `claudes-world`):

| scenario | result |
|---|---|
| sibling window selected | orchestrator **RESTARTED**, ssh-tab **untouched** |
| orchestrator window dead, tab renumbered into slot 1 | **500** + bystander **survived** (no phantom success) |
| no session at all | `cold-started-fresh`, launcher ran, session up |
| restart after cold start | `respawned-tagged-pane` (round-trips) |

Both wrong-kill bugs were also reproduced live *before* fixing, in both directions.

Suites: server 441/441, web 393/393, `tsc --noEmit` clean. Mutation-checked: dropping `-s`, or reverting to a role-first `-F` format, fails the relevant tests.

## A bug this found in the boot path

The first tagging commit (`abb7d11`) used `tmux set-option -p -t "=$SESSION"`. The `=` form is a *session* target, so `set-option -p` fails with `no such pane` — and under `cw-launch`'s `set -euo pipefail`, that abort skipped `exec cw-boot-confirm`, which would have left the orchestrator wedged behind the boot dialog on the next reboot (the ~54-minute idle failure boot-confirm exists to prevent). Fixed in `db7e204` by capturing the pane id at creation:

```bash
PANE=$(tmux new-session -d -P -F '#{pane_id}' -s "${SESSION}" …)
tmux set-option -p -t "${PANE}" @cpc-role orchestrator
```

## Not merging

Repo gitflow: only orch merges to `dev`, only Liam merges to `main`. Live-verify plan for the real button is posted in-thread — **no live restart has been executed**; that kills the Director's session and is Liam-gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Pattern note: five bugs, none caught by the tests

Every bug found on this PR had the identical shape — **does the wrong thing, returns `ok:true`**:

1. resolved the *selected* window → killed a focused SSH tab, orchestrator untouched (codex r1)
2. window 1 died, an SSH tab renumbered into slot 1 → killed the tab (codex r2)
3. cold start onto an occupied session → reported `cold-started-fresh` having started nothing (found by my own live test)
4. trailing-whitespace role collapsed by `trim()` → matched a non-orchestrator pane (codex r3)
5. role check went stale before `respawn-pane` → killed a pane that no longer qualified (codex r4)

**The suite was green through all five.** Not one was caught by tests — each came from a reviewer or from deliberately attacking the code. Each time, the mock encoded the same wrong assumption as the implementation, so the tests could only confirm the bug, never expose it. Every fix here therefore ships with a mock change *and* a mutation check proving the new test actually fails against the old behaviour.

A second, sharper pattern: **five comments were caught asserting more than had been checked** — `respawn-pane` erroring on a stale tag (it does not); a concurrent race producing a no-op (it errors, exit 1); pane-ids never being reused (true, but unverified when written); "we never `-k` what we cannot prove"; and "reached only when no pane claims the role". One of those was load-bearing: the false "tmux would error" comment is precisely what made bug 5 look safe. The code got verified; the confident prose about it kept being wrong.

## On the lane's own crash (asked, and answered honestly)

Mid-review this lane's process died and came back as a fresh session. It was asked whether its own pane-targeting verification had killed it — which would have been a neat live specimen of the bug class.

**It had not.** Every destructive tmux command run during verification used an exact-match `=wos415-*` target on a throwaway session created moments earlier; everything aimed at real sessions was read-only (`list-panes`, `display-message`, `show-options`), and the last tmux write preceded the crash by ~40 minutes. The tempting story was declined.

The crash *is* a genuine specimen of a different property documented here: the pane re-ran its **creation-time argv** and came back as a stale configuration (fresh session, dead plugin). That is exactly the "respawn replays what the pane was born with" behaviour noted as a caveat — which is why this PR resolves the orchestrator by role rather than trusting whatever a pane happens to be.
