### PR TITLE
release: v1.17.0 — Telegram fullscreen UX (safe-area inset, session switcher sheet) + markdown viewer fixes

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -13,7 +13,7 @@ import { PrTicker } from "./components/PrTicker";
 import { HomeScreenPrompt } from "./components/HomeScreenPrompt";
 import { CockpitPage } from "./components/CockpitPage";
 import { VaultExplorerPage } from "./components/VaultExplorerPage";
-import { type TmuxSessionInfo } from "./components/SessionPicker";
+import { SessionPicker, type TmuxSessionInfo } from "./components/SessionPicker";
 import { SessionSwitcherSheet } from "./components/SessionSwitcherSheet";
 import {
   buildLandingUrl,
@@ -144,7 +144,6 @@ export function App() {
   const sessionPicker = resolveSessionPickerProps(sessionList, activeSession, defaultSession);
   const [sessionSwitcherOpen, setSessionSwitcherOpen] = useState(false);
   const activeSessionName = activeSession ?? defaultSession ?? "";
-  const activeSessionInfo = sessionPicker.sessions.find((s) => s.name === activeSessionName);
   const [fileOpenRequest, setFileOpenRequest] = useState({ path: initialRoute.file, sequence: 0 });
   // FileViewer is keyed by this request sequence. Keep the latest request in
   // a ref so callbacks retained by an unmounted viewer cannot publish a late
@@ -600,75 +599,52 @@ export function App() {
         </div>
       )}
 
-      {/* Session bar — terminal tab only. A single big-tap-target row showing
-          the active session; tapping opens the SessionSwitcherSheet (a
-          bottom-sheet picker with full-width rows). Replaces the old cramped
-          horizontal chip strip (SessionPicker). Visibility + session list
-          (including the stale-deep-link escape hatch) are still decided by
-          resolveSessionPickerProps — see its docstring for the round-2
-          (PR #299) fix: an earlier inline `sessionList.length > 0` guard
-          hid the picker entirely whenever /api/terminal/sessions failed
-          while a stale session was active, stranding the user. */}
+      {/* Session switcher row — terminal tab only. Liam's design (2026-07-15):
+          BOTH a horizontal sliding chip strip (quick one-tap select) AND a
+          list-view button on its left that opens the full session list
+          (SessionSwitcherSheet). Visibility + session list (including the
+          stale-deep-link escape hatch) are decided by resolveSessionPickerProps
+          — see its docstring for the round-2 (PR #299) fix: an earlier inline
+          `sessionList.length > 0` guard hid the picker entirely whenever
+          /api/terminal/sessions failed while a stale session was active,
+          stranding the user. */}
       {activeTab === "terminal" && sessionPicker.visible && (
-        <button
-          data-testid="session-bar"
-          onClick={() => { haptic.selection(); setSessionSwitcherOpen(true); }}
-          onTouchStart={(e) => e.stopPropagation()}
+        <div
           style={{
             display: "flex",
-            alignItems: "center",
-            gap: 8,
-            width: "100%",
-            padding: "9px 14px",
-            background: "none",
-            border: "none",
+            alignItems: "stretch",
             borderBottom: "1px solid var(--color-border)",
             flexShrink: 0,
-            cursor: "pointer",
-            textAlign: "left",
           }}
+          onTouchStart={(e) => e.stopPropagation()}
         >
-          <span
-            aria-hidden="true"
+          <button
+            data-testid="session-list-button"
+            aria-label="Show all sessions in a list"
+            onClick={() => { haptic.selection(); setSessionSwitcherOpen(true); }}
             style={{
-              width: 7,
-              height: 7,
-              borderRadius: "50%",
-              flexShrink: 0,
-              background: (activeSessionInfo?.alive ?? true)
-                ? "var(--color-accent-green)"
-                : "var(--color-subtle)",
-            }}
-          />
-          <span
-            style={{
-              flex: 1,
-              minWidth: 0,
-              fontFamily: "monospace",
-              fontSize: 13,
-              fontWeight: 600,
-              color: "var(--color-fg)",
-              whiteSpace: "nowrap",
-              overflow: "hidden",
-              textOverflow: "ellipsis",
-            }}
-          >
-            {activeSessionName || "default"}
-          </span>
-          <span
-            style={{
-              fontSize: 11,
-              color: "var(--color-muted)",
               flexShrink: 0,
               display: "inline-flex",
               alignItems: "center",
-              gap: 4,
+              justifyContent: "center",
+              padding: "0 13px",
+              background: "none",
+              border: "none",
+              borderRight: "1px solid var(--color-border)",
+              cursor: "pointer",
+              color: "var(--color-muted)",
+              fontSize: 15,
+              lineHeight: 1,
             }}
           >
-            {sessionPicker.sessions.length > 1 ? `${sessionPicker.sessions.length} terminals` : "switch"}
-            <span aria-hidden="true">&#9662;</span>
-          </span>
-        </button>
+            <span aria-hidden="true">&#9776;</span>
+          </button>
+          <SessionPicker
+            sessions={sessionPicker.sessions}
+            active={activeSessionName}
+            onSelect={onSelectSession}
+          />
+        </div>
       )}
 
       {/* Content area — swipeable viewport */}

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -13,7 +13,8 @@ import { PrTicker } from "./components/PrTicker";
 import { HomeScreenPrompt } from "./components/HomeScreenPrompt";
 import { CockpitPage } from "./components/CockpitPage";
 import { VaultExplorerPage } from "./components/VaultExplorerPage";
-import { SessionPicker, type TmuxSessionInfo } from "./components/SessionPicker";
+import { type TmuxSessionInfo } from "./components/SessionPicker";
+import { SessionSwitcherSheet } from "./components/SessionSwitcherSheet";
 import {
   buildLandingUrl,
   isCockpitRoute,
@@ -141,6 +142,9 @@ export function App() {
   // same session), so the pessimistic default is safe either way.
   const paletteSession = activeSession !== null && activeSession !== defaultSession ? activeSession : null;
   const sessionPicker = resolveSessionPickerProps(sessionList, activeSession, defaultSession);
+  const [sessionSwitcherOpen, setSessionSwitcherOpen] = useState(false);
+  const activeSessionName = activeSession ?? defaultSession ?? "";
+  const activeSessionInfo = sessionPicker.sessions.find((s) => s.name === activeSessionName);
   const [fileOpenRequest, setFileOpenRequest] = useState({ path: initialRoute.file, sequence: 0 });
   // FileViewer is keyed by this request sequence. Keep the latest request in
   // a ref so callbacks retained by an unmounted viewer cannot publish a late
@@ -568,18 +572,75 @@ export function App() {
         </div>
       )}
 
-      {/* Session picker — terminal tab only. Visibility + session list
-          (including the stale-deep-link escape hatch) are decided by
+      {/* Session bar — terminal tab only. A single big-tap-target row showing
+          the active session; tapping opens the SessionSwitcherSheet (a
+          bottom-sheet picker with full-width rows). Replaces the old cramped
+          horizontal chip strip (SessionPicker). Visibility + session list
+          (including the stale-deep-link escape hatch) are still decided by
           resolveSessionPickerProps — see its docstring for the round-2
           (PR #299) fix: an earlier inline `sessionList.length > 0` guard
           hid the picker entirely whenever /api/terminal/sessions failed
           while a stale session was active, stranding the user. */}
       {activeTab === "terminal" && sessionPicker.visible && (
-        <SessionPicker
-          sessions={sessionPicker.sessions}
-          active={activeSession ?? defaultSession ?? ""}
-          onSelect={onSelectSession}
-        />
+        <button
+          data-testid="session-bar"
+          onClick={() => { haptic.selection(); setSessionSwitcherOpen(true); }}
+          onTouchStart={(e) => e.stopPropagation()}
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 8,
+            width: "100%",
+            padding: "9px 14px",
+            background: "none",
+            border: "none",
+            borderBottom: "1px solid var(--color-border)",
+            flexShrink: 0,
+            cursor: "pointer",
+            textAlign: "left",
+          }}
+        >
+          <span
+            aria-hidden="true"
+            style={{
+              width: 7,
+              height: 7,
+              borderRadius: "50%",
+              flexShrink: 0,
+              background: (activeSessionInfo?.alive ?? true)
+                ? "var(--color-accent-green)"
+                : "var(--color-subtle)",
+            }}
+          />
+          <span
+            style={{
+              flex: 1,
+              minWidth: 0,
+              fontFamily: "monospace",
+              fontSize: 13,
+              fontWeight: 600,
+              color: "var(--color-fg)",
+              whiteSpace: "nowrap",
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+            }}
+          >
+            {activeSessionName || "default"}
+          </span>
+          <span
+            style={{
+              fontSize: 11,
+              color: "var(--color-muted)",
+              flexShrink: 0,
+              display: "inline-flex",
+              alignItems: "center",
+              gap: 4,
+            }}
+          >
+            {sessionPicker.sessions.length > 1 ? `${sessionPicker.sessions.length} terminals` : "switch"}
+            <span aria-hidden="true">&#9662;</span>
+          </span>
+        </button>
       )}
 
       {/* Content area — swipeable viewport */}
@@ -643,6 +704,16 @@ export function App() {
           currentFolder={currentFolder}
         />
       </div>
+
+      {/* Terminal session switcher sheet — opened from the session bar */}
+      {sessionSwitcherOpen && (
+        <SessionSwitcherSheet
+          sessions={sessionPicker.sessions}
+          active={activeSessionName}
+          onSelect={onSelectSession}
+          onClose={() => setSessionSwitcherOpen(false)}
+        />
+      )}
 
       {/* Home screen prompt — rendered once, dismissed to localStorage */}
       {showHomeScreenPrompt && <HomeScreenPrompt onDismiss={handleHomeScreenDismiss} />}

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -12,10 +12,12 @@ import { DebugOverlay } from "./debug/DebugOverlay";
 import { PrTicker } from "./components/PrTicker";
 import { HomeScreenPrompt } from "./components/HomeScreenPrompt";
 import { CockpitPage } from "./components/CockpitPage";
+import { VaultExplorerPage } from "./components/VaultExplorerPage";
 import { SessionPicker, type TmuxSessionInfo } from "./components/SessionPicker";
 import {
   buildLandingUrl,
   isCockpitRoute,
+  isVaultRoute,
   resolveInitialAppState,
   type AppTab as Tab,
 } from "./lib/app-routing";
@@ -123,6 +125,7 @@ export function App() {
 
   const [activeTab, setActiveTab] = useState<Tab>(initialRoute.tab);
   const [cockpitOpen, setCockpitOpen] = useState(() => isCockpitRoute(window.location.hash));
+  const [vaultOpen, setVaultOpen] = useState(() => isVaultRoute(window.location.hash));
   const [reconnectKey, setReconnectKey] = useState(0);
 
   // Multi-session terminal (world-os#218): which tmux session the terminal
@@ -167,15 +170,24 @@ export function App() {
   const [showHomeScreenPrompt, setShowHomeScreenPrompt] = useState(false);
 
   useEffect(() => {
-    const syncCockpitRoute = () => setCockpitOpen(isCockpitRoute(window.location.hash));
-    window.addEventListener("hashchange", syncCockpitRoute);
-    return () => window.removeEventListener("hashchange", syncCockpitRoute);
+    const syncStandaloneRoutes = () => {
+      setCockpitOpen(isCockpitRoute(window.location.hash));
+      setVaultOpen(isVaultRoute(window.location.hash));
+    };
+    window.addEventListener("hashchange", syncStandaloneRoutes);
+    return () => window.removeEventListener("hashchange", syncStandaloneRoutes);
   }, []);
 
   const closeCockpit = useCallback(() => {
     setActiveTab("links");
     window.location.hash = "links";
     setCockpitOpen(false);
+  }, []);
+
+  const closeVault = useCallback(() => {
+    setActiveTab("links");
+    window.location.hash = "links";
+    setVaultOpen(false);
   }, []);
 
   const fileViewerSequence = fileOpenRequest.sequence;
@@ -452,6 +464,10 @@ export function App() {
 
   if (cockpitOpen) {
     return <CockpitPage onBack={closeCockpit} />;
+  }
+
+  if (vaultOpen) {
+    return <VaultExplorerPage onBack={closeVault} />;
   }
 
   return (

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -619,6 +619,7 @@ export function App() {
           onTouchStart={(e) => e.stopPropagation()}
         >
           <button
+            type="button"
             data-testid="session-list-button"
             aria-label="Show all sessions in a list"
             onClick={() => { haptic.selection(); setSessionSwitcherOpen(true); }}

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -358,6 +358,34 @@ export function App() {
     }
   }, []);
 
+  // Telegram fullscreen chrome (the centered island + the Close / collapse /
+  // "⋯" buttons) floats OVER the top of the webview, stomping the app's tab
+  // bar and header (see on-device screenshot 2026-07-15). Pad the whole app
+  // below it. The offset is the device safe area PLUS Telegram's own content
+  // safe area — the band its buttons occupy. `env(safe-area-inset-top)` alone
+  // is NOT enough: Telegram's pills sit AT the device inset, so content padded
+  // only by the device inset still lands under the Close button. Both values
+  // are read straight off the WebApp object (CPC uses the raw WebApp, not the
+  // CSS-var-publishing SDK) and re-read on the change events, since they
+  // resolve asynchronously after requestFullscreen() and update on rotation /
+  // fullscreen toggle. Non-Telegram browsers report 0 → no padding.
+  const [topInset, setTopInset] = useState(0);
+  useEffect(() => {
+    const tg = getTelegramWebApp() as any;
+    if (!tg) return;
+    const readInset = () => {
+      const device = tg.safeAreaInset?.top ?? 0;
+      const content = tg.contentSafeAreaInset?.top ?? 0;
+      setTopInset(device + content);
+    };
+    readInset();
+    const events = ["safeAreaChanged", "contentSafeAreaChanged", "fullscreenChanged"];
+    if (typeof tg.onEvent === "function") events.forEach((e) => tg.onEvent(e, readInset));
+    return () => {
+      if (typeof tg.offEvent === "function") events.forEach((e) => tg.offEvent(e, readInset));
+    };
+  }, []);
+
   // Telegram Login Widget callback (for fallback auth)
   useEffect(() => {
     if (authed) return;
@@ -475,7 +503,7 @@ export function App() {
   }
 
   return (
-    <div style={{ display: "flex", flexDirection: "column", height: "100%", width: "100%", maxWidth: "100vw", overflowX: "hidden" }}>
+    <div style={{ display: "flex", flexDirection: "column", height: "100%", width: "100%", maxWidth: "100vw", overflowX: "hidden", boxSizing: "border-box", paddingTop: topInset, background: "var(--color-bg)" }}>
       {/* Dev mode banner */}
       {isDev && (
         <div style={{

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback, useRef, useMemo } from "react";
 import { FiDownload } from "react-icons/fi";
-import { getAuthHeaders } from "../lib/telegram";
+import { getAuthHeaders, requestTelegramDownload } from "../lib/telegram";
 import { MarkdownViewer } from "./MarkdownViewer";
 import { BottomSheet } from "./BottomSheet";
 import { getFileIcon } from "./file-icons";
@@ -239,10 +239,20 @@ export function FileViewer({ onClose, initialFile, showHidden = false, sortMode 
         throw new Error("Download failed: missing ticket");
       }
 
-      // Use a hidden <a> element with download attribute to trigger the
-      // browser's native download. This works in Telegram WebView where
-      // window.open("about:blank") is blocked as a popup.
-      const url = `/api/files/download?ticket=${encodeURIComponent(data.ticket)}`;
+      // Absolute URL: Telegram's downloader runs outside this document and
+      // rejects anything that isn't a fully-qualified https URL.
+      const url = new URL(
+        `/api/files/download?ticket=${encodeURIComponent(data.ticket)}`,
+        window.location.href,
+      ).href;
+
+      // Prefer Telegram's native downloader. In its WebView an <a download>
+      // only navigates, and the WebView paints the bytes inline as uncopyable
+      // text rather than saving a file (WORLD-375).
+      if (requestTelegramDownload(url, fileName)) return;
+
+      // Fallback for desktop/browser, where <a download> does save the file.
+      // Preferred over window.open("about:blank"), which is popup-blocked.
       const anchor = document.createElement("a");
       anchor.href = url;
       anchor.download = fileName;

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -248,10 +248,12 @@ export function FileViewer({ onClose, initialFile, showHidden = false, sortMode 
 
       // Prefer Telegram's native downloader. In its WebView an <a download>
       // only navigates, and the WebView paints the bytes inline as uncopyable
-      // text rather than saving a file (WORLD-375).
-      if (requestTelegramDownload(url, fileName)) return;
+      // text rather than saving a file (WORLD-375). "busy" means Telegram
+      // already has a download popup open from a previous tap, so it owns the
+      // flow too — falling through would reproduce that bug on a double-tap.
+      if (requestTelegramDownload(url, fileName) !== "unsupported") return;
 
-      // Fallback for desktop/browser, where <a download> does save the file.
+      // Fallback for real browsers, where <a download> does save the file.
       // Preferred over window.open("about:blank"), which is popup-blocked.
       const anchor = document.createElement("a");
       anchor.href = url;

--- a/apps/web/src/components/Links.tsx
+++ b/apps/web/src/components/Links.tsx
@@ -5,7 +5,7 @@ import "./Links.css";
 
 interface LinkItem {
   title: string;
-  url: string;
+  url?: string;
   icon?: string;
   description?: string;
   /**
@@ -58,6 +58,12 @@ interface AppItem {
 }
 
 const LINKS: LinkItem[] = [
+  {
+    title: "Vault Explorer",
+    icon: "🗂️",
+    description: "Read-only second-brain structure + health",
+    internalRoute: "#/vault",
+  },
   {
     title: "Fleet Cockpit",
     url: "https://cockpit.claude.do",
@@ -162,11 +168,13 @@ export function Links({ onClose, onOpenFile }: LinksProps) {
       <div style={{ flex: 1, overflow: "auto" }}>
         <ReadingList onOpenFile={onOpenFile} />
         {LINKS.map((link) => {
-          const useInternalRoute = Boolean(link.internalRoute && cockpitProxyAvailable);
-          const href = useInternalRoute ? link.internalRoute! : link.url;
+          const useInternalRoute = Boolean(
+            link.internalRoute && (link.internalRoute === "#/vault" || cockpitProxyAvailable),
+          );
+          const href = useInternalRoute ? link.internalRoute! : (link.url ?? "#");
           return (
           <a
-            key={link.url}
+            key={link.internalRoute ?? link.url}
             href={href}
             // In-app links navigate the webview itself (see openInApp);
             // everything else keeps the external-tab behavior. rel stays on
@@ -183,7 +191,7 @@ export function Links({ onClose, onOpenFile }: LinksProps) {
               e.preventDefault();
               if (useInternalRoute) {
                 window.location.hash = link.internalRoute!.slice(1);
-              } else {
+              } else if (link.url) {
                 openInApp(link.url);
               }
             } : undefined}

--- a/apps/web/src/components/MarkdownViewer.tsx
+++ b/apps/web/src/components/MarkdownViewer.tsx
@@ -624,14 +624,20 @@ export function MarkdownViewer({ content, fileName: _fileName }: MarkdownViewerP
           gap: 6px;
           border-radius: 3px;
           width: 100%;
-          /* Heading text should be as selectable as the body. The cascade may
-             already achieve this via "all: unset" above — measured true in
-             Blink — but WebKit has a long-standing quirk where native controls
-             resist inherited re-enabling of selection. Unverified there, and
-             re-asserting the value the cascade should already produce costs
-             nothing, so this stays until an on-device check says otherwise.
-             Tap-to-fold is unaffected: long-press on this button did nothing
-             before, so selecting instead is a gain, not a regression. */
+          /* Heading text should be as selectable as the body. "all: unset"
+             above may already achieve that — measured true in Blink — but
+             Blink cannot settle it: this only ever runs in WebKit (Telegram's
+             iOS WKWebView), whose UA sheet forces -webkit-user-select:none on
+             native controls in a way author declarations don't dependably
+             defeat. So this stays as an explicit hedge; where it is redundant
+             it is a proven no-op.
+
+             UNVERIFIED RISK — for the on-device pass, not a settled question:
+             making a tappable control selectable can let iOS's
+             press-and-hold-to-select heuristic engage on a short-but-not-
+             instant tap, swallow the click, and leave tap-to-fold needing a
+             second try. We have no iOS rig here, so this is named rather than
+             dismissed. If folding feels sticky on device, start here. */
           user-select: text;
           -webkit-user-select: text;
         }

--- a/apps/web/src/components/MarkdownViewer.tsx
+++ b/apps/web/src/components/MarkdownViewer.tsx
@@ -374,6 +374,12 @@ export function MarkdownViewer({ content, fileName: _fileName }: MarkdownViewerP
           overflow-wrap: break-word;
           word-break: break-word;
           max-width: 100%;
+          /* Telegram's WebView suppresses selection/callout by default to feel
+             native. The markdown body is read-mode content, so opt back in
+             explicitly — without this, long-press selects nothing. */
+          user-select: text;
+          -webkit-user-select: text;
+          -webkit-touch-callout: default;
         }
         .md-content * {
           max-width: 100%;
@@ -609,6 +615,11 @@ export function MarkdownViewer({ content, fileName: _fileName }: MarkdownViewerP
           gap: 6px;
           border-radius: 3px;
           width: 100%;
+          /* WebKit's UA sheet applies -webkit-user-select:none to <button>.
+             "all: unset" does not dependably restore it, so heading text needs
+             its own declaration to stay selectable like the body. */
+          user-select: text;
+          -webkit-user-select: text;
         }
         .md-content .cpc-fold-label {
           flex: 1 1 auto;
@@ -622,6 +633,9 @@ export function MarkdownViewer({ content, fileName: _fileName }: MarkdownViewerP
           color: var(--color-muted);
           font-size: 10px;
           transition: transform 0.2s ease;
+          /* aria-hidden decoration — keep it out of selected/copied text. */
+          user-select: none;
+          -webkit-user-select: none;
         }
         .md-content .cpc-fold-btn:hover .cpc-toggle-chevron {
           color: var(--color-accent-blue);

--- a/apps/web/src/components/MarkdownViewer.tsx
+++ b/apps/web/src/components/MarkdownViewer.tsx
@@ -381,6 +381,15 @@ export function MarkdownViewer({ content, fileName: _fileName }: MarkdownViewerP
           -webkit-user-select: text;
           -webkit-touch-callout: default;
         }
+        /* -webkit-touch-callout is inherited, so the rule above would also
+           re-enable iOS's native long-press sheets on links and images. That is
+           a behaviour change this ticket never asked for, and it would fight
+           MarkdownLink, which deliberately routes taps through Telegram's
+           openLink. Hold those two at the ambient default; only text opts in. */
+        .md-content a,
+        .md-content img {
+          -webkit-touch-callout: none;
+        }
         .md-content * {
           max-width: 100%;
           box-sizing: border-box;
@@ -615,9 +624,14 @@ export function MarkdownViewer({ content, fileName: _fileName }: MarkdownViewerP
           gap: 6px;
           border-radius: 3px;
           width: 100%;
-          /* WebKit's UA sheet applies -webkit-user-select:none to <button>.
-             "all: unset" does not dependably restore it, so heading text needs
-             its own declaration to stay selectable like the body. */
+          /* Heading text should be as selectable as the body. The cascade may
+             already achieve this via "all: unset" above — measured true in
+             Blink — but WebKit has a long-standing quirk where native controls
+             resist inherited re-enabling of selection. Unverified there, and
+             re-asserting the value the cascade should already produce costs
+             nothing, so this stays until an on-device check says otherwise.
+             Tap-to-fold is unaffected: long-press on this button did nothing
+             before, so selecting instead is a gain, not a regression. */
           user-select: text;
           -webkit-user-select: text;
         }

--- a/apps/web/src/components/SessionPicker.tsx
+++ b/apps/web/src/components/SessionPicker.tsx
@@ -36,8 +36,12 @@ export function SessionPicker({ sessions, active, onSelect }: SessionPickerProps
         gap: 6,
         padding: "6px 12px",
         overflowX: "auto",
-        borderBottom: "1px solid var(--color-border)",
-        flexShrink: 0,
+        // Fills the row to the right of the list-view button (App.tsx owns the
+        // row's bottom border). flex:1 + minWidth:0 lets the strip scroll
+        // horizontally within the remaining width instead of pushing the button
+        // off-screen.
+        flex: 1,
+        minWidth: 0,
         // Momentum scrolling in the Telegram WebView
         WebkitOverflowScrolling: "touch",
       }}

--- a/apps/web/src/components/SessionSwitcherSheet.tsx
+++ b/apps/web/src/components/SessionSwitcherSheet.tsx
@@ -33,6 +33,7 @@ export function SessionSwitcherSheet({ sessions, active, onSelect, onClose }: Se
           return (
             <button
               key={s.name}
+              type="button"
               onClick={() => {
                 haptic.selection();
                 if (!isActive) onSelect(s.writable ? null : s.name);

--- a/apps/web/src/components/SessionSwitcherSheet.tsx
+++ b/apps/web/src/components/SessionSwitcherSheet.tsx
@@ -1,0 +1,123 @@
+import { BottomSheet } from "./BottomSheet";
+import { haptic } from "../lib/haptic";
+import type { TmuxSessionInfo } from "./SessionPicker";
+
+interface SessionSwitcherSheetProps {
+  sessions: TmuxSessionInfo[];
+  /** Resolved name of the session currently viewed. */
+  active: string;
+  /** null selects the server default (writable) session. */
+  onSelect: (name: string | null) => void;
+  onClose: () => void;
+}
+
+/**
+ * Full-screen-reachable terminal session picker. Replaces the cramped
+ * horizontal chip strip (SessionPicker) that lived under the Telegram
+ * buttons: that strip had ~11px labels and 3px tap padding and scrolled
+ * sideways, which made switching sessions on a phone genuinely hard.
+ *
+ * Here each session is a full-width row with a real tap target (~52px),
+ * a status dot, the session name, and the running command as a subtitle
+ * so cryptic session names are still identifiable. Same select semantics
+ * as SessionPicker — the writable/default session maps to `onSelect(null)`
+ * (the "view the server default" sentinel), every other name is passed
+ * through literally. Selecting closes the sheet.
+ */
+export function SessionSwitcherSheet({ sessions, active, onSelect, onClose }: SessionSwitcherSheetProps) {
+  return (
+    <BottomSheet onClose={onClose} title="Switch terminal">
+      <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+        {sessions.map((s) => {
+          const isActive = s.name === active;
+          return (
+            <button
+              key={s.name}
+              onClick={() => {
+                haptic.selection();
+                if (!isActive) onSelect(s.writable ? null : s.name);
+                onClose();
+              }}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 12,
+                width: "100%",
+                padding: "13px 14px",
+                borderRadius: 12,
+                cursor: "pointer",
+                textAlign: "left",
+                background: isActive ? "var(--color-surface)" : "transparent",
+                border: isActive
+                  ? "1px solid var(--color-accent-blue)"
+                  : "1px solid var(--color-border)",
+              }}
+            >
+              <span
+                aria-hidden="true"
+                style={{
+                  width: 9,
+                  height: 9,
+                  borderRadius: "50%",
+                  flexShrink: 0,
+                  background: s.alive ? "var(--color-accent-green)" : "var(--color-subtle)",
+                }}
+              />
+              <span style={{ flex: 1, minWidth: 0, display: "flex", flexDirection: "column", gap: 2 }}>
+                <span
+                  style={{
+                    fontFamily: "monospace",
+                    fontSize: 15,
+                    fontWeight: isActive ? 600 : 500,
+                    color: isActive ? "var(--color-fg)" : "var(--color-fg-muted)",
+                    whiteSpace: "nowrap",
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                  }}
+                >
+                  {s.name}
+                </span>
+                {(s.command || !s.alive) && (
+                  <span
+                    style={{
+                      fontSize: 11,
+                      color: "var(--color-muted)",
+                      whiteSpace: "nowrap",
+                      overflow: "hidden",
+                      textOverflow: "ellipsis",
+                    }}
+                  >
+                    {s.alive ? s.command : "ended"}
+                  </span>
+                )}
+              </span>
+              {s.writable && (
+                <span
+                  style={{
+                    fontSize: 11,
+                    color: "var(--color-accent-green)",
+                    display: "inline-flex",
+                    alignItems: "center",
+                    gap: 3,
+                    flexShrink: 0,
+                  }}
+                >
+                  <span aria-label="writable session">&#9998;</span>
+                  writable
+                </span>
+              )}
+              {isActive && (
+                <span
+                  aria-label="current session"
+                  style={{ fontSize: 15, color: "var(--color-accent-blue)", flexShrink: 0 }}
+                >
+                  &#10003;
+                </span>
+              )}
+            </button>
+          );
+        })}
+      </div>
+    </BottomSheet>
+  );
+}

--- a/apps/web/src/components/VaultExplorerPage.tsx
+++ b/apps/web/src/components/VaultExplorerPage.tsx
@@ -71,6 +71,7 @@ export function VaultExplorerPage({ onBack }: VaultExplorerPageProps) {
   const [loadError, setLoadError] = useState<string | null>(null);
   const [selection, setSelection] = useState<PageSelection>(() => pageSelection(SAMPLE_INDEX.pages[0]));
   const detailRef = useRef<HTMLDivElement>(null);
+  const fileReadSeq = useRef(0);
 
   useEffect(() => {
     const backButton = getTelegramWebApp()?.BackButton;
@@ -125,11 +126,16 @@ export function VaultExplorerPage({ onBack }: VaultExplorerPageProps) {
 
   const handleFile = async (file: File | undefined) => {
     if (!file) return;
+    // Sequence concurrent reads: only the most recent selection wins, so a
+    // slow first read can't clobber a newer one after it resolves.
+    const seq = ++fileReadSeq.current;
     try {
       const text = await file.text();
+      if (seq !== fileReadSeq.current) return;
       setPastedJson(text);
       loadValue(text);
     } catch {
+      if (seq !== fileReadSeq.current) return;
       setLoadError("The selected file could not be read.");
     }
   };

--- a/apps/web/src/components/VaultExplorerPage.tsx
+++ b/apps/web/src/components/VaultExplorerPage.tsx
@@ -1,0 +1,665 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import sampleExport from "../fixtures/vault-link-check.sample.json";
+import {
+  FINDING_CATEGORIES,
+  findPageByPath,
+  getBacklinks,
+  getOutgoingEdges,
+  groupVaultPages,
+  mapVaultFindings,
+  parseVaultIndex,
+  type FindingCategory,
+  type VaultEdge,
+  type VaultIndex,
+  type VaultPage,
+} from "../lib/vault-explorer";
+import { getTelegramWebApp } from "../lib/telegram";
+
+interface VaultExplorerPageProps {
+  onBack: () => void;
+}
+
+type ExplorerView = "browse" | "health";
+
+interface PageSelection {
+  path: string;
+  page: VaultPage | null;
+  line?: number;
+}
+
+const CATEGORY_LABELS: Record<FindingCategory, string> = {
+  broken: "Broken",
+  ambiguous: "Ambiguous",
+  orphan: "Orphan",
+  unreferenced_raw: "Unreferenced raw",
+  receipt: "Receipt",
+};
+
+const CATEGORY_COLORS: Record<FindingCategory, string> = {
+  broken: "var(--color-accent-red)",
+  ambiguous: "var(--color-accent-yellow)",
+  orphan: "var(--color-accent-purple)",
+  unreferenced_raw: "var(--color-accent-cyan)",
+  receipt: "var(--color-accent-orange)",
+};
+
+const sampleResult = parseVaultIndex(sampleExport);
+if (!sampleResult.ok) throw new Error(`Invalid bundled vault fixture: ${sampleResult.message}`);
+const SAMPLE_INDEX = sampleResult.data;
+
+function formatGeneratedAt(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+function pageSelection(page: VaultPage, line?: number): PageSelection {
+  return { path: page.path, page, ...(line === undefined ? {} : { line }) };
+}
+
+export function VaultExplorerPage({ onBack }: VaultExplorerPageProps) {
+  const [index, setIndex] = useState<VaultIndex>(SAMPLE_INDEX);
+  const [view, setView] = useState<ExplorerView>("browse");
+  const [loadOpen, setLoadOpen] = useState(false);
+  const [pastedJson, setPastedJson] = useState("");
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [selection, setSelection] = useState<PageSelection>(() => pageSelection(SAMPLE_INDEX.pages[0]));
+  const detailRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const backButton = getTelegramWebApp()?.BackButton;
+    backButton?.show();
+    backButton?.onClick(onBack);
+    return () => {
+      backButton?.offClick(onBack);
+      backButton?.hide();
+    };
+  }, [onBack]);
+
+  const groups = useMemo(() => groupVaultPages(index.pages), [index.pages]);
+  const mappedFindings = useMemo(() => mapVaultFindings(index), [index]);
+
+  const revealDetail = () => {
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => detailRef.current?.scrollIntoView({ behavior: "smooth", block: "start" }));
+    });
+  };
+
+  const selectPage = (page: VaultPage, line?: number) => {
+    setSelection(pageSelection(page, line));
+    revealDetail();
+  };
+
+  const selectReference = (path: string, line?: number) => {
+    const page = findPageByPath(index.pages, path);
+    setSelection({ path, page, ...(line === undefined ? {} : { line }) });
+    setView("browse");
+    revealDetail();
+  };
+
+  const loadValue = (value: string | unknown) => {
+    const result = parseVaultIndex(value);
+    if (!result.ok) {
+      setLoadError(result.message);
+      return false;
+    }
+    setIndex(result.data);
+    const firstPage = result.data.pages[0] ?? null;
+    setSelection(firstPage ? pageSelection(firstPage) : { path: "No page selected", page: null });
+    setLoadError(null);
+    setLoadOpen(false);
+    setView("browse");
+    return true;
+  };
+
+  const resetToSample = () => {
+    setPastedJson("");
+    loadValue(sampleExport);
+  };
+
+  const handleFile = async (file: File | undefined) => {
+    if (!file) return;
+    try {
+      const text = await file.text();
+      setPastedJson(text);
+      loadValue(text);
+    } catch {
+      setLoadError("The selected file could not be read.");
+    }
+  };
+
+  const statusColor = index.status === "clean" ? "var(--color-accent-green)" : "var(--color-accent-yellow)";
+
+  return (
+    <div
+      style={{
+        background: "var(--color-bg)",
+        color: "var(--color-fg)",
+        display: "flex",
+        flexDirection: "column",
+        height: "100%",
+        minHeight: 0,
+        width: "100%",
+      }}
+    >
+      <header
+        style={{
+          alignItems: "center",
+          borderBottom: "1px solid var(--color-border)",
+          display: "flex",
+          flexShrink: 0,
+          gap: 10,
+          minHeight: 48,
+          padding: "max(8px, env(safe-area-inset-top)) 12px 8px",
+        }}
+        onTouchStart={(event) => event.stopPropagation()}
+      >
+        <button onClick={onBack} aria-label="Back to Links" style={iconButtonStyle}>←</button>
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div style={{ fontSize: 15, fontWeight: 700, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+            Vault Explorer
+          </div>
+          <div style={{ color: "var(--color-muted)", fontSize: 11, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+            {index.vault}
+          </div>
+        </div>
+        <span style={{ color: "var(--color-muted)", fontSize: 10, letterSpacing: "0.08em", textTransform: "uppercase" }}>
+          Read only
+        </span>
+        <button
+          onClick={() => { setLoadError(null); setLoadOpen((open) => !open); }}
+          aria-expanded={loadOpen}
+          style={{ ...smallButtonStyle, color: "var(--color-accent-blue)" }}
+        >
+          Load
+        </button>
+      </header>
+
+      {loadOpen && (
+        <section style={{ background: "var(--color-bg-alt)", borderBottom: "1px solid var(--color-border)", padding: 12 }}>
+          <div style={{ color: "var(--color-fg-muted)", fontSize: 12, marginBottom: 10 }}>
+            Open a local <code style={codeStyle}>link-check --json</code> export. Nothing is uploaded or saved.
+          </div>
+          <div style={{ display: "flex", flexWrap: "wrap", gap: 8, marginBottom: 10 }}>
+            <label style={{ ...smallButtonStyle, alignItems: "center", display: "inline-flex" }}>
+              Choose JSON
+              <input
+                type="file"
+                accept="application/json,.json"
+                onChange={(event) => {
+                  void handleFile(event.currentTarget.files?.[0]);
+                  event.currentTarget.value = "";
+                }}
+                style={{ display: "none" }}
+              />
+            </label>
+            <button onClick={resetToSample} style={smallButtonStyle}>Reset sample</button>
+          </div>
+          <textarea
+            value={pastedJson}
+            onChange={(event) => setPastedJson(event.target.value)}
+            placeholder="Paste a version 1 link-check JSON export…"
+            aria-label="Pasted link-check JSON"
+            spellCheck={false}
+            style={{
+              background: "var(--color-surface)",
+              border: "1px solid var(--color-border-alt)",
+              borderRadius: 8,
+              color: "var(--color-fg)",
+              display: "block",
+              fontFamily: "var(--font-mono)",
+              fontSize: 11,
+              minHeight: 112,
+              padding: 10,
+              resize: "vertical",
+              width: "100%",
+            }}
+          />
+          {loadError && (
+            <div role="alert" style={{ color: "var(--color-accent-red)", fontSize: 12, marginTop: 8 }}>
+              {loadError}
+            </div>
+          )}
+          <button
+            onClick={() => loadValue(pastedJson)}
+            disabled={!pastedJson.trim()}
+            style={{
+              ...primaryButtonStyle,
+              marginTop: 10,
+              opacity: pastedJson.trim() ? 1 : 0.45,
+            }}
+          >
+            View pasted export
+          </button>
+        </section>
+      )}
+
+      <div style={{ borderBottom: "1px solid var(--color-border)", flexShrink: 0, padding: "10px 12px" }}>
+        <div style={{ alignItems: "center", display: "flex", gap: 8 }}>
+          <div style={{ background: "var(--color-surface)", borderRadius: 8, display: "flex", padding: 2 }}>
+            {(["browse", "health"] as const).map((item) => (
+              <button
+                key={item}
+                onClick={() => setView(item)}
+                style={{
+                  background: view === item ? "var(--color-border-alt)" : "transparent",
+                  border: 0,
+                  borderRadius: 6,
+                  color: view === item ? "var(--color-fg)" : "var(--color-muted)",
+                  fontSize: 12,
+                  fontWeight: view === item ? 700 : 500,
+                  minHeight: 32,
+                  padding: "6px 14px",
+                  textTransform: "capitalize",
+                }}
+              >
+                {item}
+              </button>
+            ))}
+          </div>
+          <span style={{ color: statusColor, fontSize: 11, fontWeight: 700, marginLeft: "auto", textTransform: "uppercase" }}>
+            {index.status}
+          </span>
+        </div>
+        <div style={{ color: "var(--color-muted)", fontSize: 10, marginTop: 6 }}>
+          {index.pages.length} pages · {index.edges.length} links · generated {formatGeneratedAt(index.generated_at)}
+        </div>
+      </div>
+
+      <main style={{ flex: 1, minHeight: 0, overflowY: "auto", padding: "12px 12px max(20px, env(safe-area-inset-bottom))" }}>
+        {view === "browse" ? (
+          <div
+            style={{
+              display: "grid",
+              gap: 12,
+              gridTemplateColumns: "repeat(auto-fit, minmax(min(100%, 340px), 1fr))",
+              margin: "0 auto",
+              maxWidth: 920,
+            }}
+          >
+            <section aria-label="Vault layers" style={panelStyle}>
+              <SectionTitle title="Layers" detail={`${index.pages.length} pages`} />
+              <LayerSection label="Index" pages={groups.index} selection={selection} onSelect={selectPage} defaultOpen />
+              <LayerSection label="Raw" pages={groups.raw} selection={selection} onSelect={selectPage} />
+              <details open style={detailsStyle}>
+                <summary style={summaryStyle}>
+                  <span>Wiki</span>
+                  <span style={countStyle}>
+                    {groups.wiki.concepts.length + groups.wiki.entities.length + groups.wiki.summaries.length + groups.wiki.other.length}
+                  </span>
+                </summary>
+                <div style={{ borderLeft: "1px solid var(--color-border)", marginLeft: 10, paddingLeft: 8 }}>
+                  <LayerSection label="Concepts" pages={groups.wiki.concepts} selection={selection} onSelect={selectPage} nested />
+                  <LayerSection label="Entities" pages={groups.wiki.entities} selection={selection} onSelect={selectPage} nested />
+                  <LayerSection label="Summaries" pages={groups.wiki.summaries} selection={selection} onSelect={selectPage} nested />
+                  {groups.wiki.other.length > 0 && (
+                    <LayerSection label="Other wiki" pages={groups.wiki.other} selection={selection} onSelect={selectPage} nested />
+                  )}
+                </div>
+              </details>
+              <LayerSection label="Doctrine" pages={groups.doctrine} selection={selection} onSelect={selectPage} />
+              <LayerSection label="Armory" pages={groups.armory} selection={selection} onSelect={selectPage} />
+              {groups.other.length > 0 && (
+                <LayerSection label="Other" pages={groups.other} selection={selection} onSelect={selectPage} />
+              )}
+            </section>
+
+            <PageDetail
+              detailRef={detailRef}
+              index={index}
+              selection={selection}
+              onSelect={selectPage}
+            />
+          </div>
+        ) : (
+          <HealthPanel
+            index={index}
+            mappedFindings={mappedFindings}
+            onSelectReference={selectReference}
+          />
+        )}
+      </main>
+    </div>
+  );
+}
+
+function LayerSection({
+  label,
+  pages,
+  selection,
+  onSelect,
+  defaultOpen = false,
+  nested = false,
+}: {
+  label: string;
+  pages: VaultPage[];
+  selection: PageSelection;
+  onSelect: (page: VaultPage) => void;
+  defaultOpen?: boolean;
+  nested?: boolean;
+}) {
+  return (
+    <details open={defaultOpen || nested} style={detailsStyle}>
+      <summary style={{ ...summaryStyle, fontSize: nested ? 11 : 12 }}>
+        <span>{label}</span>
+        <span style={countStyle}>{pages.length}</span>
+      </summary>
+      {pages.length === 0 ? (
+        <div style={{ color: "var(--color-muted)", fontSize: 11, padding: "5px 8px 8px" }}>No pages</div>
+      ) : (
+        <div style={{ display: "grid", gap: 4, padding: "4px 0 8px" }}>
+          {pages.map((page) => {
+            const selected = selection.page?.path === page.path;
+            return (
+              <button
+                key={page.path}
+                onClick={() => onSelect(page)}
+                style={{
+                  background: selected ? "rgba(122, 162, 247, 0.14)" : "transparent",
+                  border: selected ? "1px solid rgba(122, 162, 247, 0.45)" : "1px solid transparent",
+                  borderRadius: 7,
+                  color: "var(--color-fg)",
+                  minHeight: 42,
+                  padding: "7px 9px",
+                  textAlign: "left",
+                  width: "100%",
+                }}
+              >
+                <span style={{ display: "block", fontSize: 12, fontWeight: 600 }}>{page.title}</span>
+                <span style={{ color: "var(--color-muted)", display: "block", fontFamily: "var(--font-mono)", fontSize: 9, marginTop: 2, overflowWrap: "anywhere" }}>
+                  {page.path}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </details>
+  );
+}
+
+function PageDetail({
+  detailRef,
+  index,
+  selection,
+  onSelect,
+}: {
+  detailRef: React.RefObject<HTMLDivElement | null>;
+  index: VaultIndex;
+  selection: PageSelection;
+  onSelect: (page: VaultPage, line?: number) => void;
+}) {
+  const page = selection.page;
+  const outgoing = page ? getOutgoingEdges(page, index.edges) : [];
+  const backlinks = page ? getBacklinks(page, index.edges) : [];
+
+  return (
+    <section ref={detailRef} aria-label="Page details" style={{ ...panelStyle, scrollMarginTop: 12 }}>
+      <SectionTitle title="Page" detail={selection.line ? `line ${selection.line}` : undefined} />
+      {page ? (
+        <>
+          <div style={{ padding: "4px 0 14px" }}>
+            <div style={{ fontSize: 17, fontWeight: 700 }}>{page.title}</div>
+            <div style={{ color: "var(--color-accent-blue)", fontFamily: "var(--font-mono)", fontSize: 10, marginTop: 5, overflowWrap: "anywhere" }}>
+              {page.path}{selection.line ? `:${selection.line}` : ""}
+            </div>
+            <span style={{ ...pillStyle, marginTop: 8 }}>{page.kind}</span>
+          </div>
+          <EdgeList
+            title="Outgoing"
+            empty="No outgoing links"
+            edges={outgoing}
+            index={index}
+            direction="outgoing"
+            onSelect={onSelect}
+          />
+          <EdgeList
+            title="Backlinks"
+            empty="No pages link here"
+            edges={backlinks}
+            index={index}
+            direction="backlink"
+            onSelect={onSelect}
+          />
+        </>
+      ) : (
+        <div style={{ color: "var(--color-fg-muted)", fontSize: 12, padding: "8px 0" }}>
+          <div style={{ color: "var(--color-accent-yellow)", fontWeight: 700 }}>Page is not present in this export.</div>
+          <div style={{ fontFamily: "var(--font-mono)", marginTop: 8, overflowWrap: "anywhere" }}>
+            {selection.path}{selection.line ? `:${selection.line}` : ""}
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}
+
+function EdgeList({
+  title,
+  empty,
+  edges,
+  index,
+  direction,
+  onSelect,
+}: {
+  title: string;
+  empty: string;
+  edges: VaultEdge[];
+  index: VaultIndex;
+  direction: "outgoing" | "backlink";
+  onSelect: (page: VaultPage, line?: number) => void;
+}) {
+  return (
+    <div style={{ borderTop: "1px solid var(--color-border)", padding: "12px 0" }}>
+      <div style={{ color: "var(--color-fg-muted)", fontSize: 11, fontWeight: 700, letterSpacing: "0.06em", marginBottom: 7, textTransform: "uppercase" }}>
+        {title} <span style={{ color: "var(--color-muted)" }}>{edges.length}</span>
+      </div>
+      {edges.length === 0 ? (
+        <div style={{ color: "var(--color-muted)", fontSize: 11 }}>{empty}</div>
+      ) : (
+        <div style={{ display: "grid", gap: 6 }}>
+          {edges.map((edge, indexInList) => {
+            const linkedPath = direction === "outgoing" ? edge.target : edge.source;
+            const linkedPage = findPageByPath(index.pages, linkedPath);
+            const canNavigate = linkedPage !== null && (direction === "backlink" || edge.resolved);
+            return (
+              <button
+                key={`${edge.source}:${edge.line}:${edge.target}:${indexInList}`}
+                onClick={() => {
+                  if (canNavigate && linkedPage) onSelect(linkedPage, direction === "backlink" ? edge.line : undefined);
+                }}
+                disabled={!canNavigate}
+                style={{
+                  background: "var(--color-bg-alt)",
+                  border: "1px solid var(--color-border)",
+                  borderRadius: 7,
+                  color: "var(--color-fg)",
+                  cursor: canNavigate ? "pointer" : "default",
+                  minHeight: 44,
+                  opacity: canNavigate ? 1 : 0.85,
+                  padding: "8px 9px",
+                  textAlign: "left",
+                }}
+              >
+                <span style={{ alignItems: "center", display: "flex", gap: 6 }}>
+                  <span style={{ color: edge.resolved ? "var(--color-accent-green)" : "var(--color-accent-red)", fontSize: 10 }}>
+                    {edge.resolved ? "●" : "●"}
+                  </span>
+                  <span style={{ flex: 1, fontSize: 11, fontWeight: 600, overflowWrap: "anywhere" }}>
+                    {edge.label || linkedPage?.title || linkedPath}
+                  </span>
+                  <span style={{ color: "var(--color-muted)", fontSize: 9 }}>line {edge.line}</span>
+                </span>
+                <span style={{ color: "var(--color-muted)", display: "block", fontFamily: "var(--font-mono)", fontSize: 9, marginLeft: 16, marginTop: 3, overflowWrap: "anywhere" }}>
+                  {linkedPath}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function HealthPanel({
+  index,
+  mappedFindings,
+  onSelectReference,
+}: {
+  index: VaultIndex;
+  mappedFindings: ReturnType<typeof mapVaultFindings>;
+  onSelectReference: (path: string, line?: number) => void;
+}) {
+  return (
+    <section aria-label="Vault health" style={{ ...panelStyle, margin: "0 auto", maxWidth: 720 }}>
+      <SectionTitle title="Vault health" detail={index.status} />
+      <div style={{ display: "grid", gap: 7, gridTemplateColumns: "repeat(5, minmax(54px, 1fr))", margin: "6px 0 14px", overflowX: "auto" }}>
+        {FINDING_CATEGORIES.map((category) => (
+          <div key={category} style={{ background: "var(--color-bg-alt)", border: "1px solid var(--color-border)", borderRadius: 8, minWidth: 54, padding: "9px 5px", textAlign: "center" }}>
+            <div style={{ color: CATEGORY_COLORS[category], fontSize: 18, fontWeight: 800 }}>{index.counts[category]}</div>
+            <div style={{ color: "var(--color-muted)", fontSize: 8, lineHeight: 1.2, marginTop: 3 }}>{CATEGORY_LABELS[category]}</div>
+          </div>
+        ))}
+      </div>
+
+      {FINDING_CATEGORIES.map((category) => (
+        <details key={category} open={index.counts[category] > 0} style={detailsStyle}>
+          <summary style={summaryStyle}>
+            <span style={{ color: CATEGORY_COLORS[category] }}>{CATEGORY_LABELS[category]}</span>
+            <span style={countStyle}>{index.counts[category]}</span>
+          </summary>
+          {mappedFindings[category].length === 0 ? (
+            <div style={{ color: "var(--color-muted)", fontSize: 11, padding: "6px 8px 10px" }}>No findings</div>
+          ) : (
+            <div style={{ display: "grid", gap: 6, padding: "5px 0 10px" }}>
+              {mappedFindings[category].map(({ finding, page }, findingIndex) => (
+                <button
+                  key={`${finding.path}:${finding.line ?? ""}:${findingIndex}`}
+                  onClick={() => onSelectReference(finding.path, finding.line)}
+                  style={{
+                    background: "var(--color-bg-alt)",
+                    border: "1px solid var(--color-border)",
+                    borderRadius: 7,
+                    color: "var(--color-fg)",
+                    minHeight: 48,
+                    padding: "8px 9px",
+                    textAlign: "left",
+                    width: "100%",
+                  }}
+                >
+                  <span style={{ display: "block", fontSize: 11, fontWeight: 600 }}>{finding.reason}</span>
+                  <span style={{ color: page ? "var(--color-accent-blue)" : "var(--color-accent-yellow)", display: "block", fontFamily: "var(--font-mono)", fontSize: 9, marginTop: 4, overflowWrap: "anywhere" }}>
+                    {finding.path}{finding.line ? `:${finding.line}` : ""}
+                  </span>
+                </button>
+              ))}
+            </div>
+          )}
+        </details>
+      ))}
+    </section>
+  );
+}
+
+function SectionTitle({ title, detail }: { title: string; detail?: string }) {
+  return (
+    <div style={{ alignItems: "center", display: "flex", marginBottom: 8 }}>
+      <h2 style={{ fontSize: 13, margin: 0 }}>{title}</h2>
+      {detail && <span style={{ color: "var(--color-muted)", fontSize: 10, marginLeft: "auto" }}>{detail}</span>}
+    </div>
+  );
+}
+
+const panelStyle: React.CSSProperties = {
+  background: "var(--color-surface)",
+  border: "1px solid var(--color-border)",
+  borderRadius: 10,
+  minWidth: 0,
+  padding: 12,
+};
+
+const detailsStyle: React.CSSProperties = {
+  borderTop: "1px solid var(--color-border)",
+};
+
+const summaryStyle: React.CSSProperties = {
+  alignItems: "center",
+  color: "var(--color-fg-muted)",
+  cursor: "pointer",
+  display: "flex",
+  fontSize: 12,
+  fontWeight: 650,
+  justifyContent: "space-between",
+  minHeight: 38,
+  padding: "6px 4px",
+};
+
+const countStyle: React.CSSProperties = {
+  background: "var(--color-bg-alt)",
+  borderRadius: 999,
+  color: "var(--color-muted)",
+  fontSize: 9,
+  minWidth: 22,
+  padding: "2px 6px",
+  textAlign: "center",
+};
+
+const iconButtonStyle: React.CSSProperties = {
+  background: "var(--color-surface)",
+  border: "1px solid var(--color-border)",
+  borderRadius: 8,
+  color: "var(--color-fg)",
+  fontSize: 18,
+  height: 34,
+  width: 34,
+};
+
+const smallButtonStyle: React.CSSProperties = {
+  background: "var(--color-surface)",
+  border: "1px solid var(--color-border-alt)",
+  borderRadius: 7,
+  color: "var(--color-fg-muted)",
+  cursor: "pointer",
+  fontSize: 11,
+  minHeight: 34,
+  padding: "7px 10px",
+};
+
+const primaryButtonStyle: React.CSSProperties = {
+  background: "var(--color-accent-blue)",
+  border: 0,
+  borderRadius: 7,
+  color: "var(--color-bg)",
+  cursor: "pointer",
+  fontSize: 12,
+  fontWeight: 700,
+  minHeight: 38,
+  padding: "8px 12px",
+};
+
+const codeStyle: React.CSSProperties = {
+  background: "var(--color-surface)",
+  borderRadius: 4,
+  color: "var(--color-accent-cyan)",
+  fontFamily: "var(--font-mono)",
+  padding: "1px 4px",
+};
+
+const pillStyle: React.CSSProperties = {
+  background: "var(--color-bg-alt)",
+  border: "1px solid var(--color-border)",
+  borderRadius: 999,
+  color: "var(--color-fg-muted)",
+  display: "inline-block",
+  fontSize: 9,
+  letterSpacing: "0.06em",
+  padding: "3px 7px",
+  textTransform: "uppercase",
+};

--- a/apps/web/src/components/VaultExplorerPage.tsx
+++ b/apps/web/src/components/VaultExplorerPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import sampleExport from "../fixtures/vault-link-check.sample.json";
 import {
   FINDING_CATEGORIES,
+  MAX_INPUT_BYTES,
   findPageByPath,
   getBacklinks,
   getOutgoingEdges,
@@ -105,6 +106,10 @@ export function VaultExplorerPage({ onBack }: VaultExplorerPageProps) {
   };
 
   const loadValue = (value: string | unknown) => {
+    // Any load (reset, paste, or a completed file read) advances the read
+    // guard, so a still-in-flight file read from an earlier selection sees
+    // the bump and bails instead of clobbering this newer value.
+    fileReadSeq.current++;
     const result = parseVaultIndex(value);
     if (!result.ok) {
       setLoadError(result.message);
@@ -126,8 +131,14 @@ export function VaultExplorerPage({ onBack }: VaultExplorerPageProps) {
 
   const handleFile = async (file: File | undefined) => {
     if (!file) return;
+    // Reject an oversized file before reading it into memory at all.
+    if (file.size > MAX_INPUT_BYTES) {
+      setLoadError(`That file is too large to load (over ${Math.floor(MAX_INPUT_BYTES / 1024 / 1024)} MB).`);
+      return;
+    }
     // Sequence concurrent reads: only the most recent selection wins, so a
-    // slow first read can't clobber a newer one after it resolves.
+    // slow read can't clobber a newer selection, reset, or paste (all of
+    // which advance fileReadSeq via loadValue).
     const seq = ++fileReadSeq.current;
     try {
       const text = await file.text();

--- a/apps/web/src/components/__tests__/FileViewer.test.tsx
+++ b/apps/web/src/components/__tests__/FileViewer.test.tsx
@@ -3,8 +3,13 @@ import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 
 // --- Mocks (must be declared before importing FileViewer) ---
 
+const { requestTelegramDownloadMock } = vi.hoisted(() => ({
+  requestTelegramDownloadMock: vi.fn(),
+}));
+
 vi.mock("../../lib/telegram", () => ({
   getAuthHeaders: () => ({ Authorization: "tma test" }),
+  requestTelegramDownload: requestTelegramDownloadMock,
 }));
 
 // Minimal stub for MarkdownViewer (heavy dependency tree)
@@ -286,5 +291,103 @@ describe("middleTruncatePath", () => {
     const path = `/${"a".repeat(58)}/`;
     expect(path).toHaveLength(60);
     expect(middleTruncatePath(path)).toBe(path);
+  });
+});
+
+describe("FileViewer download (WORLD-375)", () => {
+  const TICKET = "a".repeat(32);
+
+  // restoreAllMocks() does not clear a vi.fn(), so call counts would leak
+  // between these tests.
+  beforeEach(() => {
+    requestTelegramDownloadMock.mockReset();
+  });
+
+  /** Open README.md and mock the ticket endpoint, leaving the viewer on-screen. */
+  async function openFileWithDownloadReady() {
+    render(<FileViewer onClose={vi.fn()} />);
+    await waitFor(() => {
+      expect(screen.getByText("README.md")).toBeInTheDocument();
+    });
+
+    fetchMock.mockImplementation(async (url: string) => {
+      if (typeof url === "string" && url.includes("/api/files/download-ticket")) {
+        return { ok: true, json: async () => ({ ticket: TICKET }) };
+      }
+      if (typeof url === "string" && url.includes("/api/files/read")) {
+        return {
+          ok: true,
+          json: async () => ({
+            content: "# Hello World",
+            path: "/home/claude/claudes-world/README.md",
+            name: "README.md",
+          }),
+        };
+      }
+      if (typeof url === "string" && url.includes("/api/terminal/dir-branch")) {
+        return makeDirBranchResponse();
+      }
+      return { ok: false, status: 404, json: async () => ({}) };
+    });
+
+    fireEvent.click(screen.getByText("README.md"));
+    await waitFor(() => {
+      expect(screen.getByLabelText("Download file")).toBeInTheDocument();
+    });
+  }
+
+  it("offers Telegram an absolute URL carrying the ticket, and stops there", async () => {
+    requestTelegramDownloadMock.mockReturnValue(true);
+    const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {});
+    await openFileWithDownloadReady();
+
+    fireEvent.click(screen.getByLabelText("Download file"));
+
+    await waitFor(() => {
+      expect(requestTelegramDownloadMock).toHaveBeenCalledTimes(1);
+    });
+    const [url, name] = requestTelegramDownloadMock.mock.calls[0];
+    // Absolute, not "/api/..." — Telegram's downloader runs outside this document.
+    expect(url).toMatch(new RegExp(`^https?://[^/]+/api/files/download\\?ticket=${TICKET}$`));
+    expect(name).toBe("README.md");
+    // Telegram took it, so the anchor fallback must not also fire.
+    expect(clickSpy).not.toHaveBeenCalled();
+  });
+
+  it("falls back to an anchor download when Telegram declines", async () => {
+    requestTelegramDownloadMock.mockReturnValue(false);
+    const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {});
+    await openFileWithDownloadReady();
+
+    fireEvent.click(screen.getByLabelText("Download file"));
+
+    await waitFor(() => {
+      expect(clickSpy).toHaveBeenCalledTimes(1);
+    });
+    const anchor = clickSpy.mock.instances[0] as HTMLAnchorElement;
+    expect(anchor.download).toBe("README.md");
+    expect(anchor.href).toContain(`/api/files/download?ticket=${TICKET}`);
+  });
+
+  it("surfaces an error and never downloads when the ticket is refused", async () => {
+    requestTelegramDownloadMock.mockReturnValue(true);
+    await openFileWithDownloadReady();
+
+    fetchMock.mockImplementation(async (url: string) => {
+      if (typeof url === "string" && url.includes("/api/files/download-ticket")) {
+        return { ok: false, status: 403, json: async () => ({ error: "path not allowed" }) };
+      }
+      if (typeof url === "string" && url.includes("/api/terminal/dir-branch")) {
+        return makeDirBranchResponse();
+      }
+      return { ok: false, status: 404, json: async () => ({}) };
+    });
+
+    fireEvent.click(screen.getByLabelText("Download file"));
+
+    await waitFor(() => {
+      expect(screen.getByText("path not allowed")).toBeInTheDocument();
+    });
+    expect(requestTelegramDownloadMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/components/__tests__/FileViewer.test.tsx
+++ b/apps/web/src/components/__tests__/FileViewer.test.tsx
@@ -337,7 +337,7 @@ describe("FileViewer download (WORLD-375)", () => {
   }
 
   it("offers Telegram an absolute URL carrying the ticket, and stops there", async () => {
-    requestTelegramDownloadMock.mockReturnValue(true);
+    requestTelegramDownloadMock.mockReturnValue("handed-off");
     const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {});
     await openFileWithDownloadReady();
 
@@ -354,8 +354,8 @@ describe("FileViewer download (WORLD-375)", () => {
     expect(clickSpy).not.toHaveBeenCalled();
   });
 
-  it("falls back to an anchor download when Telegram declines", async () => {
-    requestTelegramDownloadMock.mockReturnValue(false);
+  it("falls back to an anchor download only when Telegram is unsupported", async () => {
+    requestTelegramDownloadMock.mockReturnValue("unsupported");
     const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {});
     await openFileWithDownloadReady();
 
@@ -369,8 +369,27 @@ describe("FileViewer download (WORLD-375)", () => {
     expect(anchor.href).toContain(`/api/files/download?ticket=${TICKET}`);
   });
 
+  it("does NOT fall back to the anchor when Telegram is busy (double-tap)", async () => {
+    // Regression guard for the codex #331 finding: a second tap while
+    // Telegram's own confirm popup is open makes downloadFile throw. Treating
+    // that as "no Telegram" would run the anchor path inside the WebView and
+    // paint the bytes inline as text — the exact bug WORLD-375 fixes.
+    requestTelegramDownloadMock.mockReturnValue("busy");
+    const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {});
+    await openFileWithDownloadReady();
+
+    fireEvent.click(screen.getByLabelText("Download file"));
+
+    await waitFor(() => {
+      expect(requestTelegramDownloadMock).toHaveBeenCalledTimes(1);
+    });
+    expect(clickSpy).not.toHaveBeenCalled();
+    // Telegram already has a dialog up; this is not an error state.
+    expect(screen.queryByText(/Download failed/)).not.toBeInTheDocument();
+  });
+
   it("surfaces an error and never downloads when the ticket is refused", async () => {
-    requestTelegramDownloadMock.mockReturnValue(true);
+    requestTelegramDownloadMock.mockReturnValue("handed-off");
     await openFileWithDownloadReady();
 
     fetchMock.mockImplementation(async (url: string) => {

--- a/apps/web/src/components/__tests__/Links.test.tsx
+++ b/apps/web/src/components/__tests__/Links.test.tsx
@@ -48,3 +48,17 @@ describe("Fleet Cockpit link", () => {
     expect(link).toHaveAttribute("target", "_blank");
   });
 });
+
+describe("Vault Explorer link", () => {
+  it("always uses the local vault route without waiting for server configuration", () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("offline")));
+    render(<Links onClose={vi.fn()} onOpenFile={vi.fn()} />);
+
+    const link = screen.getByRole("link", { name: /Vault Explorer/ });
+    expect(link).toHaveAttribute("href", "#/vault");
+    expect(link).not.toHaveAttribute("target");
+
+    fireEvent.click(link);
+    expect(window.location.hash).toBe("#/vault");
+  });
+});

--- a/apps/web/src/fixtures/vault-link-check.sample.json
+++ b/apps/web/src/fixtures/vault-link-check.sample.json
@@ -1,0 +1,48 @@
+{
+  "index_schema_version": 1,
+  "pages": [
+    { "path": "index.md", "kind": "index", "title": "Second Brain" },
+    { "path": "raw/inbox-voice-note.md", "kind": "raw", "title": "Inbox voice note" },
+    { "path": "wiki/concepts/agency.md", "kind": "concept", "title": "Agency" },
+    { "path": "wiki/concepts/attention.md", "kind": "concept", "title": "Attention" },
+    { "path": "wiki/entities/claude.md", "kind": "entity", "title": "Claude" },
+    { "path": "wiki/summaries/weekly-review.md", "kind": "summary", "title": "Weekly review" },
+    { "path": "doctrine/write-it-down.md", "kind": "doctrine", "title": "Write it down" },
+    { "path": "armory/vault-ingest.md", "kind": "raw", "title": "vault-ingest" }
+  ],
+  "edges": [
+    { "source": "index.md", "target": "wiki/concepts/agency", "label": "Agency", "resolved": true, "line": 8 },
+    { "source": "index.md", "target": "wiki/summaries/weekly-review", "label": "Latest review", "resolved": true, "line": 12 },
+    { "source": "wiki/concepts/agency.md", "target": "doctrine/write-it-down", "label": null, "resolved": true, "line": 16 },
+    { "source": "wiki/concepts/agency.md", "target": "wiki/concepts/unknown", "label": "Unknown concept", "resolved": false, "line": 21 },
+    { "source": "wiki/summaries/weekly-review.md", "target": "wiki/concepts/agency", "label": null, "resolved": true, "line": 6 },
+    { "source": "armory/vault-ingest.md", "target": "wiki/entities/claude", "label": "Claude", "resolved": true, "line": 10 }
+  ],
+  "findings": {
+    "broken": [
+      { "category": "broken", "path": "wiki/concepts/agency.md", "reason": "Target wiki/concepts/unknown does not exist", "line": 21 }
+    ],
+    "ambiguous": [
+      { "category": "ambiguous", "path": "index.md", "reason": "Agency could refer to more than one title", "line": 8 }
+    ],
+    "orphan": [
+      { "category": "orphan", "path": "wiki/concepts/attention.md", "reason": "No incoming links" }
+    ],
+    "unreferenced_raw": [
+      { "category": "unreferenced_raw", "path": "raw/inbox-voice-note.md", "reason": "Raw note is not referenced by an indexed page" }
+    ],
+    "receipt": [
+      { "category": "receipt", "path": "wiki/summaries/weekly-review.md", "reason": "Summary has no receipt link", "line": 18 }
+    ]
+  },
+  "counts": {
+    "broken": 1,
+    "ambiguous": 1,
+    "orphan": 1,
+    "unreferenced_raw": 1,
+    "receipt": 1
+  },
+  "status": "findings",
+  "generated_at": "2026-07-14T14:30:00Z",
+  "vault": "second-brain-sample"
+}

--- a/apps/web/src/lib/__tests__/app-routing.test.ts
+++ b/apps/web/src/lib/__tests__/app-routing.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildLandingUrl, isCockpitRoute, resolveInitialAppState } from "../app-routing";
+import { buildLandingUrl, isCockpitRoute, isVaultRoute, resolveInitialAppState } from "../app-routing";
 
 describe("resolveInitialAppState", () => {
   it("resolves root to the default bot alias and a cosmetic redirect", () => {
@@ -79,6 +79,13 @@ describe("resolveInitialAppState", () => {
     expect(isCockpitRoute("#/cockpit&source=links")).toBe(true);
     expect(isCockpitRoute("#links")).toBe(false);
     expect(resolveInitialAppState("/", "#/cockpit").redirectPath).toBeNull();
+  });
+
+  it("recognizes #/vault as an app route without triggering the root redirect", () => {
+    expect(isVaultRoute("#/vault")).toBe(true);
+    expect(isVaultRoute("#/vault&source=links")).toBe(true);
+    expect(isVaultRoute("#links")).toBe(false);
+    expect(resolveInitialAppState("/", "#/vault").redirectPath).toBeNull();
   });
 
   it("preserves terminal session deep-link resolution and validation", () => {

--- a/apps/web/src/lib/__tests__/telegram.test.ts
+++ b/apps/web/src/lib/__tests__/telegram.test.ts
@@ -23,56 +23,68 @@ describe("requestTelegramDownload (WORLD-375)", () => {
   it("hands the download to Telegram and reports it was taken", () => {
     const { downloadFile } = stubWebApp();
 
-    expect(requestTelegramDownload(HTTPS_URL, "README.md")).toBe(true);
+    expect(requestTelegramDownload(HTTPS_URL, "README.md")).toBe("handed-off");
     expect(downloadFile).toHaveBeenCalledWith({
       url: HTTPS_URL,
       file_name: "README.md",
     });
   });
 
-  it("declines when Telegram is absent entirely (plain browser)", () => {
-    expect(requestTelegramDownload(HTTPS_URL, "README.md")).toBe(false);
+  it("reports unsupported when Telegram is absent entirely (plain browser)", () => {
+    expect(requestTelegramDownload(HTTPS_URL, "README.md")).toBe("unsupported");
   });
 
-  it("declines when the client is older than Bot API 8.0", () => {
+  it("reports unsupported when the client is older than Bot API 8.0", () => {
     // downloadFile throws on such clients, so the version gate must come first.
     const { downloadFile } = stubWebApp({ isVersionAtLeast: () => false });
 
-    expect(requestTelegramDownload(HTTPS_URL, "README.md")).toBe(false);
+    expect(requestTelegramDownload(HTTPS_URL, "README.md")).toBe("unsupported");
     expect(downloadFile).not.toHaveBeenCalled();
   });
 
-  it("declines when the client predates isVersionAtLeast", () => {
+  it("reports unsupported when the client predates isVersionAtLeast", () => {
     const { downloadFile } = stubWebApp({ isVersionAtLeast: undefined });
 
-    expect(requestTelegramDownload(HTTPS_URL, "README.md")).toBe(false);
+    expect(requestTelegramDownload(HTTPS_URL, "README.md")).toBe("unsupported");
     expect(downloadFile).not.toHaveBeenCalled();
   });
 
-  it("declines when downloadFile is missing from the SDK", () => {
+  it("reports unsupported when downloadFile is missing from the SDK", () => {
     stubWebApp({ downloadFile: undefined });
 
-    expect(requestTelegramDownload(HTTPS_URL, "README.md")).toBe(false);
+    expect(requestTelegramDownload(HTTPS_URL, "README.md")).toBe("unsupported");
   });
 
-  it("declines a non-https URL instead of letting downloadFile throw", () => {
+  it("reports unsupported for a non-https URL instead of letting downloadFile throw", () => {
     // Local dev is served over http; downloadFile rejects any non-https url.
     const { downloadFile } = stubWebApp();
 
     expect(
       requestTelegramDownload("http://localhost:58830/api/files/download?ticket=abc", "README.md"),
-    ).toBe(false);
+    ).toBe("unsupported");
     expect(downloadFile).not.toHaveBeenCalled();
   });
 
-  it("declines rather than propagating a throw from downloadFile", () => {
-    // e.g. WebAppDownloadFilePopupOpened when a dialog is already up.
+  it("reports busy — NOT unsupported — when a download popup is already open", () => {
+    // The distinction is load-bearing: we are inside a capable Telegram client
+    // here, where the anchor fallback is broken. Reporting "unsupported" would
+    // send the caller down that path and reproduce WORLD-375 on a double-tap.
     stubWebApp({
       downloadFile: vi.fn(() => {
         throw new Error("WebAppDownloadFilePopupOpened");
       }),
     });
 
-    expect(requestTelegramDownload(HTTPS_URL, "README.md")).toBe(false);
+    expect(requestTelegramDownload(HTTPS_URL, "README.md")).toBe("busy");
+  });
+
+  it("reports busy for any other throw from a capable client", () => {
+    stubWebApp({
+      downloadFile: vi.fn(() => {
+        throw new Error("something else entirely");
+      }),
+    });
+
+    expect(requestTelegramDownload(HTTPS_URL, "README.md")).toBe("busy");
   });
 });

--- a/apps/web/src/lib/__tests__/telegram.test.ts
+++ b/apps/web/src/lib/__tests__/telegram.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { requestTelegramDownload } from "../telegram";
+
+const HTTPS_URL = "https://cpc.claude.do/api/files/download?ticket=abc";
+
+/** Install a fake WebApp. `downloadFile` defaults to a spy that succeeds. */
+function stubWebApp(overrides: Record<string, unknown> = {}) {
+  const downloadFile = vi.fn();
+  const webApp = {
+    isVersionAtLeast: () => true,
+    downloadFile,
+    ...overrides,
+  };
+  (window as unknown as { Telegram?: unknown }).Telegram = { WebApp: webApp };
+  return { downloadFile };
+}
+
+afterEach(() => {
+  delete (window as unknown as { Telegram?: unknown }).Telegram;
+});
+
+describe("requestTelegramDownload (WORLD-375)", () => {
+  it("hands the download to Telegram and reports it was taken", () => {
+    const { downloadFile } = stubWebApp();
+
+    expect(requestTelegramDownload(HTTPS_URL, "README.md")).toBe(true);
+    expect(downloadFile).toHaveBeenCalledWith({
+      url: HTTPS_URL,
+      file_name: "README.md",
+    });
+  });
+
+  it("declines when Telegram is absent entirely (plain browser)", () => {
+    expect(requestTelegramDownload(HTTPS_URL, "README.md")).toBe(false);
+  });
+
+  it("declines when the client is older than Bot API 8.0", () => {
+    // downloadFile throws on such clients, so the version gate must come first.
+    const { downloadFile } = stubWebApp({ isVersionAtLeast: () => false });
+
+    expect(requestTelegramDownload(HTTPS_URL, "README.md")).toBe(false);
+    expect(downloadFile).not.toHaveBeenCalled();
+  });
+
+  it("declines when the client predates isVersionAtLeast", () => {
+    const { downloadFile } = stubWebApp({ isVersionAtLeast: undefined });
+
+    expect(requestTelegramDownload(HTTPS_URL, "README.md")).toBe(false);
+    expect(downloadFile).not.toHaveBeenCalled();
+  });
+
+  it("declines when downloadFile is missing from the SDK", () => {
+    stubWebApp({ downloadFile: undefined });
+
+    expect(requestTelegramDownload(HTTPS_URL, "README.md")).toBe(false);
+  });
+
+  it("declines a non-https URL instead of letting downloadFile throw", () => {
+    // Local dev is served over http; downloadFile rejects any non-https url.
+    const { downloadFile } = stubWebApp();
+
+    expect(
+      requestTelegramDownload("http://localhost:58830/api/files/download?ticket=abc", "README.md"),
+    ).toBe(false);
+    expect(downloadFile).not.toHaveBeenCalled();
+  });
+
+  it("declines rather than propagating a throw from downloadFile", () => {
+    // e.g. WebAppDownloadFilePopupOpened when a dialog is already up.
+    stubWebApp({
+      downloadFile: vi.fn(() => {
+        throw new Error("WebAppDownloadFilePopupOpened");
+      }),
+    });
+
+    expect(requestTelegramDownload(HTTPS_URL, "README.md")).toBe(false);
+  });
+});

--- a/apps/web/src/lib/__tests__/vault-explorer.test.ts
+++ b/apps/web/src/lib/__tests__/vault-explorer.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  buildPageIndex,
   getBacklinks,
   getOutgoingEdges,
   groupVaultPages,
@@ -124,5 +125,36 @@ describe("vault view model", () => {
     expect(mapped.orphan[0].page).toBeNull();
     expect(mapped.unreferenced_raw[0].finding.category).toBe("unreferenced_raw");
     expect(mapped.receipt[0]).toMatchObject({ page: { path: "wiki/concepts/agency.md" } });
+  });
+});
+
+describe("hardening", () => {
+  it("rejects oversized arrays instead of freezing", () => {
+    const pages = Array.from({ length: 20001 }, (_, i) => ({ path: `raw/${i}.md`, kind: "raw", title: `p${i}` }));
+    expect(parseVaultIndex(fixture({ pages }))).toMatchObject({ ok: false, code: "invalid-contract" });
+  });
+
+  it("derives counts and status from findings, ignoring self-reported values", () => {
+    const result = parseVaultIndex(fixture({
+      // export lies: claims clean/zero while a finding is present
+      status: "clean",
+      counts: { broken: 0, ambiguous: 0, orphan: 0, unreferenced_raw: 0, receipt: 0 },
+      findings: {
+        broken: [{ category: "broken", path: "index.md", reason: "x", line: 2 }],
+        ambiguous: [], orphan: [], unreferenced_raw: [], receipt: [],
+      },
+    }));
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data.status).toBe("findings");
+      expect(result.data.counts.broken).toBe(1);
+    }
+  });
+
+  it("buildPageIndex gives O(1) lookups matching findPageByPath", () => {
+    const idx = parsedIndex(fixture());
+    const map = buildPageIndex(idx.pages);
+    expect(map.get("wiki/concepts/agency")?.path).toBe("wiki/concepts/agency.md");
+    expect(map.get("index")?.path).toBe("index.md");
   });
 });

--- a/apps/web/src/lib/__tests__/vault-explorer.test.ts
+++ b/apps/web/src/lib/__tests__/vault-explorer.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+import {
+  getBacklinks,
+  getOutgoingEdges,
+  groupVaultPages,
+  mapVaultFindings,
+  parseVaultIndex,
+  type VaultIndex,
+} from "../vault-explorer";
+
+function fixture(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    index_schema_version: 1,
+    pages: [
+      { path: "index.md", kind: "index", title: "Home" },
+      { path: "wiki/concepts/agency.md", kind: "concept", title: "Agency" },
+    ],
+    edges: [
+      { source: "index.md", target: "wiki/concepts/agency", label: "Agency", resolved: true, line: 4 },
+    ],
+    findings: {
+      broken: [],
+      ambiguous: [],
+      orphan: [],
+      unreferenced_raw: [],
+      receipt: [],
+    },
+    counts: { broken: 0, ambiguous: 0, orphan: 0, unreferenced_raw: 0, receipt: 0 },
+    status: "clean",
+    generated_at: "2026-07-14T12:00:00Z",
+    vault: "sample-vault",
+    ...overrides,
+  };
+}
+
+function parsedIndex(value: Record<string, unknown>): VaultIndex {
+  const result = parseVaultIndex(value);
+  if (!result.ok) throw new Error(result.message);
+  return result.data;
+}
+
+describe("parseVaultIndex", () => {
+  it("accepts a version 1 link-check export", () => {
+    const result = parseVaultIndex(JSON.stringify(fixture()));
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.data.vault).toBe("sample-vault");
+  });
+
+  it("rejects unsupported schema versions with a compatibility message", () => {
+    const result = parseVaultIndex(fixture({ index_schema_version: 2 }));
+    expect(result).toMatchObject({
+      ok: false,
+      code: "unsupported-version",
+      message: "Unsupported index schema version 2. This viewer supports version 1.",
+    });
+  });
+
+  it("distinguishes malformed JSON from an invalid contract", () => {
+    expect(parseVaultIndex("{")).toMatchObject({ ok: false, code: "invalid-json" });
+    expect(parseVaultIndex(fixture({ pages: "not-an-array" }))).toMatchObject({
+      ok: false,
+      code: "invalid-contract",
+    });
+  });
+});
+
+describe("vault view model", () => {
+  it("groups top-level layers and nested wiki folders", () => {
+    const index = parsedIndex(fixture({
+      pages: [
+        { path: "index.md", kind: "index", title: "Home" },
+        { path: "raw/inbox.md", kind: "raw", title: "Inbox" },
+        { path: "wiki/concepts/c.md", kind: "concept", title: "Concept" },
+        { path: "wiki/entities/e.md", kind: "entity", title: "Entity" },
+        { path: "wiki/summaries/s.md", kind: "summary", title: "Summary" },
+        { path: "doctrine/rule.md", kind: "doctrine", title: "Rule" },
+        { path: "armory/tool.md", kind: "raw", title: "Tool" },
+        { path: "notes/misc.md", kind: "raw", title: "Misc" },
+      ],
+    }));
+
+    const groups = groupVaultPages(index.pages);
+    expect(groups.index.map((page) => page.path)).toEqual(["index.md"]);
+    expect(groups.raw.map((page) => page.path)).toEqual(["raw/inbox.md"]);
+    expect(groups.wiki.concepts).toHaveLength(1);
+    expect(groups.wiki.entities).toHaveLength(1);
+    expect(groups.wiki.summaries).toHaveLength(1);
+    expect(groups.doctrine).toHaveLength(1);
+    expect(groups.armory).toHaveLength(1);
+    expect(groups.other.map((page) => page.path)).toEqual(["notes/misc.md"]);
+  });
+
+  it("derives outgoing edges and backlinks across .md and extensionless paths", () => {
+    const index = parsedIndex(fixture());
+    const [home, agency] = index.pages;
+    expect(getOutgoingEdges(home, index.edges)).toHaveLength(1);
+    expect(getBacklinks(agency, index.edges)).toEqual(index.edges);
+    expect(getBacklinks(home, index.edges)).toHaveLength(0);
+  });
+
+  it("maps all finding categories to pages and preserves optional lines", () => {
+    const finding = (category: string, path: string, line?: number) => ({
+      category,
+      path,
+      reason: `${category} reason`,
+      ...(line ? { line } : {}),
+    });
+    const findings = {
+      broken: [finding("broken", "index.md", 8)],
+      ambiguous: [finding("ambiguous", "wiki/concepts/agency")],
+      orphan: [finding("orphan", "missing.md", 3)],
+      unreferenced_raw: [finding("unreferenced_raw", "index.md")],
+      receipt: [finding("receipt", "wiki/concepts/agency.md", 12)],
+    };
+    const index = parsedIndex(fixture({
+      findings,
+      counts: { broken: 1, ambiguous: 1, orphan: 1, unreferenced_raw: 1, receipt: 1 },
+      status: "findings",
+    }));
+
+    const mapped = mapVaultFindings(index);
+    expect(mapped.broken[0]).toMatchObject({ page: { path: "index.md" }, finding: { line: 8 } });
+    expect(mapped.ambiguous[0].page?.path).toBe("wiki/concepts/agency.md");
+    expect(mapped.orphan[0].page).toBeNull();
+    expect(mapped.unreferenced_raw[0].finding.category).toBe("unreferenced_raw");
+    expect(mapped.receipt[0]).toMatchObject({ page: { path: "wiki/concepts/agency.md" } });
+  });
+});

--- a/apps/web/src/lib/__tests__/vault-explorer.test.ts
+++ b/apps/web/src/lib/__tests__/vault-explorer.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  MAX_INPUT_BYTES,
   buildPageIndex,
   getBacklinks,
   getOutgoingEdges,
@@ -156,5 +157,18 @@ describe("hardening", () => {
     const map = buildPageIndex(idx.pages);
     expect(map.get("wiki/concepts/agency")?.path).toBe("wiki/concepts/agency.md");
     expect(map.get("index")?.path).toBe("index.md");
+  });
+});
+
+describe("raw input size cap (PR #329 swarm MUST-1)", () => {
+  it("rejects an oversized raw string before JSON.parse runs", () => {
+    const huge = " ".repeat(MAX_INPUT_BYTES + 1);
+    const result = parseVaultIndex(huge);
+    expect(result).toMatchObject({ ok: false, code: "invalid-contract" });
+    if (!result.ok) expect(result.message).toMatch(/too large/i);
+  });
+
+  it("still parses a normal-size export", () => {
+    expect(parseVaultIndex(JSON.stringify(fixture())).ok).toBe(true);
   });
 });

--- a/apps/web/src/lib/app-routing.ts
+++ b/apps/web/src/lib/app-routing.ts
@@ -75,11 +75,15 @@ function resolveHashState(hashParams: string): InitialAppState {
 
 function isAppDeepLink(hashParams: string): boolean {
   const firstSegment = hashParams.split("&", 1)[0];
-  return firstSegment === "/cockpit" || TABS.includes(firstSegment as AppTab) || DEEP_LINK_PARAM_RE.test(hashParams);
+  return firstSegment === "/cockpit" || firstSegment === "/vault" || TABS.includes(firstSegment as AppTab) || DEEP_LINK_PARAM_RE.test(hashParams);
 }
 
 export function isCockpitRoute(hash: string): boolean {
   return hash.replace(/^#/, "").split("&", 1)[0] === "/cockpit";
+}
+
+export function isVaultRoute(hash: string): boolean {
+  return hash.replace(/^#/, "").split("&", 1)[0] === "/vault";
 }
 
 /** Resolve the first-render route without reading from or mutating window. */

--- a/apps/web/src/lib/telegram.ts
+++ b/apps/web/src/lib/telegram.ts
@@ -60,29 +60,41 @@ export function getInitData(): string {
 }
 
 /**
- * Hand a download off to Telegram's native file downloader. Returns true when
- * the request was accepted by the SDK (Telegram then shows its own confirm
- * dialog and owns the rest of the flow).
+ * - `handed-off`: Telegram accepted it and now owns the flow (its own confirm
+ *   dialog, its own downloader).
+ * - `busy`: we ARE in a capable Telegram client, but it refused this call right
+ *   now — in practice because a download popup is already open.
+ * - `unsupported`: no Telegram, too old, or a URL its downloader won't take.
+ */
+export type TelegramDownloadOutcome = "handed-off" | "busy" | "unsupported";
+
+/**
+ * Hand a download off to Telegram's native file downloader.
  *
  * Inside Telegram's WebView a `<a download>` navigation does not save the file:
  * the WebView renders the response bytes inline as uncopyable text instead.
  * `downloadFile` is the only path that produces a real file, so callers should
- * prefer it and keep the anchor as a fallback for desktop/browser use.
+ * prefer it and keep the anchor strictly for non-Telegram browsers.
  *
- * Returns false — rather than throwing — whenever the native path is
- * unavailable, because `downloadFile` throws on an unsupported client, a
+ * Never throws, though `downloadFile` does — on an unsupported client, a
  * non-https URL (e.g. local dev over http), or an already-open popup.
+ *
+ * The `busy` case matters: once the capability and https gates pass we know we
+ * are inside a Telegram WebView, where the anchor is broken by definition. A
+ * caller that treated a refusal as "fall back to the anchor" would re-trigger
+ * the very inline-render bug this function exists to avoid — so a throw past
+ * those gates is reported as `busy`, never as `unsupported`.
  */
-export function requestTelegramDownload(url: string, fileName: string): boolean {
+export function requestTelegramDownload(url: string, fileName: string): TelegramDownloadOutcome {
   const tg = getTelegramWebApp();
-  if (typeof tg?.downloadFile !== "function") return false;
-  if (!tg.isVersionAtLeast?.("8.0")) return false;
-  if (!url.startsWith("https:")) return false;
+  if (typeof tg?.downloadFile !== "function") return "unsupported";
+  if (!tg.isVersionAtLeast?.("8.0")) return "unsupported";
+  if (!url.startsWith("https:")) return "unsupported";
   try {
     tg.downloadFile({ url, file_name: fileName });
-    return true;
+    return "handed-off";
   } catch {
-    return false;
+    return "busy";
   }
 }
 

--- a/apps/web/src/lib/telegram.ts
+++ b/apps/web/src/lib/telegram.ts
@@ -34,6 +34,14 @@ interface TelegramWebApp {
   themeParams: Record<string, string>;
   colorScheme: "light" | "dark";
   isExpanded: boolean;
+  version?: string;
+  isVersionAtLeast?(version: string): boolean;
+  /** Bot API 8.0+. Throws when unsupported, when `url` is not https, or when a
+   *  download popup is already open — always call via `requestTelegramDownload`. */
+  downloadFile?(
+    params: { url: string; file_name: string },
+    callback?: (accepted: boolean) => void,
+  ): void;
   checkHomeScreenStatus?(callback: (status: "added" | "missed" | "unknown") => void): void;
   addToHomeScreen?(): void;
   HapticFeedback?: {
@@ -49,6 +57,33 @@ export function getTelegramWebApp(): TelegramWebApp | null {
 
 export function getInitData(): string {
   return window.Telegram?.WebApp?.initData ?? "";
+}
+
+/**
+ * Hand a download off to Telegram's native file downloader. Returns true when
+ * the request was accepted by the SDK (Telegram then shows its own confirm
+ * dialog and owns the rest of the flow).
+ *
+ * Inside Telegram's WebView a `<a download>` navigation does not save the file:
+ * the WebView renders the response bytes inline as uncopyable text instead.
+ * `downloadFile` is the only path that produces a real file, so callers should
+ * prefer it and keep the anchor as a fallback for desktop/browser use.
+ *
+ * Returns false — rather than throwing — whenever the native path is
+ * unavailable, because `downloadFile` throws on an unsupported client, a
+ * non-https URL (e.g. local dev over http), or an already-open popup.
+ */
+export function requestTelegramDownload(url: string, fileName: string): boolean {
+  const tg = getTelegramWebApp();
+  if (typeof tg?.downloadFile !== "function") return false;
+  if (!tg.isVersionAtLeast?.("8.0")) return false;
+  if (!url.startsWith("https:")) return false;
+  try {
+    tg.downloadFile({ url, file_name: fileName });
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 export function getUrlToken(): string {

--- a/apps/web/src/lib/telegram.ts
+++ b/apps/web/src/lib/telegram.ts
@@ -93,7 +93,13 @@ export function requestTelegramDownload(url: string, fileName: string): Telegram
   try {
     tg.downloadFile({ url, file_name: fileName });
     return "handed-off";
-  } catch {
+  } catch (err) {
+    // Deliberately not classified by error content — matching on message text
+    // would be brittle. But that means a throw which is genuinely "this client
+    // won't take this request" is reported as `busy` and does nothing visible.
+    // We cannot see inside Telegram's downloader, so leave a breadcrumb: if a
+    // tap ever appears to do nothing on-device, this is the only evidence.
+    console.debug("[cpc] Telegram declined downloadFile; treating as busy", err);
     return "busy";
   }
 }

--- a/apps/web/src/lib/vault-explorer.ts
+++ b/apps/web/src/lib/vault-explorer.ts
@@ -1,0 +1,296 @@
+export const VAULT_SCHEMA_VERSION = 1 as const;
+
+export const PAGE_KINDS = [
+  "index",
+  "raw",
+  "summary",
+  "entity",
+  "concept",
+  "doctrine",
+] as const;
+
+export const FINDING_CATEGORIES = [
+  "broken",
+  "ambiguous",
+  "orphan",
+  "unreferenced_raw",
+  "receipt",
+] as const;
+
+export type VaultPageKind = (typeof PAGE_KINDS)[number];
+export type FindingCategory = (typeof FINDING_CATEGORIES)[number];
+
+export interface VaultPage {
+  path: string;
+  kind: VaultPageKind;
+  title: string;
+}
+
+export interface VaultEdge {
+  source: string;
+  target: string;
+  label: string | null;
+  resolved: boolean;
+  line: number;
+}
+
+export interface VaultFinding {
+  category: string;
+  path: string;
+  reason: string;
+  line?: number;
+}
+
+export type VaultFindings = Record<FindingCategory, VaultFinding[]>;
+export type VaultCounts = Record<FindingCategory, number>;
+
+export interface VaultIndex {
+  index_schema_version: typeof VAULT_SCHEMA_VERSION;
+  pages: VaultPage[];
+  edges: VaultEdge[];
+  findings: VaultFindings;
+  counts: VaultCounts;
+  status: "clean" | "findings";
+  generated_at: string;
+  vault: string;
+}
+
+export type VaultParseResult =
+  | { ok: true; data: VaultIndex }
+  | {
+      ok: false;
+      code: "invalid-json" | "unsupported-version" | "invalid-contract";
+      message: string;
+    };
+
+export interface VaultPageGroups {
+  index: VaultPage[];
+  raw: VaultPage[];
+  wiki: {
+    concepts: VaultPage[];
+    entities: VaultPage[];
+    summaries: VaultPage[];
+    other: VaultPage[];
+  };
+  doctrine: VaultPage[];
+  armory: VaultPage[];
+  other: VaultPage[];
+}
+
+export interface MappedFinding {
+  finding: VaultFinding;
+  page: VaultPage | null;
+}
+
+export type MappedFindings = Record<FindingCategory, MappedFinding[]>;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isLineNumber(value: unknown): value is number {
+  return Number.isInteger(value) && (value as number) > 0;
+}
+
+function invalid(message: string): VaultParseResult {
+  return { ok: false, code: "invalid-contract", message };
+}
+
+function parsePage(value: unknown, index: number): VaultPage | string {
+  if (!isRecord(value)) return `pages[${index}] must be an object.`;
+  if (typeof value.path !== "string") return `pages[${index}].path must be a string.`;
+  if (!PAGE_KINDS.includes(value.kind as VaultPageKind)) {
+    return `pages[${index}].kind is not supported.`;
+  }
+  if (typeof value.title !== "string") return `pages[${index}].title must be a string.`;
+  return { path: value.path, kind: value.kind as VaultPageKind, title: value.title };
+}
+
+function parseEdge(value: unknown, index: number): VaultEdge | string {
+  if (!isRecord(value)) return `edges[${index}] must be an object.`;
+  if (typeof value.source !== "string") return `edges[${index}].source must be a string.`;
+  if (typeof value.target !== "string") return `edges[${index}].target must be a string.`;
+  if (value.label !== null && typeof value.label !== "string") {
+    return `edges[${index}].label must be a string or null.`;
+  }
+  if (typeof value.resolved !== "boolean") return `edges[${index}].resolved must be a boolean.`;
+  if (!isLineNumber(value.line)) return `edges[${index}].line must be a positive integer.`;
+  return {
+    source: value.source,
+    target: value.target,
+    label: value.label as string | null,
+    resolved: value.resolved,
+    line: value.line,
+  };
+}
+
+function parseFinding(value: unknown, location: string): VaultFinding | string {
+  if (!isRecord(value)) return `${location} must be an object.`;
+  if (typeof value.category !== "string") return `${location}.category must be a string.`;
+  if (typeof value.path !== "string") return `${location}.path must be a string.`;
+  if (typeof value.reason !== "string") return `${location}.reason must be a string.`;
+  if (value.line !== undefined && !isLineNumber(value.line)) {
+    return `${location}.line must be a positive integer when present.`;
+  }
+  return {
+    category: value.category,
+    path: value.path,
+    reason: value.reason,
+    ...(value.line === undefined ? {} : { line: value.line }),
+  };
+}
+
+export function parseVaultIndex(input: string | unknown): VaultParseResult {
+  let value = input;
+  if (typeof input === "string") {
+    try {
+      value = JSON.parse(input) as unknown;
+    } catch {
+      return { ok: false, code: "invalid-json", message: "This is not valid JSON." };
+    }
+  }
+
+  if (!isRecord(value)) return invalid("The link-check export must be a JSON object.");
+  if (!("index_schema_version" in value)) {
+    return invalid("The export is missing index_schema_version.");
+  }
+  if (value.index_schema_version !== VAULT_SCHEMA_VERSION) {
+    return {
+      ok: false,
+      code: "unsupported-version",
+      message: `Unsupported index schema version ${String(value.index_schema_version)}. This viewer supports version 1.`,
+    };
+  }
+
+  if (!Array.isArray(value.pages)) return invalid("pages must be an array.");
+  const pages: VaultPage[] = [];
+  for (const [index, pageValue] of value.pages.entries()) {
+    const page = parsePage(pageValue, index);
+    if (typeof page === "string") return invalid(page);
+    pages.push(page);
+  }
+
+  if (!Array.isArray(value.edges)) return invalid("edges must be an array.");
+  const edges: VaultEdge[] = [];
+  for (const [index, edgeValue] of value.edges.entries()) {
+    const edge = parseEdge(edgeValue, index);
+    if (typeof edge === "string") return invalid(edge);
+    edges.push(edge);
+  }
+
+  if (!isRecord(value.findings)) return invalid("findings must be an object.");
+  if (!isRecord(value.counts)) return invalid("counts must be an object.");
+
+  const findings = {} as VaultFindings;
+  const counts = {} as VaultCounts;
+  for (const category of FINDING_CATEGORIES) {
+    const categoryFindings = value.findings[category];
+    if (!Array.isArray(categoryFindings)) return invalid(`findings.${category} must be an array.`);
+    const parsedFindings: VaultFinding[] = [];
+    for (const [index, findingValue] of categoryFindings.entries()) {
+      const finding = parseFinding(findingValue, `findings.${category}[${index}]`);
+      if (typeof finding === "string") return invalid(finding);
+      parsedFindings.push(finding);
+    }
+    findings[category] = parsedFindings;
+
+    const count = value.counts[category];
+    if (!Number.isInteger(count) || (count as number) < 0) {
+      return invalid(`counts.${category} must be a non-negative integer.`);
+    }
+    counts[category] = count as number;
+  }
+
+  if (value.status !== "clean" && value.status !== "findings") {
+    return invalid('status must be either "clean" or "findings".');
+  }
+  if (typeof value.generated_at !== "string") return invalid("generated_at must be a string.");
+  if (typeof value.vault !== "string") return invalid("vault must be a string.");
+
+  return {
+    ok: true,
+    data: {
+      index_schema_version: VAULT_SCHEMA_VERSION,
+      pages,
+      edges,
+      findings,
+      counts,
+      status: value.status,
+      generated_at: value.generated_at,
+      vault: value.vault,
+    },
+  };
+}
+
+export function canonicalVaultPath(path: string): string {
+  return path.trim().replace(/^\.\//, "").replace(/^\//, "").replace(/\.md$/, "");
+}
+
+export function findPageByPath(pages: VaultPage[], path: string): VaultPage | null {
+  const wanted = canonicalVaultPath(path);
+  return pages.find((page) => canonicalVaultPath(page.path) === wanted) ?? null;
+}
+
+function sorted(pages: VaultPage[]): VaultPage[] {
+  return [...pages].sort((a, b) => a.path.localeCompare(b.path));
+}
+
+export function groupVaultPages(pages: VaultPage[]): VaultPageGroups {
+  const groups: VaultPageGroups = {
+    index: [],
+    raw: [],
+    wiki: { concepts: [], entities: [], summaries: [], other: [] },
+    doctrine: [],
+    armory: [],
+    other: [],
+  };
+
+  for (const page of pages) {
+    const path = canonicalVaultPath(page.path);
+    const segments = path.split("/");
+    const top = segments[0];
+    const second = segments[1];
+
+    if (path === "index" || top === "index") groups.index.push(page);
+    else if (top === "raw") groups.raw.push(page);
+    else if (top === "wiki" && second === "concepts") groups.wiki.concepts.push(page);
+    else if (top === "wiki" && second === "entities") groups.wiki.entities.push(page);
+    else if (top === "wiki" && second === "summaries") groups.wiki.summaries.push(page);
+    else if (top === "wiki") groups.wiki.other.push(page);
+    else if (top === "doctrine") groups.doctrine.push(page);
+    else if (top === "armory") groups.armory.push(page);
+    else groups.other.push(page);
+  }
+
+  groups.index = sorted(groups.index);
+  groups.raw = sorted(groups.raw);
+  groups.wiki.concepts = sorted(groups.wiki.concepts);
+  groups.wiki.entities = sorted(groups.wiki.entities);
+  groups.wiki.summaries = sorted(groups.wiki.summaries);
+  groups.wiki.other = sorted(groups.wiki.other);
+  groups.doctrine = sorted(groups.doctrine);
+  groups.armory = sorted(groups.armory);
+  groups.other = sorted(groups.other);
+  return groups;
+}
+
+export function getOutgoingEdges(page: VaultPage, edges: VaultEdge[]): VaultEdge[] {
+  const source = canonicalVaultPath(page.path);
+  return edges.filter((edge) => canonicalVaultPath(edge.source) === source);
+}
+
+export function getBacklinks(page: VaultPage, edges: VaultEdge[]): VaultEdge[] {
+  const target = canonicalVaultPath(page.path);
+  return edges.filter((edge) => canonicalVaultPath(edge.target) === target);
+}
+
+export function mapVaultFindings(index: VaultIndex): MappedFindings {
+  const mapped = {} as MappedFindings;
+  for (const category of FINDING_CATEGORIES) {
+    mapped[category] = index.findings[category].map((finding) => ({
+      finding,
+      page: findPageByPath(index.pages, finding.path),
+    }));
+  }
+  return mapped;
+}

--- a/apps/web/src/lib/vault-explorer.ts
+++ b/apps/web/src/lib/vault-explorer.ts
@@ -1,5 +1,11 @@
 export const VAULT_SCHEMA_VERSION = 1 as const;
 
+// Bound an uploaded/pasted export so a large or malicious link-check blob
+// can't freeze the Telegram WebView during parse/render.
+export const MAX_PAGES = 20000;
+export const MAX_EDGES = 100000;
+export const MAX_FINDINGS_PER_CATEGORY = 50000;
+
 export const PAGE_KINDS = [
   "index",
   "raw",
@@ -163,6 +169,7 @@ export function parseVaultIndex(input: string | unknown): VaultParseResult {
   }
 
   if (!Array.isArray(value.pages)) return invalid("pages must be an array.");
+  if (value.pages.length > MAX_PAGES) return invalid(`Too many pages (max ${MAX_PAGES}).`);
   const pages: VaultPage[] = [];
   for (const [index, pageValue] of value.pages.entries()) {
     const page = parsePage(pageValue, index);
@@ -171,6 +178,7 @@ export function parseVaultIndex(input: string | unknown): VaultParseResult {
   }
 
   if (!Array.isArray(value.edges)) return invalid("edges must be an array.");
+  if (value.edges.length > MAX_EDGES) return invalid(`Too many edges (max ${MAX_EDGES}).`);
   const edges: VaultEdge[] = [];
   for (const [index, edgeValue] of value.edges.entries()) {
     const edge = parseEdge(edgeValue, index);
@@ -183,9 +191,13 @@ export function parseVaultIndex(input: string | unknown): VaultParseResult {
 
   const findings = {} as VaultFindings;
   const counts = {} as VaultCounts;
+  let anyFindings = false;
   for (const category of FINDING_CATEGORIES) {
     const categoryFindings = value.findings[category];
     if (!Array.isArray(categoryFindings)) return invalid(`findings.${category} must be an array.`);
+    if (categoryFindings.length > MAX_FINDINGS_PER_CATEGORY) {
+      return invalid(`Too many ${category} findings (max ${MAX_FINDINGS_PER_CATEGORY}).`);
+    }
     const parsedFindings: VaultFinding[] = [];
     for (const [index, findingValue] of categoryFindings.entries()) {
       const finding = parseFinding(findingValue, `findings.${category}[${index}]`);
@@ -193,12 +205,11 @@ export function parseVaultIndex(input: string | unknown): VaultParseResult {
       parsedFindings.push(finding);
     }
     findings[category] = parsedFindings;
-
-    const count = value.counts[category];
-    if (!Number.isInteger(count) || (count as number) < 0) {
-      return invalid(`counts.${category} must be a non-negative integer.`);
-    }
-    counts[category] = count as number;
+    // Derive counts/status from the actual findings arrays rather than
+    // trusting the export's self-reported values, so the display can never
+    // claim "clean"/zero while findings are present.
+    counts[category] = parsedFindings.length;
+    if (parsedFindings.length > 0) anyFindings = true;
   }
 
   if (value.status !== "clean" && value.status !== "findings") {
@@ -215,7 +226,8 @@ export function parseVaultIndex(input: string | unknown): VaultParseResult {
       edges,
       findings,
       counts,
-      status: value.status,
+      // Derived from the findings arrays, not the export's claim.
+      status: anyFindings ? "findings" : "clean",
       generated_at: value.generated_at,
       vault: value.vault,
     },
@@ -229,6 +241,16 @@ export function canonicalVaultPath(path: string): string {
 export function findPageByPath(pages: VaultPage[], path: string): VaultPage | null {
   const wanted = canonicalVaultPath(path);
   return pages.find((page) => canonicalVaultPath(page.path) === wanted) ?? null;
+}
+
+/** Canonical-path → page index for O(1) lookups over many findings/edges. */
+export function buildPageIndex(pages: VaultPage[]): Map<string, VaultPage> {
+  const index = new Map<string, VaultPage>();
+  for (const page of pages) {
+    const key = canonicalVaultPath(page.path);
+    if (!index.has(key)) index.set(key, page);
+  }
+  return index;
 }
 
 function sorted(pages: VaultPage[]): VaultPage[] {
@@ -285,11 +307,14 @@ export function getBacklinks(page: VaultPage, edges: VaultEdge[]): VaultEdge[] {
 }
 
 export function mapVaultFindings(index: VaultIndex): MappedFindings {
+  // Build the path index once instead of a linear scan per finding
+  // (was ~O(pages × findings), a WebView-freeze risk on large exports).
+  const pageIndex = buildPageIndex(index.pages);
   const mapped = {} as MappedFindings;
   for (const category of FINDING_CATEGORIES) {
     mapped[category] = index.findings[category].map((finding) => ({
       finding,
-      page: findPageByPath(index.pages, finding.path),
+      page: pageIndex.get(canonicalVaultPath(finding.path)) ?? null,
     }));
   }
   return mapped;

--- a/apps/web/src/lib/vault-explorer.ts
+++ b/apps/web/src/lib/vault-explorer.ts
@@ -2,6 +2,9 @@ export const VAULT_SCHEMA_VERSION = 1 as const;
 
 // Bound an uploaded/pasted export so a large or malicious link-check blob
 // can't freeze the Telegram WebView during parse/render.
+// MAX_INPUT_BYTES caps the RAW payload before JSON.parse even runs — the
+// per-array caps below only apply after a (potentially huge) parse.
+export const MAX_INPUT_BYTES = 16 * 1024 * 1024;
 export const MAX_PAGES = 20000;
 export const MAX_EDGES = 100000;
 export const MAX_FINDINGS_PER_CATEGORY = 50000;
@@ -149,6 +152,15 @@ function parseFinding(value: unknown, location: string): VaultFinding | string {
 export function parseVaultIndex(input: string | unknown): VaultParseResult {
   let value = input;
   if (typeof input === "string") {
+    // Cap the raw text before JSON.parse — an oversized blob would freeze
+    // the WebView at parse time, before any array-count check could apply.
+    if (input.length > MAX_INPUT_BYTES) {
+      return {
+        ok: false,
+        code: "invalid-contract",
+        message: `Export is too large to load (over ${Math.floor(MAX_INPUT_BYTES / 1024 / 1024)} MB).`,
+      };
+    }
     try {
       value = JSON.parse(input) as unknown;
     } catch {


### PR DESCRIPTION
Release to prod per Liam's request (2026-07-16 ~23:30 ET): fix the fullscreen UX.

## Scope (dev → main since v1.16.0)
- **#333 — session switcher sheet + safe-area top inset + chip row restore** (today's fullscreen work: app no longer hides under Telegram's fullscreen chrome; cramped chip strip replaced by tap-to-open switcher sheet with sliding chips, Liam's design)
- **#332 — markdown viewer: download trigger + text selection** (WORLD-375, WORLD-376)
- Post-review nit: explicit type=button on switcher buttons (gemini, #333)

Both PRs were swarm-reviewed on their way into dev. After merge: Director tags v1.17.0, deploys to the prod worktree (pnpm install + build, cpc.service restart), and live-verifies health + asset hash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)